### PR TITLE
release: v3.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A harness system for Claude Code that solves multi-session continuity, parallel agent coordination, and automated quality enforcement. Built on Anthropic's research for long-running tasks, evolved through three major versions into a system built on Claude Code's native Agent Teams primitives.
 
-**Current version: v3.4.0** — Fixes four bugs where harness hooks silently did nothing on real systems (scope enforcement, dependency filtering, correction_cycles targeting, JSON parsing). Adds proactive context management for teammates, a PostCompact circuit breaker, and TaskCreate metadata conventions for task-to-feature correlation that survives compaction.
+**Current version: v3.5.0** — Session discipline improvements from real-world harness violations. Adds mandatory smoke test gate, pre-commit features.json audit, mandatory retrospective for all session types, inline context updates during bug fixes, commit-at-breakpoints hygiene, stale task prevention, and coverage blocker documentation.
 
 ---
 
@@ -20,7 +20,7 @@ Two failure patterns emerge consistently:
 
 Both failures stem from the same root cause: no persistent memory of intent, progress, or remaining work.
 
-v2.1 addressed a third failure: parallel agents stepping on each other. v3.0 replaced the custom coordination layer entirely with Claude Code's native Agent Teams. And v3.2 added mechanical enforcement (shell hooks that physically prevent completion without passing tests), v3.3 added metacognitive self-improvement (the harness learns from its own coordination patterns), and v3.4 fixed four hooks that were silently broken on real systems.
+v2.1 addressed a third failure: parallel agents stepping on each other. v3.0 replaced the custom coordination layer entirely with Claude Code's native Agent Teams. And v3.2 added mechanical enforcement (shell hooks that physically prevent completion without passing tests), v3.3 added metacognitive self-improvement (the harness learns from its own coordination patterns), v3.4 fixed four hooks that were silently broken on real systems, and v3.5 tightened session discipline based on real-world violation analysis.
 
 ## Two solutions, one insight
 
@@ -316,6 +316,38 @@ https://github.com/user-attachments/assets/9684d120-3cbf-438d-a01f-469387f507ff
 ---
 
 ## Changelog
+
+### v3.5.0 (2026-04-06)
+
+**Session discipline improvements** based on root cause analysis of 11 harness violations observed during a real iOS project session (voice fix, test expansion, app icon work).
+
+**Five serious violation remediations:**
+
+1. **Pre-commit features.json audit** — Session end now requires diffing `features.json` against actual work done. Any code change relating to a tracked feature must update that feature's metadata. Work that doesn't map to any feature gets a new entry with `discovered_via`. This is a gate before `git commit`, not an afterthought.
+
+2. **Inline context_summary.md updates** — `context_summary.md` updates are now part of the task, not after the task. After every bug fix revealing a non-obvious root cause, write the gotcha to `context_summary.md` BEFORE moving to the next request.
+
+3. **Mandatory retrospective for all session types** — The retrospective is now explicitly mandatory at session end regardless of whether the session used Agent Teams or single-session mode. Minimum viable: 3-5 bullets covering actual vs planned scope, unanticipated discoveries, and transferable patterns.
+
+4. **Task updates at moment of state change** — Task updates must happen immediately when state changes, not in batch. When you finish something, the NEXT action is `TaskUpdate`. Stale tasks are explicitly called out as worse than no tasks.
+
+5. **Smoke test gate at session start** — `init.sh` is now a dedicated Step 2.5 in the orient flow, run within the first 5 actions of every session. Its purpose is to establish known-good state before changes, not to diagnose problems.
+
+**Four moderate/minor violation remediations:**
+
+6. **Single-session mode declaration** — When choosing single-session over Agent Teams, the lead must explicitly declare it to make the decision conscious and documented.
+
+7. **Bug fix diagnosis before editing** — Debugging Phase 1 now requires stating diagnosis and proposed fix in 2-3 sentences before editing code, even for seemingly obvious fixes.
+
+8. **Commit at natural breakpoints** — Commit hygiene rules now require committing after each feature/fix passes tests, separating harness metadata from code, and checkpointing inherited uncommitted work before making new changes.
+
+9. **Untracked file and task metadata audit at orient** — The orient step now checks for unknown untracked files (surfaced to user) and verifies inherited tasks have required `feature_id` metadata.
+
+**Two standards improvements:**
+
+10. **Coverage blocker documentation** — If coverage measurement isn't available in the project's tooling, document it as a gotcha in `context_summary.md` and create a feature to enable it. Silent coverage gate skipping is no longer acceptable.
+
+11. **Strengthened task completion checklist** — Harness-specific checklist items now explicitly require features.json audit, context_summary.md updates, retrospective, and task list currency check.
 
 ### v3.4.0 (2026-04-02)
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,10 +1,10 @@
 ---
 scope: global
 location: ~/.claude/CLAUDE.md
