### PR TITLE
feat: detect-and-warn stale files from older harness versions (v3.6.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,12 @@ Files under `claude/` are **distribution templates**, not active project configu
 
 - No build system, no tests, no application code
 - Changes are documentation and template edits only
-- Version number lives in: `install` (`HARNESS_VERSION` constant + module docstring banner), `claude/CLAUDE.md` frontmatter + description line, `README.md` "Current version" header, `README.md` download/unzip examples in "Getting started", `README.md` changelog header, and `INSTALL.md` title
-- Keep all version references in sync when bumping. Sanity check: `grep -rn "X\.Y\.Z" --include="*.md" --include="install"` should return only the new version (plus historical changelog entries)
+- Version number lives in:
+  - `install` — `HARNESS_VERSION` constant + module docstring banner
+  - `claude/CLAUDE.md` — frontmatter `version:` + description line
+  - `claude/skills/harness-init/SKILL.md` — frontmatter description, H1 title, `version:` field in the `harness.json` template, the init commit message, and the final report banner
+  - `claude/skills/harness-continue/SKILL.md` — frontmatter description and H1 title
+  - `README.md` — "Current version" header, download/unzip examples in "Getting started", and changelog header for the new entry
+  - `INSTALL.md` — title
+- Keep all version references in sync when bumping. Sanity check: `grep -rn "OLD\.VERSION" --include="*.md" --include="install"` should return only historical changelog entries; `grep -rn "NEW\.VERSION"` should hit every location above
 - The installed global copy at `~/.claude/CLAUDE.md` must match `claude/CLAUDE.md` (minus personal sections like Slack config)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,4 @@
-# Installation Guide: Harness v3.5.1
+# Installation Guide: Harness v3.6.0
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A harness system for Claude Code that solves multi-session continuity, parallel agent coordination, and automated quality enforcement. Built on Anthropic's research for long-running tasks, evolved through three major versions into a system built on Claude Code's native Agent Teams primitives.
 
-**Current version: v3.5.0** — Session discipline improvements from real-world harness violations. Adds mandatory smoke test gate, pre-commit features.json audit, mandatory retrospective for all session types, inline context updates during bug fixes, commit-at-breakpoints hygiene, stale task prevention, and coverage blocker documentation.
+**Current version: v3.6.0** — Stale-file detection in the installer. Surfaces residue from older harness versions (including the v2.x module-lock era's `orchestrator.md` / `scheduling.md` / `coding-agent.md` / `context-graph` skill) that previously sat silently in `~/.claude/` after upgrades. Default behavior is detect-and-warn; pass `--clean-stale` to remove. Replaces the older silent auto-delete pass, which had an incomplete manifest. Builds on v3.5.0's session discipline improvements: smoke test gate, features.json audit, mandatory retrospectives, inline context updates.
 
 ---
 
@@ -267,14 +267,14 @@ In non-harness projects, only CLAUDE.md loads (~4.2K). The agent-teams-protocol 
 
 Everything you need is in this repo:
 
-1. Download [harness-v3.5.1.zip](https://github.com/oeftimie/vv-claude-harness/releases)
+1. Download [harness-v3.6.0.zip](https://github.com/oeftimie/vv-claude-harness/releases)
 2. Follow the [INSTALL.md](./INSTALL.md) instructions
 3. Review the [CLAUDE.md](./claude/CLAUDE.md) for core engineering standards
 
 ### Quick install
 
 ```bash
-unzip vv-claude-harness-v3.5.1.zip
+unzip vv-claude-harness-v3.6.0.zip
 cd vv-claude-harness
 ./install
 ```
@@ -316,6 +316,18 @@ https://github.com/user-attachments/assets/9684d120-3cbf-438d-a01f-469387f507ff
 ---
 
 ## Changelog
+
+### v3.6.0 (2026-04-26)
+
+**Stale-file detection in the installer.** Before v3.6.0, the installer silently auto-deleted a small list of deprecated files (`engineering-standards.md`, `non-harness-workflow.md`) and missed the v2.x module-lock residue entirely (`orchestrator.md`, `scheduling.md`, `coding-agent.md`, the `context-graph` skill). Anyone who upgraded from v2.x kept those dead files in `~/.claude/` and could end up with two competing harness models loaded at once — exactly the conflict that surfaced in a real session and prompted this work.
+
+**Behavior change** — the installer no longer auto-deletes. Stale files are now **detected and reported** by default, listing each one with its `~/.claude/` path. Pass `--clean-stale` to remove them; the regular backup pass picks them up first. This is a deliberate trade: silent cleanup hid both the problem and the fix from users. The new default surfaces the decision.
+
+**Updated stale manifest:**
+- v2.x module-lock era (retired in v3.0): `rules/orchestrator.md`, `rules/scheduling.md`, `rules/coding-agent.md`, `skills/context-graph/`, `harness/`, `templates/`, `commands/project-harness-init.md`, `commands/project-harness-continue.md`
+- v3.2.x cleanup (retired in v3.2.2): `rules/engineering-standards.md`, `rules/non-harness-workflow.md`
+
+**Scope:** global files only (`~/.claude/`). Per-project residue (`.context/modules.yaml`, old `.harness/` schemas, project-local `.claude/rules/scheduling.md`) is intentionally left alone — projects contain user data and the upgrade flow needs more thought before it touches them.
 
 ### v3.5.1 (2026-04-25)
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,10 +1,10 @@
 ---
 scope: global
 location: ~/.claude/CLAUDE.md
-version: 3.5.0
-last_updated: 2026-04-06
+version: 3.6.0
+last_updated: 2026-04-26
 author: {{USER_NAME}}
-description: Core engineering standards for all Claude Code sessions. Works with Long-Running Agent Harness v3.5.0.
+description: Core engineering standards for all Claude Code sessions. Works with Long-Running Agent Harness v3.6.0.
 supplements: Project-level CLAUDE.md files in individual repositories
 ---
 

--- a/claude/skills/harness-continue/SKILL.md
+++ b/claude/skills/harness-continue/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: harness-continue
-description: Continue working on a harness-managed project (v3.5.0). Orients to current state, picks single-session or Agent Teams mode, and guides implementation with TDD, quality gate hooks, and compaction-aware context management. Use at the start of any session on a harness project.
+description: Continue working on a harness-managed project (v3.6.0). Orients to current state, picks single-session or Agent Teams mode, and guides implementation with TDD, quality gate hooks, and compaction-aware context management. Use at the start of any session on a harness project.
 ---
 
-# Harness Continue v3.5.0
+# Harness Continue v3.6.0
 
 ## Step 1: Orient Yourself
 

--- a/claude/skills/harness-init/SKILL.md
+++ b/claude/skills/harness-init/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: harness-init
-description: Initialize a new project with the Long-Running Agent Harness v3.5.0. Sets up feature tracking, git identity capture, context summary, build hooks, quality gate hooks, and optional Agent Teams structure. Use when starting a new multi-session project.
+description: Initialize a new project with the Long-Running Agent Harness v3.6.0. Sets up feature tracking, git identity capture, context summary, build hooks, quality gate hooks, and optional Agent Teams structure. Use when starting a new multi-session project.
 ---
 
-# Harness Initializer v3.5.0
+# Harness Initializer v3.6.0
 
 Follow these steps in order. Do not skip steps. Ask the user when indicated.
 
@@ -48,7 +48,7 @@ Create `.harness/` with these files:
   "project": "PROJECT_NAME",
   "stack": "DETECTED_OR_SPECIFIED_STACK",
   "created": "ISO_DATE",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "git_identity": {
     "user_name": "DETECTED_NAME",
     "user_email": "DETECTED_EMAIL",
@@ -468,13 +468,13 @@ The team_structure is a starting suggestion. The lead may restructure during /ha
 
 ```bash
 git add .harness/ .claude/ CLAUDE.md
-git commit -m "chore: initialize harness v3.5.0 scaffolding"
+git commit -m "chore: initialize harness v3.6.0 scaffolding"
 ```
 
 Report:
 
 ```
-Harness v3.5.0 initialized:
+Harness v3.6.0 initialized:
 - .harness/ created with [N] features (scope and dependencies defined)
 - Git identity captured: [user] <[email]>
 - Build hook: [installed | skipped] for [STACK]

--- a/install
+++ b/install
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-VV Claude Code Harness — Installer v3.5.1
+VV Claude Code Harness — Installer v3.6.0
 
 Usage:
   ./install                  Interactive install (prompts for name)
@@ -8,6 +8,7 @@ Usage:
   ./install --dry-run        Show what would be done without doing it
   ./install --no-backup      Skip backup of existing files
   ./install --upgrade-only   Only upgrade per-project harness files (no global install)
+  ./install --clean-stale    Remove stale files from older harness versions (default: warn only)
 """
 
 import argparse
@@ -20,7 +21,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
-HARNESS_VERSION = "3.5.1"
+HARNESS_VERSION = "3.6.0"
 CLAUDE_DIR = Path.home() / ".claude"
 SCRIPT_DIR = Path(__file__).resolve().parent
 
@@ -36,20 +37,31 @@ GLOBAL_DIRS = {
     "claude/skills/harness-continue": "skills/harness-continue",
 }
 
-# Files that older versions installed but are no longer needed
-DEPRECATED_FILES = [
+# Files older harness versions installed that are no longer current.
+# Detected and reported on every install. Removed only when --clean-stale is passed.
+# When adding entries: include the harness version in which the file was retired,
+# so future maintainers can decide when an entry is old enough to drop.
+STALE_FILES = [
+    # Pre-v3.0 module-lock / orchestrator era (retired in v3.0)
+    "rules/orchestrator.md",
+    "rules/scheduling.md",
+    "rules/coding-agent.md",
+    # v3.2.x cleanup (retired in v3.2.2)
     "rules/non-harness-workflow.md",
     "rules/engineering-standards.md",
 ]
 
-DEPRECATED_DIRS = [
-    "harness/",
+STALE_DIRS = [
+    # Pre-v3.0 module-lock skill (retired in v3.0)
     "skills/context-graph/",
+    # Pre-v3.0 layout (retired in v3.0)
+    "harness/",
     "templates/",
 ]
 
 # Only remove commands/ if it contains harness-specific files
-DEPRECATED_COMMAND_FILES = [
+STALE_COMMAND_FILES = [
+    # Pre-v3.0 slash commands (retired in v3.0)
     "commands/project-harness-init.md",
     "commands/project-harness-continue.md",
 ]
@@ -130,8 +142,12 @@ def detect_shell_profile():
     return Path.home() / ".profile"
 
 
-def backup_existing(dry_run=False):
-    """Backup existing harness files. Returns backup dir path or None."""
+def backup_existing(dry_run=False, extra_paths=None):
+    """Backup existing harness files. Returns backup dir path or None.
+
+    extra_paths: optional list of CLAUDE_DIR-relative paths to also back up
+                 (e.g., stale files about to be cleaned).
+    """
     existing = []
 
     # Check global files
@@ -144,6 +160,12 @@ def backup_existing(dry_run=False):
     for dest in GLOBAL_DIRS.values():
         path = CLAUDE_DIR / dest
         if path.exists():
+            existing.append(path)
+
+    # Check extra paths (e.g., stale files for --clean-stale)
+    for rel in extra_paths or []:
+        path = CLAUDE_DIR / rel
+        if path.exists() and path not in existing:
             existing.append(path)
 
     if not existing:
@@ -212,37 +234,32 @@ def install_global_files(user_name, dry_run=False):
     return True
 
 
-def remove_deprecated(dry_run=False):
-    """Remove files/dirs from older versions that are no longer needed."""
-    removed = []
-    for rel in DEPRECATED_FILES:
-        path = CLAUDE_DIR / rel
-        if path.exists():
-            if dry_run:
-                print(f"  {dim(f'Would remove: ~/.claude/{rel}')}")
-            else:
-                path.unlink()
-            removed.append(rel)
+def detect_stale_files():
+    """Return paths (relative to CLAUDE_DIR) of stale files from older harness versions."""
+    found = []
+    for rel in STALE_FILES + STALE_COMMAND_FILES:
+        if (CLAUDE_DIR / rel).exists():
+            found.append(rel)
+    for rel in STALE_DIRS:
+        if (CLAUDE_DIR / rel).exists():
+            found.append(rel)
+    return found
 
-    for rel in DEPRECATED_DIRS:
-        path = CLAUDE_DIR / rel
-        if path.exists():
-            if dry_run:
-                print(f"  {dim(f'Would remove: ~/.claude/{rel}')}")
-            else:
-                shutil.rmtree(path)
-            removed.append(rel)
 
-    for rel in DEPRECATED_COMMAND_FILES:
+def clean_stale_files(stale, dry_run=False):
+    """Remove the given stale files. Caller must have detected them first."""
+    for rel in stale:
         path = CLAUDE_DIR / rel
-        if path.exists():
-            if dry_run:
-                print(f"  {dim(f'Would remove: ~/.claude/{rel}')}")
-            else:
-                path.unlink()
-            removed.append(rel)
-
-    return removed
+        if not path.exists():
+            continue
+        if dry_run:
+            print(f"  {dim(f'Would remove: ~/.claude/{rel}')}")
+            continue
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+        print(f"  Removed: {dim(rel)}")
 
 
 def setup_agent_teams_env(dry_run=False):
@@ -425,6 +442,8 @@ def main():
     parser.add_argument("--no-backup", action="store_true", help="Skip backup of existing files")
     parser.add_argument("--upgrade-only", metavar="PROJECT_DIR", nargs="?", const=".",
                         help="Only upgrade per-project harness files (default: current dir)")
+    parser.add_argument("--clean-stale", action="store_true",
+                        help="Remove stale files from older harness versions (default: warn only)")
 
     args = parser.parse_args()
 
@@ -493,10 +512,14 @@ def main():
 
     print(f"  Using name: {bold(user_name)}\n")
 
+    # --- Detect stale files early so backup can include them if --clean-stale ---
+    stale = detect_stale_files()
+
     # --- Backup ---
     if not args.no_backup:
         print(f"{bold('Backing up existing files...')}")
-        backup = backup_existing(dry_run=args.dry_run)
+        extra = stale if args.clean_stale else None
+        backup = backup_existing(dry_run=args.dry_run, extra_paths=extra)
         if not backup:
             print(f"  No existing harness files to backup.")
         print()
@@ -509,15 +532,21 @@ def main():
         sys.exit(1)
     print(f"  {green('Done.')}\n")
 
-    # --- Remove deprecated files ---
-    print(f"{bold('Cleaning up deprecated files...')}")
-    removed = remove_deprecated(dry_run=args.dry_run)
-    if removed:
-        for r in removed:
-            if not args.dry_run:
-                print(f"  Removed: {dim(r)}")
+    # --- Stale files from older harness versions ---
+    # (already detected above so the backup pass could include them)
+    print(f"{bold('Checking for stale files from older harness versions...')}")
+    if not stale:
+        print(f"  None found.")
+    elif args.clean_stale:
+        clean_stale_files(stale, dry_run=args.dry_run)
     else:
-        print(f"  No deprecated files found.")
+        print(f"  {yellow('Found stale files from older harness versions:')}")
+        for rel in stale:
+            print(f"    ~/.claude/{rel}")
+        print()
+        print(f"  These files were shipped by older harness versions and are no")
+        print(f"  longer current. They may conflict with current rules. To remove")
+        print(f"  them, re-run with {bold('--clean-stale')} (a backup is taken first).")
     print()
 
     # --- Agent Teams env var ---


### PR DESCRIPTION
## Summary

The installer used to silently auto-delete a small list of deprecated files (`engineering-standards.md`, `non-harness-workflow.md`) and missed the v2.x module-lock era entirely (`orchestrator.md`, `scheduling.md`, `coding-agent.md`, the `context-graph` skill, `harness/`, `templates/`, the old `project-harness-*` slash commands). Anyone who upgraded from v2.x kept those dead files in `~/.claude/` and could end up with two competing harness models loaded at once — exactly the conflict that surfaced in a real session and prompted this work.

## Behavior change

- Stale files are now **detected and reported by default**, listing each path under `~/.claude/`
- Pass `--clean-stale` to actually remove them; the regular backup pass picks them up first (so they end up in `~/.claude/backup-<timestamp>/`)
- Replaces the prior silent auto-delete pass

This is a deliberate trade: silent cleanup hid both the problem and the fix from users. The new default surfaces the decision.

## Scope

Global files only (`~/.claude/`). Per-project residue (`.context/modules.yaml`, old `.harness/` schemas, project-local `.claude/rules/scheduling.md`) is intentionally left alone — projects contain user data and the upgrade flow needs more thought before it touches them. Likely a follow-up.

## Other changes

- Repo `CLAUDE.md` version-sync list now enumerates **every** file holding the version string, including both `SKILL.md` files (which had been missed in v3.5.x)
- Skills bumped to `v3.6.0` to keep frontmatter and titles in sync

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('install').read())"` parses clean
- [x] `./install --help` shows `--clean-stale`
- [x] `./install --dry-run --name "X"` runs end-to-end and reports correct version + "None found" on a clean `~/.claude/`
- [ ] Run `./install --dry-run` against a `~/.claude/` containing one of the stale files (e.g., create an empty `~/.claude/rules/orchestrator.md` for the test) and confirm:
  - default behavior lists the file under "Found stale files..." and prints the `--clean-stale` hint
  - `--clean-stale` lists "Would remove: rules/orchestrator.md" and includes it in the backup-paths preview
- [ ] Run `./install --clean-stale` (no `--dry-run`) against a stale file and confirm it ends up in the backup dir