### PR TITLE
hotfix: bump install script and stale strings to v3.5.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,6 @@ Files under `claude/` are **distribution templates**, not active project configu
 
 - No build system, no tests, no application code
 - Changes are documentation and template edits only
-- Version number lives in: `claude/CLAUDE.md` frontmatter, `README.md` header, and `README.md` changelog
-- Keep all three version references in sync when bumping
+- Version number lives in: `install` (`HARNESS_VERSION` constant + module docstring banner), `claude/CLAUDE.md` frontmatter + description line, `README.md` "Current version" header, `README.md` download/unzip examples in "Getting started", `README.md` changelog header, and `INSTALL.md` title
+- Keep all version references in sync when bumping. Sanity check: `grep -rn "X\.Y\.Z" --include="*.md" --include="install"` should return only the new version (plus historical changelog entries)
 - The installed global copy at `~/.claude/CLAUDE.md` must match `claude/CLAUDE.md` (minus personal sections like Slack config)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,4 @@
-# Installation Guide: Harness v3.4.0
+# Installation Guide: Harness v3.5.1
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -267,14 +267,14 @@ In non-harness projects, only CLAUDE.md loads (~4.2K). The agent-teams-protocol 
 
 Everything you need is in this repo:
 
-1. Download [harness-v3.4.0.zip](https://github.com/oeftimie/vv-claude-harness/releases)
+1. Download [harness-v3.5.1.zip](https://github.com/oeftimie/vv-claude-harness/releases)
 2. Follow the [INSTALL.md](./INSTALL.md) instructions
 3. Review the [CLAUDE.md](./claude/CLAUDE.md) for core engineering standards
 
 ### Quick install
 
 ```bash
-unzip vv-claude-harness-v3.4.0.zip
+unzip vv-claude-harness-v3.5.1.zip
 cd vv-claude-harness
 ./install
 ```
@@ -316,6 +316,10 @@ https://github.com/user-attachments/assets/9684d120-3cbf-438d-a01f-469387f507ff
 ---
 
 ## Changelog
+
+### v3.5.1 (2026-04-25)
+
+**Hotfix:** v3.5.0 shipped without bumping `install` (`HARNESS_VERSION` constant + banner), `INSTALL.md` title, and the README download/unzip examples. Running `./install` from a v3.5.0 directory reported "Upgrade (v3.5.0 -> v3.4.0)" — a downgrade against the installed copy. No functional changes; version strings only. Repo `CLAUDE.md` updated to add `install` to the version-sync list so this regression can't repeat.
 
 ### v3.5.0 (2026-04-06)
 

--- a/install
+++ b/install
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-VV Claude Code Harness — Installer v3.4.0
+VV Claude Code Harness — Installer v3.5.1
 
 Usage:
   ./install                  Interactive install (prompts for name)
@@ -20,7 +20,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
-HARNESS_VERSION = "3.4.0"
+HARNESS_VERSION = "3.5.1"
 CLAUDE_DIR = Path.home() / ".claude"
 SCRIPT_DIR = Path(__file__).resolve().parent
 


### PR DESCRIPTION
## Summary

v3.5.0 shipped without updating the installer's \`HARNESS_VERSION\` constant or banner, the \`INSTALL.md\` title, or the README download/unzip examples. Running \`./install\` from a v3.5.0 directory reports \`Upgrade (v3.5.0 -> v3.4.0)\` — a downgrade against the installed copy.

## Changes

- \`install\`: \`HARNESS_VERSION\` constant + module docstring banner → \`3.5.1\`
- \`INSTALL.md\`: title → \`v3.5.1\`
- \`README.md\`: "Getting started" download link + unzip example → \`v3.5.1\`; new v3.5.1 changelog entry
- \`CLAUDE.md\` (repo): version-sync list now enumerates every file that holds the version string, plus a \`grep\` sanity check

No functional changes; version strings only.

## Test plan

- [x] grep returns only historical v3.4.0 entries (changelog line + the new v3.5.1 entry referencing the bug)
- [x] grep for v3.5.1 returns the five new locations
- [ ] \`./install --dry-run\` banner reads v3.5.1
- [ ] \`./install --dry-run\` against installed v3.5.0 reports "Upgrade (v3.5.0 -> v3.5.1)"