-version: 3.4.0
-last_updated: 2026-03-26
+version: 3.5.0
+last_updated: 2026-04-06
 author: {{USER_NAME}}
-description: Core engineering standards for all Claude Code sessions. Works with Long-Running Agent Harness v3.4.0.
+description: Core engineering standards for all Claude Code sessions. Works with Long-Running Agent Harness v3.5.0.
 supplements: Project-level CLAUDE.md files in individual repositories
 ---
 
@@ -160,7 +160,7 @@ No exceptions unless tooling is broken.
 
 ### Coverage
 
-For harness projects: coverage >= 95% on code touched during the feature. Features aren't done until `features.json` has `status: "passing"`, `test_file` points to a test, and `coverage` meets threshold.
+For harness projects: coverage >= 95% on code touched during the feature. Features aren't done until `features.json` has `status: "passing"`, `test_file` points to a test, and `coverage` meets threshold. If the project's test tooling doesn't support coverage measurement, document this as a blocker in `context_summary.md` under Gotchas and create a feature to enable it. Do not silently skip the coverage gate — either measure it or explicitly note why you can't.
 
 For non-harness projects: match the project's existing test patterns for file naming, assertion style, and organization. Run existing tests before committing.
 
@@ -174,6 +174,7 @@ YOU MUST find the root cause. NEVER fix a symptom or add a workaround.
 - Read error messages carefully; they often contain the exact solution
 - Reproduce consistently before investigating
 - Check recent changes: git diff, recent commits
+- For user-reported bugs: state your diagnosis and proposed fix in 2-3 sentences BEFORE editing code. ("I think the crash is X because Y, I'll fix it by Z.") This gives the user a chance to correct your understanding and costs one message.
 
 ### Phase 2: Pattern Analysis
 - Find working examples in the same codebase
@@ -307,6 +308,7 @@ When gitleaks blocks a push due to false positives, add entries to `.gitleaks.to
 - No auto-generated signatures
 - No "Generated with Claude Code" or "Co-Authored-By: Claude"
 - Write commits as if a human wrote them
+- Commit at natural breakpoints during the session, not at the end. Specifically: (1) commit after each feature/fix passes tests, (2) commit harness metadata separately from code with `docs:` prefix, (3) if you inherit uncommitted work from a previous session, commit it as-is first ("checkpoint: uncommitted work from session N") before making new changes
 - Separate documentation commits from code when practical
 - Prefix: `docs:` for pure documentation changes
 
@@ -451,7 +453,10 @@ Before declaring ANY task complete:
 - [ ] {{USER_NAME}} informed of what changed
 
 Additional for harness projects:
-- [ ] `features.json` updated (status, test_file, coverage)
+- [ ] `features.json` audited against actual work done — every touched feature has updated status, test_file, coverage; unmapped work gets a new feature entry with `discovered_via`
+- [ ] `context_summary.md` has any non-obvious root causes, gotchas, or patterns discovered this session
+- [ ] Retrospective written to `context_summary.md` under `## Meta-Session [DATE]` (mandatory even for single-session work)
 - [ ] `claude-progress.txt` has session handoff
+- [ ] Task list is current — no stale in-progress or pending tasks that no longer reflect reality
 
 Do NOT skip this checklist.

