### PR TITLE
fix: harness v3.4.0 improvements

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,4 @@
-# Installation Guide: Harness v3.2.2
+# Installation Guide: Harness v3.4.0
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A harness system for Claude Code that solves multi-session continuity, parallel agent coordination, and automated quality enforcement. Built on Anthropic's research for long-running tasks, evolved through three major versions into a system built on Claude Code's native Agent Teams primitives.
 
-**Current version: v3.3.0**
+**Current version: v3.4.0**
 
 ---
 
@@ -245,14 +245,14 @@ In non-harness projects, only CLAUDE.md loads (~4.2K). The agent-teams-protocol 
 
 Everything you need is in this repo:
 
-1. Download [harness-v3.3.0.zip](https://github.com/oeftimie/vv-claude-harness/releases)
+1. Download [harness-v3.4.0.zip](https://github.com/oeftimie/vv-claude-harness/releases)
 2. Follow the [INSTALL.md](./INSTALL.md) instructions
 3. Review the [CLAUDE.md](./claude/CLAUDE.md) for core engineering standards
 
 ### Quick install
 
 ```bash
-unzip vv-claude-harness-v3.3.0.zip
+unzip vv-claude-harness-v3.4.0.zip
 cd vv-claude-harness
 ./install
 ```

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,10 +1,10 @@
 ---
 scope: global
 location: ~/.claude/CLAUDE.md
-version: 3.3.0
+version: 3.4.0
 last_updated: 2026-03-26
 author: {{USER_NAME}}
-description: Core engineering standards for all Claude Code sessions. Works with Long-Running Agent Harness v3.3.0.
+description: Core engineering standards for all Claude Code sessions. Works with Long-Running Agent Harness v3.4.0.
 supplements: Project-level CLAUDE.md files in individual repositories
 ---
 

--- a/claude/rules/agent-teams-protocol.md
+++ b/claude/rules/agent-teams-protocol.md
@@ -156,6 +156,13 @@ All team communication uses `SendMessage`. These are the message patterns for ha
 | Scope expansion needed | `SendMessage({ type: "message", recipient: "team-lead", content: "Need access to [files] because [reason]. Currently outside my scope.", summary: "Scope expand: [files]" })` |
 | Plan for approval | `SendMessage({ type: "plan_approval_request", recipient: "team-lead", content: "# Implementation Plan\n\n1. [step]\n2. [step]\n...", summary: "Plan for task #N" })` |
 
+**Completion deduplication**: Send the "Task #N complete" message exactly once per task ID.
+If the TeammateIdle hook immediately prompts you to pick up a new task after completing:
+1. Claim the new task first via TaskUpdate
+2. Then send the completion message for the previous task
+3. Never send two completion messages for the same task ID
+4. If you already sent a completion message and the TaskCompleted hook rejected it (tests failed), fix the issue and re-complete the task — do not send a new "complete" message until the hook accepts
+
 **Lead to Teammate:**
 
 | Situation | SendMessage call |

--- a/claude/skills/harness-continue/SKILL.md
+++ b/claude/skills/harness-continue/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: harness-continue
-description: Continue working on a harness-managed project (v3.2.2). Orients to current state, picks single-session or Agent Teams mode, and guides implementation with TDD, quality gate hooks, and compaction-aware context management. Use at the start of any session on a harness project.
+description: Continue working on a harness-managed project (v3.4.0). Orients to current state, picks single-session or Agent Teams mode, and guides implementation with TDD, quality gate hooks, and compaction-aware context management. Use at the start of any session on a harness project.
 ---
 
-# Harness Continue v3.2.2
+# Harness Continue v3.4.0
 
 ## Step 1: Orient Yourself
 
@@ -81,13 +81,13 @@ Which do you prefer?
 3. Create a structured task list using TaskCreate (these survive compaction):
 
 ```
-TaskCreate({ subject: "Read existing code in [scope directories]", description: "Understand patterns before implementing", activeForm: "Reading existing code" })
-TaskCreate({ subject: "Write failing test for [feature]", description: "[feature description] — TDD red phase", activeForm: "Writing failing test" })
-TaskCreate({ subject: "Implement minimum code to pass", description: "TDD green phase", activeForm: "Implementing feature" })
-TaskCreate({ subject: "Run full test suite", description: "Verify no regressions" })
-TaskCreate({ subject: "Verify coverage >= 95% on touched code", description: "Coverage gate" })
-TaskCreate({ subject: "Update features.json", description: "Set status to passing, populate test_file and coverage" })
-TaskCreate({ subject: "Update context_summary.md with learnings", description: "Persist decisions and patterns" })
+TaskCreate({ subject: "F001: Read existing code in [scope directories]", description: "Understand patterns before implementing", activeForm: "Reading existing code", metadata: { feature_id: "F001" } })
+TaskCreate({ subject: "F001: Write failing test for [feature]", description: "[feature description] — TDD red phase", activeForm: "Writing failing test", metadata: { feature_id: "F001" } })
+TaskCreate({ subject: "F001: Implement minimum code to pass", description: "TDD green phase", activeForm: "Implementing feature", metadata: { feature_id: "F001" } })
+TaskCreate({ subject: "F001: Run full test suite", description: "Verify no regressions", metadata: { feature_id: "F001" } })
+TaskCreate({ subject: "F001: Verify coverage >= 95% on touched code", description: "Coverage gate", metadata: { feature_id: "F001" } })
+TaskCreate({ subject: "F001: Update features.json", description: "Set status to passing, populate test_file and coverage", metadata: { feature_id: "F001" } })
+TaskCreate({ subject: "F001: Update context_summary.md with learnings", description: "Persist decisions and patterns", metadata: { feature_id: "F001" } })
 ```
 
 Use `TaskUpdate` to mark each task `in_progress` when starting and `completed` when done. Tasks are your crash-recovery journal: if compaction hits unexpectedly, stale tasks are worse than no tasks.
@@ -205,14 +205,15 @@ Wait for user approval before proceeding to Phase 2.
    TeamCreate({ team_name: "PROJECT-sprint-N", description: "Parallel implementation of F001 and F002" })
    ```
 
-4. Create tasks, then set dependency chains (derived from features.json `depends_on`):
+4. Create tasks with feature metadata, then set dependency chains (derived from features.json `depends_on`):
    ```
    # Create all tasks first (they start as pending by default)
-   TaskCreate({ subject: "F001: Build API endpoint", description: "[detailed spec]", activeForm: "Building API endpoint" })
+   # Always include metadata.feature_id — hooks and TaskList use it for correlation
+   TaskCreate({ subject: "F001: Build API endpoint", description: "[detailed spec]", activeForm: "Building API endpoint", metadata: { feature_id: "F001", scope: "src/api/", model: "sonnet" } })
    # → task id "1"
-   TaskCreate({ subject: "F002: Build UI consuming API", description: "[detailed spec]", activeForm: "Building UI layer" })
+   TaskCreate({ subject: "F002: Build UI consuming API", description: "[detailed spec]", activeForm: "Building UI layer", metadata: { feature_id: "F002", scope: "src/ui/", model: "sonnet" } })
    # → task id "2"
-   TaskCreate({ subject: "Review F001 + F002", description: "[review criteria]", activeForm: "Reviewing implementation" })
+   TaskCreate({ subject: "Review F001 + F002", description: "[review criteria]", activeForm: "Reviewing implementation", metadata: { feature_id: "F001,F002", scope: "*", model: "opus" } })
    # → task id "3"
 
    # Then set dependencies via TaskUpdate

--- a/claude/skills/harness-continue/team-spawn-prompts.md
+++ b/claude/skills/harness-continue/team-spawn-prompts.md
@@ -40,6 +40,15 @@ Implement [FEATURE_DESCRIPTION] with:
 2. Read existing code in your scope to understand patterns
 3. Claim your task: TaskUpdate({ taskId: "[TASK_ID]", status: "in_progress", owner: "[YOUR_NAME]" })
 
+## Context Management
+If you completed a previous feature and were assigned a new one by the TeammateIdle hook,
+compact BEFORE starting the new feature:
+  /compact Focus on: [NEW_FEATURE_ID], scope [NEW_SCOPE_DIRS], TDD state clean
+This prevents mid-implementation compaction from losing TDD state.
+
+If at any point your conversation feels long (multiple research passes, prior debugging),
+compact proactively rather than waiting for automatic compaction.
+
 ## TDD Rules
 1. Write failing test that defines "done"
 2. Confirm it fails
@@ -101,6 +110,15 @@ Do not start coding until the interface is confirmed via a reply.
 - Git identity: [USER_NAME] <[USER_EMAIL]> with SSH key [SSH_KEY]
 - Test command: ./.harness/init.sh
 - Current branch: [BRANCH]
+
+## Context Management
+If you completed a previous feature and were assigned a new one by the TeammateIdle hook,
+compact BEFORE starting the new feature:
+  /compact Focus on: [NEW_FEATURE_ID], scope [NEW_SCOPE_DIRS], TDD state clean
+This prevents mid-implementation compaction from losing TDD state.
+
+If at any point your conversation feels long (multiple research passes, prior debugging),
+compact proactively rather than waiting for automatic compaction.
 
 ## TDD Rules
 Same as Feature Implementer: failing test first, implement, verify, refactor.
@@ -202,6 +220,9 @@ When target isn't ready:
 **Plan approval**: true
 
 Same as Feature Implementer above, with this addition after "Session Start":
+
+(The "Context Management" section from the base template applies here too.
+Compact before plan submission if you've done extensive research.)
 
 ```
 ## Plan Before Implementing

--- a/claude/skills/harness-init/SKILL.md
+++ b/claude/skills/harness-init/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: harness-init
-description: Initialize a new project with the Long-Running Agent Harness v3.2.2. Sets up feature tracking, git identity capture, context summary, build hooks, quality gate hooks, and optional Agent Teams structure. Use when starting a new multi-session project.
+description: Initialize a new project with the Long-Running Agent Harness v3.4.0. Sets up feature tracking, git identity capture, context summary, build hooks, quality gate hooks, and optional Agent Teams structure. Use when starting a new multi-session project.
 ---
 
-# Harness Initializer v3.2.2
+# Harness Initializer v3.4.0
 
 Follow these steps in order. Do not skip steps. Ask the user when indicated.
 
@@ -48,7 +48,7 @@ Create `.harness/` with these files:
   "project": "PROJECT_NAME",
   "stack": "DETECTED_OR_SPECIFIED_STACK",
   "created": "ISO_DATE",
-  "version": "3.2.2",
+  "version": "3.4.0",
   "git_identity": {
     "user_name": "DETECTED_NAME",
     "user_email": "DETECTED_EMAIL",
@@ -332,7 +332,7 @@ Set up Agent Teams quality enforcement hooks. Read the two `.sh.template` files 
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Context was just compacted. Immediately re-read .harness/context_summary.md and run TaskList to recover your current state before continuing work."
+            "prompt": "Context was just compacted. Immediately re-read .harness/context_summary.md and run TaskList to recover your current state before continuing work. If this is the third or more compaction in rapid succession and you are losing context each time, STOP: write your current progress and known state to .harness/context_summary.md, message the lead with SendMessage({ type: 'message', recipient: 'team-lead', content: 'Context collapse: repeated compaction losing state. Current feature [ID] progress saved to context_summary.md. Need intervention.' }), then wait for instructions."
           }
         ]
       }
@@ -389,7 +389,7 @@ If the project already has a CLAUDE.md, append the harness reference. If not, cr
 
 ## Harness
 
-This project uses the Long-Running Agent Harness v3.2.
+This project uses the Long-Running Agent Harness v3.4.
 
 - Feature tracking: `.harness/features.json`
 - Context and decisions: `.harness/context_summary.md` (READ THIS at session start)
@@ -468,13 +468,13 @@ The team_structure is a starting suggestion. The lead may restructure during /ha
 
 ```bash
 git add .harness/ .claude/ CLAUDE.md
-git commit -m "chore: initialize harness v3.2.2 scaffolding"
+git commit -m "chore: initialize harness v3.4.0 scaffolding"
 ```
 
 Report:
 
 ```
-Harness v3.2.2 initialized:
+Harness v3.4.0 initialized:
 - .harness/ created with [N] features (scope and dependencies defined)
 - Git identity captured: [user] <[email]>
 - Build hook: [installed | skipped] for [STACK]

--- a/claude/skills/harness-init/check-remaining-tasks.sh.template
+++ b/claude/skills/harness-init/check-remaining-tasks.sh.template
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Harness v3.2.2 - TeammateIdle hook
+# Harness v3.4.0 - TeammateIdle hook
 # Runs when a teammate is about to go idle.
 # Exit code 0 = allow idle (no more work)
 # Exit code 2 = send feedback, keep teammate working
@@ -19,16 +19,28 @@ if [ -f ".harness/features.json" ]; then
     CLAIMABLE=$(cat .harness/features.json | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
-claimable = [f for f in data.get('features', []) if f['status'] in ('pending', 'failed')]
+features = data.get('features', [])
+passing_ids = {f['id'] for f in features if f['status'] == 'passing'}
+claimable = [
+    f for f in features
+    if f['status'] in ('pending', 'failed')
+    and all(dep in passing_ids for dep in f.get('depends_on', []))
+]
 print(len(claimable))
 " 2>/dev/null || echo "0")
 
     if [ "$CLAIMABLE" -gt 0 ]; then
-        # Find the highest priority claimable feature
+        # Find the highest priority claimable feature whose dependencies are met
         NEXT=$(cat .harness/features.json | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
-claimable = [f for f in data.get('features', []) if f['status'] in ('pending', 'failed')]
+features = data.get('features', [])
+passing_ids = {f['id'] for f in features if f['status'] == 'passing'}
+claimable = [
+    f for f in features
+    if f['status'] in ('pending', 'failed')
+    and all(dep in passing_ids for dep in f.get('depends_on', []))
+]
 if claimable:
     claimable.sort(key=lambda f: f.get('priority', 999))
     f = claimable[0]

--- a/claude/skills/harness-init/enforce-scope.sh.template
+++ b/claude/skills/harness-init/enforce-scope.sh.template
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Harness v3.2.2 - PreToolUse scope enforcement hook
+# Harness v3.4.0 - PreToolUse scope enforcement hook
 # Runs before Edit/Write tool calls when a teammate scope file exists.
 # Exit code 0 = allow edit
 # Exit code 2 = block edit (file outside scope)
@@ -22,6 +22,13 @@ print(data.get('tool_input', {}).get('file_path', ''))
 
 if [ -z "$FILE_PATH" ]; then
     exit 0
+fi
+
+# Normalize absolute paths to relative (tool input uses absolute paths,
+# scope patterns use relative paths like "src/auth/")
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+if [[ "$FILE_PATH" == "$PROJECT_ROOT/"* ]]; then
+    FILE_PATH="${FILE_PATH#$PROJECT_ROOT/}"
 fi
 
 # Check if file path matches any scope pattern

--- a/claude/skills/harness-init/init.sh.template
+++ b/claude/skills/harness-init/init.sh.template
@@ -37,7 +37,12 @@ detect_stack() {
 }
 
 if [ -f ".harness/harness.json" ]; then
-    STACK=$(cat .harness/harness.json | grep -o '"stack"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"stack"[[:space:]]*:[[:space:]]*"\([^"]*\)"/\1/')
+    STACK=$(python3 -c "
+import json
+with open('.harness/harness.json') as f:
+    data = json.load(f)
+print(data.get('stack', ''))
+" 2>/dev/null)
 fi
 
 if [ -z "$STACK" ] || [ "$STACK" = "null" ]; then

--- a/claude/skills/harness-init/verify-git-identity.sh.template
+++ b/claude/skills/harness-init/verify-git-identity.sh.template
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Harness v3.2.2 - PreToolUse git identity verification hook
+# Harness v3.4.0 - PreToolUse git identity verification hook
 # Runs before Bash tool calls that contain git push/pull/clone.
 # Exit code 0 = allow
 # Exit code 2 = block (identity mismatch)

--- a/claude/skills/harness-init/verify-task-quality.sh.template
+++ b/claude/skills/harness-init/verify-task-quality.sh.template
@@ -18,6 +18,22 @@ cd "$PROJECT_ROOT"
 # Read hook input from stdin
 INPUT=$(cat)
 
+# Try to extract feature ID from task metadata (if TaskCreate used metadata.feature_id)
+FEATURE_ID=$(echo "$INPUT" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+# Check task metadata first, then fall back to parsing task subject for 'FXXX:'
+metadata = data.get('task', {}).get('metadata', {})
+feature_id = metadata.get('feature_id', '')
+if not feature_id:
+    subject = data.get('task', {}).get('subject', '')
+    if ':' in subject:
+        candidate = subject.split(':')[0].strip()
+        if candidate.startswith('F') and candidate[1:].isdigit():
+            feature_id = candidate
+print(feature_id)
+" 2>/dev/null || echo "")
+
 if [ ! -f ".harness/init.sh" ]; then
     echo "Task rejected: .harness/init.sh not found. Cannot verify tests pass."
     echo "Run /harness-init to create the test script, or create it manually."
@@ -29,16 +45,18 @@ fi
 # useful for retrospectives and dynamic model selection.
 increment_correction_cycles() {
     if [ -f ".harness/features.json" ]; then
-        python3 - <<'PYEOF'
-import json
+        python3 - "$FEATURE_ID" <<'PYEOF'
+import json, sys
+target_id = sys.argv[1] if len(sys.argv) > 1 and sys.argv[1] else None
 try:
     with open('.harness/features.json', 'r') as f:
         data = json.load(f)
     changed = False
     for feature in data.get('features', []):
         if feature.get('status') == 'in-progress':
-            feature['correction_cycles'] = feature.get('correction_cycles', 0) + 1
-            changed = True
+            if target_id is None or feature.get('id') == target_id:
+                feature['correction_cycles'] = feature.get('correction_cycles', 0) + 1
+                changed = True
     if changed:
         with open('.harness/features.json', 'w') as f:
             json.dump(data, f, indent=2)

--- a/install
+++ b/install
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-VV Claude Code Harness — Installer v3.3.0
+VV Claude Code Harness — Installer v3.4.0
 
 Usage:
   ./install                  Interactive install (prompts for name)
@@ -20,7 +20,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
-HARNESS_VERSION = "3.3.0"
+HARNESS_VERSION = "3.4.0"
 CLAUDE_DIR = Path.home() / ".claude"
 SCRIPT_DIR = Path(__file__).resolve().parent
 


### PR DESCRIPTION
## Summary

- **Fix scope enforcement**: normalize absolute paths to relative before matching scope patterns — scope enforcement was silently broken on all real systems
- **Fix idle hook**: respect `depends_on` chains so blocked features aren't assigned to teammates
- **Fix correction_cycles**: target specific feature ID instead of incrementing all in-progress features
- **Fix init.sh**: replace fragile grep/sed JSON parsing with python3 (consistent with all other scripts)
- **Add context management**: spawn templates now instruct proactive compaction between features
- **Add PostCompact circuit breaker**: detect repeated compaction context collapse and escalate
- **Add TaskCreate metadata convention**: `metadata.feature_id` for task-to-feature correlation
- **Add completion deduplication**: prevent duplicate completion messages from TeammateIdle race
- **Bump version to 3.4.0**

## Test plan

- [ ] Verify enforce-scope.sh strips absolute paths correctly
- [ ] Verify check-remaining-tasks.sh only offers features with passing dependencies
- [ ] Verify verify-task-quality.sh increments only the target feature's correction_cycles
- [ ] Verify init.sh reads stack from harness.json via python3
- [ ] Grep for stale version references (3.2.2 / 3.3.0) outside changelog sections