--- a/claude/skills/harness-continue/SKILL.md
+++ b/claude/skills/harness-continue/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: harness-continue
-description: Continue working on a harness-managed project (v3.4.0). Orients to current state, picks single-session or Agent Teams mode, and guides implementation with TDD, quality gate hooks, and compaction-aware context management. Use at the start of any session on a harness project.
+description: Continue working on a harness-managed project (v3.5.0). Orients to current state, picks single-session or Agent Teams mode, and guides implementation with TDD, quality gate hooks, and compaction-aware context management. Use at the start of any session on a harness project.
 ---
 
-# Harness Continue v3.4.0
+# Harness Continue v3.5.0
 
 ## Step 1: Orient Yourself
 
@@ -15,6 +15,16 @@ cat .harness/features.json
 cat .harness/harness.json
 ```
 
+Check for untracked files and inherited task quality:
+
+```bash
+git status -s          # surface unknown untracked files
+```
+
+If you see untracked files you didn't create (e.g., `notes.md`, scratch files), surface them to the user immediately: "I see `[file]` untracked — should I delete it, gitignore it, or leave it?" This takes 5 seconds and prevents orphaned file accumulation.
+
+If inheriting tasks from a previous session, verify they have required metadata fields (`feature_id` at minimum) via `TaskList`. Tasks without `feature_id` can't be correlated by hooks or retrospectives. Update them with `TaskUpdate` now if they're missing it.
+
 Summarize what you find:
 
 ```
@@ -24,6 +34,7 @@ Project state:
 - Next up: [highest priority incomplete feature]
 - Blockers: [any noted in progress or context_summary]
 - Git identity: [from harness.json]
+- Untracked files: [any unexpected files surfaced to user]
 ```
 
 ## Step 2: Verify Git Identity
@@ -35,6 +46,16 @@ git config user.email
 ```
 
 Compare against `.harness/harness.json` `git_identity`. If mismatch, fix before proceeding. Do not skip this.
+
+## Step 2.5: Smoke Test
+
+Run the project's build/test smoke test:
+
+```bash
+./.harness/init.sh
+```
+
+This is a gate, not a diagnostic. Its purpose is to confirm the environment is in a known-good state BEFORE any changes. If it fails, you know the problem is pre-existing, not something you introduced. Run it within the first 5 actions of every session. No exceptions. The 15-second cost prevents 15-minute debugging sessions later.
 
 ## Step 3: Set Effort Level
 
@@ -53,6 +74,8 @@ Adjust as you transition between phases during the session.
 - The feature is sequential (can't be parallelized)
 - `harness.json` team_structure is null
 - User explicitly asks for focused work
+
+When choosing single-session, explicitly declare it: "Running in single-session mode — I'm both lead and implementer." This makes the decision conscious and documented, preventing ambiguity between "I forgot plan mode" and "plan mode doesn't apply here."
 
 **Choose Agent Teams if:**
 - Multiple independent features are ready
@@ -90,7 +113,7 @@ TaskCreate({ subject: "F001: Update features.json", description: "Set status to 
 TaskCreate({ subject: "F001: Update context_summary.md with learnings", description: "Persist decisions and patterns", metadata: { feature_id: "F001" } })
 ```
 
-Use `TaskUpdate` to mark each task `in_progress` when starting and `completed` when done. Tasks are your crash-recovery journal: if compaction hits unexpectedly, stale tasks are worse than no tasks.
+Use `TaskUpdate` to mark each task `in_progress` when starting and `completed` when done. Task updates must happen at the moment of state change, not in batch. The rule: when you finish something, the NEXT action is `TaskUpdate` — before responding to the user, before starting the next task. If planned tasks no longer match reality (scope changed, new work appeared), update or delete stale tasks immediately. A stale task list is worse than no task list because it creates false confidence about state.
 
 4. Run smoke test: `./.harness/init.sh`
 
@@ -108,6 +131,10 @@ Use `TaskUpdate` to mark each task `in_progress` when starting and `completed` w
 7. Run full suite; coverage >= 95% on touched code
 
 No exceptions unless tooling is broken.
+
+### Context Updates During Work
+
+Treat `context_summary.md` updates as part of the task, not after the task. Specifically: after every bug fix that reveals a non-obvious root cause, write the gotcha to `context_summary.md` BEFORE moving to the next request. The cost is 30 seconds; the value is permanent. A future session will benefit from knowing the root cause without re-discovering it.
 
 ### When Feature Passes
 
@@ -135,8 +162,9 @@ After compaction, the **PostCompact hook** fires automatically and reminds you t
 ### Session End
 
 1. Run full test suite one final time
-2. If all features are now passing, run the retrospective (see Phase 5.5 above — same process applies to single-session work). Skip if this is the project's first completed session.
-3. Write handoff to `claude-progress.txt`:
+2. **Pre-commit features.json audit**: Diff `features.json` against the actual work done this session. If any code was changed that relates to a tracked feature, that feature's metadata must be updated (status, test_file, coverage). If work was done that doesn't map to any existing feature, create a new feature entry with `discovered_via` pointing to the trigger. This check is a gate before `git commit`, not an afterthought.
+3. **Retrospective (mandatory)**: Run the retrospective regardless of session type. For single-session work, it can be shorter (3-5 bullets), but it must exist. Minimum viable retrospective: (1) what was the session's actual scope vs planned scope? (2) what was discovered that wasn't anticipated? (3) what pattern or gotcha should transfer to future sessions? Write to `context_summary.md` under `## Meta-Session [DATE]` before the final commit. Skip only if this is the project's very first session.
+4. Write handoff to `claude-progress.txt`:
    ```
    ## Session [N] - [DATE]
    - Feature: F00X - [description]
@@ -147,7 +175,7 @@ After compaction, the **PostCompact hook** fires automatically and reminds you t
    - Next: [what the next session should do]
    - Blockers: [any blockers]
    ```
-3. Git commit
+5. Git commit (see Commit Hygiene rules — separate harness metadata from code commits)
 
 ---
 

--- a/claude/skills/harness-init/SKILL.md
+++ b/claude/skills/harness-init/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: harness-init
-description: Initialize a new project with the Long-Running Agent Harness v3.4.0. Sets up feature tracking, git identity capture, context summary, build hooks, quality gate hooks, and optional Agent Teams structure. Use when starting a new multi-session project.
+description: Initialize a new project with the Long-Running Agent Harness v3.5.0. Sets up feature tracking, git identity capture, context summary, build hooks, quality gate hooks, and optional Agent Teams structure. Use when starting a new multi-session project.
 ---
 
-# Harness Initializer v3.4.0
+# Harness Initializer v3.5.0
 
 Follow these steps in order. Do not skip steps. Ask the user when indicated.
 
@@ -48,7 +48,7 @@ Create `.harness/` with these files:
   "project": "PROJECT_NAME",
   "stack": "DETECTED_OR_SPECIFIED_STACK",
   "created": "ISO_DATE",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "git_identity": {
     "user_name": "DETECTED_NAME",
     "user_email": "DETECTED_EMAIL",
@@ -468,13 +468,13 @@ The team_structure is a starting suggestion. The lead may restructure during /ha
 
 ```bash
 git add .harness/ .claude/ CLAUDE.md
-git commit -m "chore: initialize harness v3.4.0 scaffolding"
+git commit -m "chore: initialize harness v3.5.0 scaffolding"
 ```
 
 Report:
 
 ```
-Harness v3.4.0 initialized:
+Harness v3.5.0 initialized:
 - .harness/ created with [N] features (scope and dependencies defined)
 - Git identity captured: [user] <[email]>
 - Build hook: [installed | skipped] for [STACK]


### PR DESCRIPTION
## Summary
- Session discipline improvements from real-world harness violation analysis
- 5 serious + 4 moderate violation remediations + 2 standards improvements
- Updates to harness-continue, harness-init skills and CLAUDE.md template

## Changes
- `claude/CLAUDE.md` — strengthened task completion checklist, retrospective mandate
- `claude/skills/harness-continue/SKILL.md` — smoke test gate, pre-commit audit, inline context updates, commit hygiene
- `claude/skills/harness-init/SKILL.md` — untracked file audit, task metadata verification
- `README.md` — v3.5.0 changelog and evolution narrative