### PR TITLE
v3.7.0 — optional OpenSpec integration for spec traceability

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,12 +1,20 @@
-# Installation Guide: Harness v3.6.0
+# Installation Guide: Harness v3.7.0
 
 ## Prerequisites
 
 - Claude Code CLI installed and working
 - Git initialized in your project
-- `jq` installed (used by hook scripts): `brew install jq` on macOS
+- `jq` installed (used by hook scripts and the OpenSpec shim): `brew install jq` on macOS
 - `python3` installed (used by hook scripts and the installer)
 - Agent Teams enabled: `export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` (the installer handles this)
+
+### Optional: OpenSpec (for spec traceability)
+
+v3.7.0 introduces optional OpenSpec integration. If you want spec traceability across sessions, install OpenSpec separately and run `openspec init` per project. The harness will not install or manage OpenSpec for you — `harness-init` only asks whether to enable the integration and creates the `.harness/openspec.sh` shim that bridges to OpenSpec.
+
+OpenSpec installs its own artifacts into `.claude/skills/openspec-*/SKILL.md` and `.claude/commands/opsx/` during its own `openspec init`. These sit alongside the harness's `harness-init` and `harness-continue` skills with distinct names — no collision.
+
+If you skip OpenSpec, harness behavior is unchanged from v3.6.0.
 
 ## Quick Install
 
@@ -107,6 +115,17 @@ claude
 ```
 
 This orients to current state, verifies git identity, and picks single-session or Agent Teams mode.
+
+## What Changed in v3.7.0
+
+- Optional OpenSpec integration for spec traceability (opt-in at `harness-init`)
+- New `spec_path` and `spec_required` fields in `features.json` feature schema
+- New `openspec` block in `harness.json` (only when enabled)
+- New `.harness/openspec.sh` shim — single integration boundary with OpenSpec; ships with `sync-config` verb in v3.7.0
+- New Phase 0 in `harness-continue`: verifies OpenSpec CLI presence and refreshes mirrored config when enabled
+- Spawn prompt template in `agent-teams-protocol.md` includes spec_path and read-before-write instruction when OpenSpec is enabled
+- New `## Spec Discipline` section in `~/.claude/CLAUDE.md` documenting the protocol
+- Backwards compatible: v3.6.0 projects without opt-in keep working unchanged
 
 ## What Changed in v3.2.2
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A harness system for Claude Code that solves multi-session continuity, parallel agent coordination, and automated quality enforcement. Built on Anthropic's research for long-running tasks, evolved through three major versions into a system built on Claude Code's native Agent Teams primitives.
 
-**Current version: v3.6.0** — Stale-file detection in the installer. Surfaces residue from older harness versions (including the v2.x module-lock era's `orchestrator.md` / `scheduling.md` / `coding-agent.md` / `context-graph` skill) that previously sat silently in `~/.claude/` after upgrades. Default behavior is detect-and-warn; pass `--clean-stale` to remove. Replaces the older silent auto-delete pass, which had an incomplete manifest. Builds on v3.5.0's session discipline improvements: smoke test gate, features.json audit, mandatory retrospectives, inline context updates.
+**Current version: v3.7.0** — Optional OpenSpec integration for spec traceability across sessions. Adds `spec_path` and `spec_required` fields to features.json, a `.harness/openspec.sh` shim as the OpenSpec integration boundary, and a "Read the spec first" protocol in spawn prompts. Existing harness projects keep working unchanged unless they opt in. v3.5.0's session discipline improvements and v3.6.0's installer stale-file detection remain intact.
 
 ---
 
@@ -20,7 +20,7 @@ Two failure patterns emerge consistently:
 
 Both failures stem from the same root cause: no persistent memory of intent, progress, or remaining work.
 
-v2.1 addressed a third failure: parallel agents stepping on each other. v3.0 replaced the custom coordination layer entirely with Claude Code's native Agent Teams. And v3.2 added mechanical enforcement (shell hooks that physically prevent completion without passing tests), v3.3 added metacognitive self-improvement (the harness learns from its own coordination patterns), v3.4 fixed four hooks that were silently broken on real systems, and v3.5 tightened session discipline based on real-world violation analysis.
+v2.1 addressed a third failure: parallel agents stepping on each other. v3.0 replaced the custom coordination layer entirely with Claude Code's native Agent Teams. v3.2 added mechanical enforcement (shell hooks that physically prevent completion without passing tests), v3.3 added metacognitive self-improvement (the harness learns from its own coordination patterns), v3.4 fixed four hooks that were silently broken on real systems, v3.5 tightened session discipline based on real-world violation analysis, v3.6 added installer stale-file detection so version upgrades don't silently leave broken artifacts behind, and v3.7 closes a fourth failure: agents inventing intent from one-line feature descriptions instead of reaching for the authoritative spec. v3.7 introduces optional OpenSpec linkage so features point at specs that live in git as living documentation.
 
 ## Two solutions, one insight
 
@@ -51,7 +51,7 @@ Three reasons:
 * **Transparency**: When an agent goes off the rails, you can open `task_plan.md` and see exactly what it thinks it's doing. You can't really debug a vector database when an agent starts hallucinating. Files are inspectable, editable, and version-controlled.
 * **Structure**: Anthropic specifically chose JSON for their features file because, [as they noted](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents), "the model is less likely to inappropriately change or overwrite JSON files compared to Markdown files." Structured formats create implicit contracts. The agent knows that `passes: false` means work remains. It knows not to delete entries. The file format itself enforces discipline.
 
-## The evolution: v2.0 to v3.4
+## The evolution: v2.0 to v3.7
 
 ### v2.0: The foundation (January 2025)
 
@@ -267,14 +267,14 @@ In non-harness projects, only CLAUDE.md loads (~4.2K). The agent-teams-protocol 
 
 Everything you need is in this repo:
 
-1. Download [harness-v3.6.0.zip](https://github.com/oeftimie/vv-claude-harness/releases)
+1. Download [harness-v3.7.0.zip](https://github.com/oeftimie/vv-claude-harness/releases)
 2. Follow the [INSTALL.md](./INSTALL.md) instructions
 3. Review the [CLAUDE.md](./claude/CLAUDE.md) for core engineering standards
 
 ### Quick install
 
 ```bash
-unzip vv-claude-harness-v3.6.0.zip
+unzip vv-claude-harness-v3.7.0.zip
 cd vv-claude-harness
 ./install
 ```
@@ -316,6 +316,43 @@ https://github.com/user-attachments/assets/9684d120-3cbf-438d-a01f-469387f507ff
 ---
 
 ## Changelog
+
+### v3.7.0 (2026-05-02)
+
+**Optional OpenSpec integration for spec traceability**, addressing a long-standing failure mode: agents that read a one-line `features.json` description and fill the gap with plausible-sounding LLM intuition, building something subtly off-intent. By the time tests pass, the deviation is baked in. v3.7.0 makes features point at authoritative specs that live in git as living documentation.
+
+**Schema additions:**
+
+1. **`spec_path`** (per feature) — pointer to the spec materials. During implementation: points at OpenSpec's change folder. After PR-merge archive (v3.8.0+): points at the archived capability spec. The path structure follows OpenSpec's conventions; the harness does not define it.
+
+2. **`spec_required`** (per feature, default `true` when OpenSpec enabled) — whether implementation may proceed without a spec. False reserved for trivial work; setting it false must be deliberate.
+
+3. **`openspec` block in `harness.json`** — `enabled`, `cli_required`, plus `specs_dir`, `changes_dir`, and `config_synced_at` populated by the shim's `sync-config` verb. The harness never hand-edits OpenSpec's path conventions.
+
+**Integration boundary:**
+
+4. **`.harness/openspec.sh` shim** — single integration point for all OpenSpec invocations. v3.7.0 ships with the `sync-config` verb (queries OpenSpec for configured paths, writes them into `harness.json`). Future verbs (`archive`, `validate`, `verify`) ship in v3.8.0 and v3.9.0. When OpenSpec changes, only the shim updates — harness logic, prompts, and hooks are unaffected.
+
+**Protocol additions:**
+
+5. **OpenSpec opt-in at init** — `harness-init` Step 1.5 prompts the user. Opting in records the choice in `harness.json` and creates the shim. Opting out (default) leaves v3.6.0 behavior unchanged.
+
+6. **Phase 0 in `harness-continue`** — when `openspec.enabled: true`, verifies the OpenSpec CLI is available (if `cli_required`) and refreshes the mirrored config via `sync-config`. Cheap (one CLI call per session). Keeps `harness.json` in sync with OpenSpec's actual configuration automatically.
+
+7. **Read-before-write protocol in spawn prompts** — when a feature has `spec_path` set, the spawn prompt instructs the teammate to Read the spec materials before writing any code. Prose-enforced in v3.7.0; mechanically enforced in v3.9.0 via PreToolUse hook.
+
+8. **`## Spec Discipline` section in CLAUDE.md** — documents the state machine for `spec_path`, the read-before-write rule, the no-inline-drafting principle (separate agents for spec drafting and implementation, with a human approval gate between), the sync-on-PR-merge timing, and the "delegate to OpenSpec, never duplicate" principle.
+
+**What's NOT in v3.7.0** (deferred to later releases):
+- Spec-drafting protocol with separate drafter agent and human approval gate (v3.8.0)
+- Drift detection and Spec Lineage retrospective (v3.8.0)
+- Git post-merge hook for automatic archive (v3.8.0)
+- Migration script for existing pre-v3.7 (v3.6.0 and earlier) projects (v3.8.0)
+- PreToolUse hook enforcing spec-read-before-write (v3.9.0)
+- Bypass mechanism (`--bypass-spec-check`) and bypass-rate metric (v3.9.0)
+- `validate` and `verify` shim verbs (v3.9.0)
+
+**Backwards compatibility:** v3.6.0 projects keep working unchanged. The new schema fields are nullable; absent `harness.json` openspec block disables all spec logic. v3.7.0 → v3.9.0 are pure additions for non-OpenSpec projects.
 
 ### v3.6.0 (2026-04-26)
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -79,6 +79,10 @@ If you catch yourself writing "new", "old", "legacy", "wrapper", "unified", or i
 
 Claude Code operates in two modes depending on whether the harness is active. The mode is determined by the presence of a `.harness/` directory in the project root.
 
+### Session Resume (applies to both modes)
+
+At the start of every session, before reading `context_summary.md` or starting fresh work: scan recent conversation messages for an in-flight investigation that was paused or interrupted. If one exists, pick it up where it left off rather than restarting from context files. Conversation context is more current than the persisted summary.
+
 ### Harness-Managed Projects
 
 When `.harness/` exists, the harness skills (`/harness-init`, `/harness-continue`) and the Agent Teams protocol rule (`agent-teams-protocol.md`) govern the workflow. Don't duplicate their instructions here; follow them.

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,10 +1,10 @@
 ---
 scope: global
 location: ~/.claude/CLAUDE.md
-version: 3.6.0
-last_updated: 2026-04-26
+version: 3.7.0
+last_updated: 2026-05-02
 author: {{USER_NAME}}
-description: Core engineering standards for all Claude Code sessions. Works with Long-Running Agent Harness v3.6.0.
+description: Core engineering standards for all Claude Code sessions. Works with Long-Running Agent Harness v3.7.0.
 supplements: Project-level CLAUDE.md files in individual repositories
 ---
 
@@ -144,6 +144,53 @@ Claude Code has a persistent auto-memory system at `~/.claude/projects/<project>
 **`context_summary.md`** is per-project, explicit, and version-controlled. Use it for architectural decisions, team-relevant patterns, and gotchas that must be shared across sessions and team members.
 
 These are complementary. Do not migrate `context_summary.md` content to auto-memory — they serve different audiences.
+
+---
+
+## Spec Discipline
+
+Applies only when `harness.json` contains an `openspec` block with `enabled: true`. Otherwise this section is inert.
+
+OpenSpec is the *intent layer*; the harness is the *execution layer*. The two link via two fields in each feature: `spec_path` (pointer) and `spec_required` (boolean). The harness orchestrates *when* to invoke OpenSpec; OpenSpec owns *what* proposals, specs, deltas, and validation look like.
+
+### State machine for `spec_path`
+
+Every feature with `spec_required: true` is in one of three states:
+
+- **Drafted, in flight**: `spec_path` points inside OpenSpec's `changes_dir` (e.g., `openspec/changes/<change-name>/`). Implementation may proceed.
+- **Archived**: `spec_path` points inside OpenSpec's `specs_dir` (e.g., `openspec/specs/<capability>.md`). Feature is complete and the spec is the long-term traceability anchor.
+- **Blocked**: `spec_path` is `null`. Implementation MUST NOT start. The feature needs a spec drafted via OpenSpec (`/opsx:propose <name>`). v3.7.0 surfaces this gap to the user; v3.8.0 automates the drafting protocol.
+
+The path itself encodes the state — the harness does not maintain a separate `spec_archived` flag.
+
+### Read before write
+
+Before writing any code on a claimed feature: Read the spec materials at `spec_path`. The folder structure follows OpenSpec's conventions — read whatever files OpenSpec placed there. Do not proceed on intuition. If the spec is unclear, ask before coding.
+
+This rule is prose-enforced in v3.7.0 (spawn prompt instructs the agent) and mechanically enforced in v3.9.0 (PreToolUse hook blocks Edit/Write to scope files unless the spec was Read in the current session).
+
+### When the spec doesn't exist yet
+
+If `spec_required: true` and `spec_path: null`:
+- Do NOT let the implementing agent draft the spec inline. Same agent + same context = LLM-invents-intent failure mode.
+- Run a separate spec-drafting pass: invoke OpenSpec's proposal flow (`/opsx:propose <change-name>`), let OpenSpec produce its proposal artifacts, present to the user for approval.
+- Only after approval, set `spec_path` in features.json and unblock the implementer.
+
+In v3.7.0, this protocol is documented but not automated — surface the gap to the user and offer to invoke `/opsx:propose` manually before claiming the feature.
+
+### When implementation passes
+
+`spec_path` remains unchanged (still inside OpenSpec's changes directory). The window between tests-green and PR-merged is the review window — reviewers may demand spec updates alongside code updates. Do not archive on feature pass.
+
+### When the PR merges
+
+Invoke OpenSpec's archive flow (e.g., `/opsx:sync` then `/opsx:archive`, or whatever OpenSpec's current canonical sequence is — defer to OpenSpec's docs and the `.harness/openspec.sh` shim). Update `spec_path` in features.json to the path OpenSpec returned. This is the long-term traceability anchor.
+
+In v3.7.0, this is a manual step performed by the user after merge; v3.8.0 automates it via a git post-merge hook.
+
+### Delegate to OpenSpec, never duplicate
+
+The harness orchestrates *when* to invoke OpenSpec; OpenSpec owns *what* the artifacts look like. If OpenSpec already has a verb for it (`/opsx:propose`, `/opsx:verify`, `/opsx:archive`), invoke the verb — never reimplement. All OpenSpec invocations from harness code go through `.harness/openspec.sh`. When OpenSpec ships a breaking change, only that file changes.
 
 ---
 

--- a/claude/rules/agent-teams-protocol.md
+++ b/claude/rules/agent-teams-protocol.md
@@ -109,7 +109,7 @@ The lead:
 3. Presents the plan to the user for approval before spawning any teammates
 4. Creates the team via `TeamCreate`
 5. Creates tasks via `TaskCreate`, then sets dependencies via `TaskUpdate` with `addBlockedBy` (derived from features.json `depends_on`)
-6. Spawns teammates via `Task` with team_name, model, and role-specific prompts
+6. Spawns teammates via `Task` with team_name, model, and role-specific prompts. If `harness.json` has `openspec.enabled: true`, the spawn prompt MUST include the feature's `spec_path` and an explicit instruction to read it before writing code (see Spawn Prompt Template below). Refuse to spawn an implementer for a feature with `spec_required: true` and `spec_path: null` — surface the gap to the user instead.
 7. Monitors progress via `TaskList` and incoming `SendMessage` messages
 8. Resolves conflicts if two teammates need overlapping files
 9. Reviews completed work (exit plan mode if needed for code review)
@@ -134,7 +134,7 @@ Each teammate is a focused implementer. It:
 4. Claims its task via `TaskUpdate({ taskId: "[ID]", status: "in_progress", owner: "[teammate-name]" })`
 5. Works ONLY within its assigned scope (files, directories)
 6. Follows TDD: write failing test, implement, verify, refactor
-7. For any API code: grounds the implementation against the canonical spec. If the spec cannot be located, sends a `SendMessage` to the lead requesting access before writing code
+7. **If the spawn prompt includes a `spec_path`** (OpenSpec enabled): Read the spec materials at that path BEFORE writing any code. The folder structure follows OpenSpec's conventions — read whatever files OpenSpec placed there. Do not proceed on intuition. If the spec is missing, ambiguous, or contradicts the feature description, SendMessage to the lead and stop.
 8. Sends messages via `SendMessage` to the lead or other teammates as needed
 9. Marks task complete via `TaskUpdate(status: "completed")`
 10. Writes its deliverable to a file (not just conversation output)
@@ -143,6 +143,32 @@ Each teammate is a focused implementer. It:
 When the `TaskCompleted` hook runs, it will verify tests pass. If the hook rejects (exit code 2), the teammate receives feedback and must fix the issues before re-completing.
 
 When the `TeammateIdle` hook runs after task completion, the teammate may be prompted to pick up a new task.
+
+## Spawn Prompt Template (OpenSpec-aware)
+
+When the lead spawns a teammate on a project with `openspec.enabled: true`, the spawn prompt must include the feature's `spec_path` line and the read-first instruction. Use this template:
+
+```
+Feature: [F00X] — [description]
+Scope: [scope directories from features.json]
+Spec: [spec_path from features.json]  (OpenSpec change folder or archived capability)
+
+BEFORE writing any code:
+1. Read the spec materials at the path above. The folder structure follows
+   OpenSpec's conventions for that change — read whatever files OpenSpec
+   placed there. If the path is in OpenSpec's changes directory, you can
+   also invoke OpenSpec's own commands (e.g., `/opsx:apply <change-name>`)
+   to follow OpenSpec's implementation flow.
+2. If the spec is missing, ambiguous, or contradicts the feature description,
+   SendMessage to the lead and stop.
+3. Do not proceed on intuition. The spec is the source of truth for intent.
+
+[Then: standard TDD instructions, scope constraints, deliverable, git identity, etc.]
+```
+
+The template names the path and the responsibility. It does NOT enumerate which files exist inside the change folder — that's OpenSpec's content model, and the harness must not duplicate it. If OpenSpec adds or renames artifacts, the prompt stays correct.
+
+When `openspec.enabled` is false (or the openspec block is absent), omit the Spec line and the BEFORE-writing block. Standard prompt only.
 
 ## Native Messaging Protocol
 

--- a/claude/rules/agent-teams-protocol.md
+++ b/claude/rules/agent-teams-protocol.md
@@ -134,10 +134,11 @@ Each teammate is a focused implementer. It:
 4. Claims its task via `TaskUpdate({ taskId: "[ID]", status: "in_progress", owner: "[teammate-name]" })`
 5. Works ONLY within its assigned scope (files, directories)
 6. Follows TDD: write failing test, implement, verify, refactor
-7. Sends messages via `SendMessage` to the lead or other teammates as needed
-8. Marks task complete via `TaskUpdate(status: "completed")`
-9. Writes its deliverable to a file (not just conversation output)
-10. Does not modify files outside its assigned scope without messaging the lead first
+7. For any API code: grounds the implementation against the canonical spec. If the spec cannot be located, sends a `SendMessage` to the lead requesting access before writing code
+8. Sends messages via `SendMessage` to the lead or other teammates as needed
+9. Marks task complete via `TaskUpdate(status: "completed")`
+10. Writes its deliverable to a file (not just conversation output)
+11. Does not modify files outside its assigned scope without messaging the lead first
 
 When the `TaskCompleted` hook runs, it will verify tests pass. If the hook rejects (exit code 2), the teammate receives feedback and must fix the issues before re-completing.
 

--- a/claude/skills/harness-continue/SKILL.md
+++ b/claude/skills/harness-continue/SKILL.md
@@ -1,9 +1,33 @@
 ---
 name: harness-continue
-description: Continue working on a harness-managed project (v3.6.0). Orients to current state, picks single-session or Agent Teams mode, and guides implementation with TDD, quality gate hooks, and compaction-aware context management. Use at the start of any session on a harness project.
+description: Continue working on a harness-managed project (v3.7.0). Orients to current state, picks single-session or Agent Teams mode, and guides implementation with TDD, quality gate hooks, optional OpenSpec spec traceability, and compaction-aware context management. Use at the start of any session on a harness project.
 ---
 
-# Harness Continue v3.6.0
+# Harness Continue v3.7.0
+
+## Step 0: OpenSpec Availability Check (skip if openspec.enabled is false)
+
+Read `.harness/harness.json`'s `openspec` block. Three branches:
+
+1. **No `openspec` block, or `enabled: false`**: skip this step entirely. Proceed to Step 1. All spec-related logic in subsequent steps no-ops.
+
+2. **`enabled: true`, `cli_required: true`**: verify the OpenSpec CLI is on PATH:
+   ```bash
+   command -v openspec || echo "MISSING"
+   ```
+   If missing, fail loudly: stop the session and tell the user OpenSpec is required for this project but not installed. Do not silently degrade.
+
+3. **`enabled: true`, `cli_required: false`**: file-only workflow; CLI may be absent. Skip the `command -v` check.
+
+Then refresh the mirrored config from OpenSpec:
+
+```bash
+.harness/openspec.sh sync-config
+```
+
+This rewrites `harness.json`'s `specs_dir`, `changes_dir`, and `config_synced_at`. Cheap (one CLI call). Keeps the harness in sync with OpenSpec's actual configured paths so subsequent steps don't operate on stale values.
+
+If `sync-config` fails (e.g., the shim itself is broken), fix that first — it's a structural issue, not transient.
 
 ## Step 1: Orient Yourself
 
@@ -32,10 +56,14 @@ Project state:
 - Last session: [date, what was done]
 - Features: [N passing / M total]
 - Next up: [highest priority incomplete feature]
+  - spec_path: [path or "null — needs drafting" if openspec enabled and spec_required]
 - Blockers: [any noted in progress or context_summary]
 - Git identity: [from harness.json]
+- OpenSpec: [enabled (last synced: TIMESTAMP) | disabled]
 - Untracked files: [any unexpected files surfaced to user]
 ```
+
+If `openspec.enabled` is true, surface `spec_path` per pending/in-progress feature. A pending feature with `spec_required: true` and `spec_path: null` is BLOCKED — it cannot be claimed by an implementer until a spec is drafted. v3.7.0 documents this state but does not yet automate spec drafting (that ships in v3.8.0); for now, surface the gap to the user and ask whether to draft the spec before proceeding.
 
 ## Step 2: Verify Git Identity
 

--- a/claude/skills/harness-init/SKILL.md
+++ b/claude/skills/harness-init/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: harness-init
-description: Initialize a new project with the Long-Running Agent Harness v3.6.0. Sets up feature tracking, git identity capture, context summary, build hooks, quality gate hooks, and optional Agent Teams structure. Use when starting a new multi-session project.
+description: Initialize a new project with the Long-Running Agent Harness v3.7.0. Sets up feature tracking, git identity capture, context summary, build hooks, quality gate hooks, optional OpenSpec spec traceability, and optional Agent Teams structure. Use when starting a new multi-session project.
 ---
 
-# Harness Initializer v3.6.0
+# Harness Initializer v3.7.0
 
 Follow these steps in order. Do not skip steps. Ask the user when indicated.
 
@@ -15,6 +15,40 @@ Ask the user (if not already provided):
 - Any existing code to preserve?
 
 If the user provided this information in their initial message, proceed without asking.
+
+## Step 1.5: Offer OpenSpec Spec Traceability
+
+Ask the user whether to enable OpenSpec integration for this project:
+
+```
+Optional: enable OpenSpec spec traceability for this project?
+
+OpenSpec is a lightweight spec-driven framework that pairs with the harness.
+When enabled:
+- Each feature points at an authoritative spec via the spec_path field.
+- Agents read the spec before writing code (instead of inventing intent
+  from a one-line description).
+- Specs are checked into git as living documentation.
+- The harness invokes OpenSpec via the .harness/openspec.sh shim — when
+  OpenSpec changes, only the shim updates.
+
+Recommended for: projects spanning >2 weeks, multi-developer projects, projects
+where intent fidelity matters (security, compliance, public APIs).
+Skip for: throwaway prototypes, single-session work, formatting-only repos.
+
+If you enable it, you'll also need OpenSpec installed (`npm i -g @openspec/cli`
+or per OpenSpec's current install instructions) and run `openspec init` in the
+project. The harness will not run those for you.
+
+Enable OpenSpec? (yes/no — default: no)
+```
+
+Record the answer. The rest of this skill branches on this choice:
+- If `yes`: include the `openspec` block in `harness.json` (Step 3), create the
+  `.harness/openspec.sh` shim (Step 3.1), default new features to
+  `spec_required: true`.
+- If `no`: omit the `openspec` block, skip Step 3.1 entirely, default new
+  features to `spec_required: false` (which makes the field a no-op).
 
 ## Step 2: Capture Git Identity
 
@@ -48,7 +82,7 @@ Create `.harness/` with these files:
   "project": "PROJECT_NAME",
   "stack": "DETECTED_OR_SPECIFIED_STACK",
   "created": "ISO_DATE",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "git_identity": {
     "user_name": "DETECTED_NAME",
     "user_email": "DETECTED_EMAIL",
@@ -58,6 +92,27 @@ Create `.harness/` with these files:
   "team_structure": null
 }
 ```
+
+If the user said yes to OpenSpec in Step 1.5, also include an `openspec` block:
+
+```json
+{
+  "openspec": {
+    "enabled": true,
+    "cli_required": true,
+    "specs_dir": "openspec/specs",
+    "changes_dir": "openspec/changes",
+    "config_synced_at": null
+  }
+}
+```
+
+**Field ownership:**
+- `enabled` and `cli_required` are user-chosen settings (recorded once at init).
+- `specs_dir`, `changes_dir`, and `config_synced_at` are **not hand-edited**. They are populated and refreshed by `.harness/openspec.sh sync-config` (created in Step 3.1). The values shown above are placeholder defaults; the shim overwrites them with OpenSpec's actual configured paths on first sync.
+- `cli_required: true` means `harness-continue` Phase 0 fails loudly if `openspec` is not on PATH. Set to `false` for file-only workflows.
+
+If the user said no, omit the `openspec` block entirely. All spec-related logic in `harness-continue` no-ops when this block is missing or `enabled: false`.
 
 **`.harness/features.json`**:
 
@@ -89,7 +144,9 @@ Each feature has this shape:
   "scope_expansions": [],
   "approaches_tried": [],
   "failure_reason": null,
-  "discovered_via": null
+  "discovered_via": null,
+  "spec_path": null,
+  "spec_required": true
 }
 ```
 
@@ -102,10 +159,15 @@ Each feature has this shape:
 - `failure_reason`: why the feature reached `status: "failed"`. Essential for understanding root cause without re-reading conversation history.
 - `discovered_via`: ID of the feature whose implementation revealed the need for this feature (discovery lineage). Different from `depends_on`, which is a technical dependency.
 
+**OpenSpec linkage fields** (only meaningful when `harness.json` has `openspec.enabled: true`):
+- `spec_path`: path to the spec materials for this feature. During drafting/implementation it points at the change folder under OpenSpec's `changes_dir`. After PR-merge archive (v3.8.0+), it points at the archived capability spec under OpenSpec's `specs_dir`. The path structure follows OpenSpec's conventions — the harness does not define it. `null` until a spec is drafted.
+- `spec_required`: whether implementation may proceed without a spec. Default `true` when OpenSpec is enabled. Set to `false` per-feature for trivial work (dep bumps, formatting, tiny refactors). Setting to `false` must be a deliberate edit.
+
 Feature is not done until:
 - `status` is `"passing"`
 - `test_file` points to a test
 - `coverage` >= 95% on touched code
+- If OpenSpec is enabled and `spec_required` is `true`: `spec_path` is set
 
 **`.harness/context_summary.md`**:
 
@@ -163,6 +225,117 @@ The script accepts one optional argument: `smoke_test` or `full_test` (default: 
 - `full_test` — complete test suite with coverage. Used by the lead at session end and synthesis phase.
 
 When configuring for the project's stack, ensure both targets work correctly.
+
+## Step 3.1: Create OpenSpec Shim (only if openspec.enabled)
+
+Skip this step if the user said no to OpenSpec in Step 1.5.
+
+`.harness/openspec.sh` is the single integration boundary between the harness and OpenSpec. All OpenSpec invocations from harness code go through it. When OpenSpec ships a breaking change, only this file changes — harness logic, prompts, and hooks are unaffected.
+
+Create `.harness/openspec.sh` with the following content, then `chmod +x` it:
+
+```bash
+#!/usr/bin/env bash
+# .harness/openspec.sh — integration boundary between the harness and OpenSpec.
+# All OpenSpec invocations from harness code go through this script.
+# When OpenSpec ships a breaking change, only this file changes.
+#
+# Verbs (v3.7.0):
+#   sync-config    Query OpenSpec for its configured paths; write them
+#                  into harness.json's openspec block. Idempotent.
+#
+# Future verbs (added in v3.8.0+):
+#   archive <name>   Delegate to OpenSpec's archive flow.
+#   validate <name>  Delegate to OpenSpec's validator.
+#   verify <name>    Delegate to OpenSpec's /opsx:verify equivalent.
+
+set -euo pipefail
+
+HARNESS_JSON=".harness/harness.json"
+
+require_jq() {
+  command -v jq >/dev/null 2>&1 || {
+    echo "openspec.sh: jq is required but not installed" >&2
+    exit 1
+  }
+}
+
+require_openspec_cli() {
+  if command -v openspec >/dev/null 2>&1; then
+    return 0
+  fi
+  local cli_required
+  cli_required=$(jq -r '.openspec.cli_required // true' "$HARNESS_JSON" 2>/dev/null || echo "true")
+  if [ "$cli_required" = "true" ]; then
+    echo "openspec.sh: 'openspec' CLI not on PATH (cli_required: true)" >&2
+    echo "Install OpenSpec or set openspec.cli_required to false in harness.json." >&2
+    exit 1
+  fi
+}
+
+cmd_sync_config() {
+  require_jq
+  require_openspec_cli
+
+  # Resolve specs_dir and changes_dir.
+  # OpenSpec's current default layout uses openspec/specs and openspec/changes.
+  # If OpenSpec exposes a config-show command in a future release, replace
+  # this block with a parse of that output. For now we detect by directory
+  # existence and fall back to defaults.
+  local specs_dir="openspec/specs"
+  local changes_dir="openspec/changes"
+
+  [ -d "openspec/specs" ] && specs_dir="openspec/specs"
+  [ -d "openspec/changes" ] && changes_dir="openspec/changes"
+
+  local now
+  now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  local tmp="${HARNESS_JSON}.tmp"
+  jq --arg specs "$specs_dir" \
+     --arg changes "$changes_dir" \
+     --arg now "$now" \
+     '.openspec.specs_dir = $specs |
+      .openspec.changes_dir = $changes |
+      .openspec.config_synced_at = $now' \
+     "$HARNESS_JSON" > "$tmp"
+  mv "$tmp" "$HARNESS_JSON"
+
+  echo "openspec.sh: synced — specs_dir=$specs_dir, changes_dir=$changes_dir"
+}
+
+case "${1:-}" in
+  sync-config)
+    cmd_sync_config
+    ;;
+  validate|verify|archive)
+    echo "openspec.sh: verb '$1' not yet implemented (added in v3.8.0+)" >&2
+    exit 64
+    ;;
+  *)
+    echo "Usage: .harness/openspec.sh <verb> [args]" >&2
+    echo "Verbs (v3.7.0): sync-config" >&2
+    echo "Future verbs: validate, verify, archive (v3.8.0+)" >&2
+    exit 64
+    ;;
+esac
+```
+
+After creating the file:
+
+```bash
+chmod +x .harness/openspec.sh
+```
+
+Then run `sync-config` once to populate the placeholder values in `harness.json`:
+
+```bash
+.harness/openspec.sh sync-config
+```
+
+Verify the result: `jq '.openspec' .harness/harness.json` should show real `specs_dir` and `changes_dir` values plus a `config_synced_at` timestamp.
+
+If the user has not yet run `openspec init` in this project (the openspec/ directory doesn't exist), the shim will fall back to default paths. That's fine — the values get refreshed automatically on the next `harness-continue` Phase 0 once OpenSpec is initialized.
 
 ## Step 3.5: Configure Build Hooks
 
@@ -389,18 +562,31 @@ If the project already has a CLAUDE.md, append the harness reference. If not, cr
 
 ## Harness
 
-This project uses the Long-Running Agent Harness v3.4.
+This project uses the Long-Running Agent Harness v3.7.0.
 
 - Feature tracking: `.harness/features.json`
 - Context and decisions: `.harness/context_summary.md` (READ THIS at session start)
 - Progress handoff: `.harness/claude-progress.txt`
 - Build/test: `.harness/init.sh`
 - Quality gates: `.claude/hooks/` (TaskCompleted, TeammateIdle, PostCompact)
+- OpenSpec shim: `.harness/openspec.sh` (only if openspec.enabled in harness.json)
 
 ## Git Identity
 
 This project uses: [user_name] <[user_email]> with SSH key [ssh_key].
 Always verify identity before push/pull/clone operations.
+```
+
+If OpenSpec was enabled in Step 1.5, also append a `## Spec Discipline` section pointing at the global rule:
+
+```markdown
+## Spec Discipline
+
+This project uses OpenSpec for spec traceability. Every feature with
+`spec_required: true` must have a `spec_path` set before implementation
+begins. Read the spec materials at `spec_path` before writing any code on
+that feature. See the global `## Spec Discipline` section in
+`~/.claude/CLAUDE.md` for the full protocol.
 ```
 
 ## Step 5: Propose Initial Features
@@ -468,15 +654,16 @@ The team_structure is a starting suggestion. The lead may restructure during /ha
 
 ```bash
 git add .harness/ .claude/ CLAUDE.md
-git commit -m "chore: initialize harness v3.6.0 scaffolding"
+git commit -m "chore: initialize harness v3.7.0 scaffolding"
 ```
 
 Report:
 
 ```
-Harness v3.6.0 initialized:
+Harness v3.7.0 initialized:
 - .harness/ created with [N] features (scope and dependencies defined)
 - Git identity captured: [user] <[email]>
+- OpenSpec: [enabled (shim created, sync-config run) | disabled]
 - Build hook: [installed | skipped] for [STACK]
 - Quality gates: TaskCompleted + TeammateIdle hooks installed and verified
 - CLAUDE.md updated

--- a/claude/skills/harness-init/check-remaining-tasks.sh.template
+++ b/claude/skills/harness-init/check-remaining-tasks.sh.template
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Harness v3.4.0 - TeammateIdle hook
+# Harness v3.7.0 - TeammateIdle hook
 # Runs when a teammate is about to go idle.
 # Exit code 0 = allow idle (no more work)
 # Exit code 2 = send feedback, keep teammate working

--- a/claude/skills/harness-init/enforce-scope.sh.template
+++ b/claude/skills/harness-init/enforce-scope.sh.template
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Harness v3.4.0 - PreToolUse scope enforcement hook
+# Harness v3.7.0 - PreToolUse scope enforcement hook
 # Runs before Edit/Write tool calls when a teammate scope file exists.
 # Exit code 0 = allow edit
 # Exit code 2 = block edit (file outside scope)

--- a/claude/skills/harness-init/verify-git-identity.sh.template
+++ b/claude/skills/harness-init/verify-git-identity.sh.template
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Harness v3.4.0 - PreToolUse git identity verification hook
+# Harness v3.7.0 - PreToolUse git identity verification hook
 # Runs before Bash tool calls that contain git push/pull/clone.
 # Exit code 0 = allow
 # Exit code 2 = block (identity mismatch)

--- a/docs/IMPROVEMENT-PLAN-v3.7-v3.9.md
+++ b/docs/IMPROVEMENT-PLAN-v3.7-v3.9.md
@@ -1,0 +1,597 @@
+# VV Claude Code Harness — Improvement Plan v3.7.0 → v3.9.0
+
+**Theme:** Spec traceability via OpenSpec linkage, plus adjacent session-discipline tightening.
+**Baseline:** v3.6.0 (released April 2026, current main). Session discipline improvements from violation analysis (v3.5.0) plus installer stale-file detection (v3.6.0).
+**Drafted:** 2026-05-02. Owner: Ovidiu.
+
+---
+
+## 1. Goal
+
+Add durable, mechanically-enforceable spec traceability to the harness without merging it with OpenSpec. After v3.9.0, an agent starting work on a feature reaches for an authoritative spec instead of inventing intent from a one-line `description`, and months later you can answer "what spec does this code satisfy?" with three deterministic queries against files in git.
+
+## 2. Problem statement
+
+The harness's `features.json[i].description` is by nature lossy — a single sentence cannot carry the constraints, scenarios, and acceptance criteria that define a feature. When a session starts and an agent reads only the description, it fills the gap with plausible-sounding intuition. By the time tests pass, the deviation is baked in. Neither v3.5.0's session-discipline work nor v3.6.0's installer hardening addresses this; both tighten execution discipline, not intent fidelity.
+
+OpenSpec already solves the intent-state problem (proposals, deltas, capabilities, archive lineage) but has no model of execution state, coverage, or coordination metrics. Each tool earns its keep on a different dimension. The gap is the linkage: the harness has no awareness of where a feature's spec lives, and OpenSpec has no awareness of which features implement which changes.
+
+## 3. Design principles
+
+These constrain every decision in this plan. Push back on any change that violates one.
+
+1. **Link, don't merge.** features.json owns execution state; OpenSpec owns intent state. The integration is two pointer fields and a read-before-write protocol — nothing more.
+2. **Default-on `spec_required`.** Once "spec is optional" becomes the norm, the failure mode leaks back in for the features that needed a spec most. Opt-out must be a deliberate edit per feature.
+3. **Spec drafting and implementation in separate sessions.** Letting the same agent draft and implement is exactly how LLM-invents-intent comes back through the back door. Different prompts, different agents, human approval gate between them.
+4. **Sync on PR merge, not on feature pass.** The interval between tests-green and merged is the review window. Archiving on pass promotes the spec before review.
+5. **Path encodes state.** `spec_path` pointing inside `openspec/changes/` means "in flight." Pointing inside `openspec/specs/` means "archived." No redundant `spec_archived` field — three sources of truth drift faster than two.
+6. **Mechanical only after prose has been validated.** Add hooks (PreToolUse, archive validation) only once the prompt-layer convention has been observed working. v3.7.0 ships with prose; v3.9.0 promotes to mechanism.
+7. **Optional, not mandatory.** OpenSpec integration is opt-in at `harness-init`. Existing v3.6.0 projects keep working unchanged. Throwaway projects skip it.
+8. **Delegate domain logic to OpenSpec.** The harness orchestrates *when* to invoke OpenSpec; OpenSpec owns *what* proposals, specs, deltas, and validation look like. Wrap all OpenSpec invocations in a `.harness/openspec.sh` shim so version differences absorb in one place. Never duplicate OpenSpec's content conventions (file names, section structure, validation rules) in harness prompts or code. If OpenSpec already has a verb for it (`/opsx:propose`, `/opsx:verify`, `/opsx:archive`), invoke the verb — don't reimplement.
+
+## 4. Schema additions
+
+### 4.1 `features.json` — new fields per feature
+
+```json
+{
+  "id": "F003",
+  "description": "Add session token rotation",
+  "...": "(existing fields unchanged)",
+  "spec_path": "openspec/changes/add-session-rotation/",
+  "spec_required": true
+}
+```
+
+- `spec_path` (string | null): Path to the change folder during implementation; updated to the archived capability spec (path returned by OpenSpec; follows OpenSpec's `specs_dir` convention) after PR merge. Null until a spec is drafted.
+- `spec_required` (boolean, default `true`): Whether implementation may proceed without a spec. False reserved for trivial work (dep bumps, formatting, tiny refactors). Setting to false must be an explicit edit, not a default.
+
+Both fields are nullable for backwards compatibility — existing v3.6.0 features without these fields are treated as `spec_required: false, spec_path: null`. This prevents v3.7.0 from breaking projects that don't opt in.
+
+### 4.2 `harness.json` — new top-level block
+
+```json
+{
+  "...": "(existing fields)",
+  "openspec": {
+    "enabled": true,
+    "cli_required": true,
+    "specs_dir": "openspec/specs",
+    "changes_dir": "openspec/changes",
+    "config_synced_at": "2026-05-02T14:30:00Z"
+  }
+}
+```
+
+Absent block = OpenSpec disabled for this project. All spec-related logic in `harness-continue` no-ops when this block is missing or `enabled: false`.
+
+**Field ownership:**
+- `enabled` and `cli_required` are harness-owned settings (the user's choices about how the harness should behave).
+- `specs_dir` and `changes_dir` are *not* hand-edited. They are populated and refreshed by the OpenSpec shim's `sync-config` verb (see §6 v3.7.0 — The OpenSpec shim). The shim queries OpenSpec for its current configured paths and writes them into harness.json. This avoids hardcoding OpenSpec's directory layout in the harness.
+- `config_synced_at` is an ISO-8601 timestamp written by the shim on each sync, used by drift detection to flag stale config.
+
+`cli_required: true` means `harness-continue` Phase 0 fails loudly if `openspec` is not on PATH. Setting to `false` allows file-only workflows (you read/write specs as plain Markdown without the CLI). Default: `true` when opted in.
+
+`harness-continue` Phase 0 runs `.harness/openspec.sh sync-config` every session when `enabled: true`, so the mirrored paths refresh automatically. Cost: one CLI call per session. Benefit: harness.json is never out of date with OpenSpec's actual configuration.
+
+## 5. Lifecycle (definitive reference)
+
+```
+Feature created in features.json
+  spec_required: true
+  spec_path: null
+  status: "pending"
+                ↓
+Spec-drafting pass (separate agent, narrow prompt: "invoke OpenSpec's
+  proposal flow")
+  → drafter invokes /opsx:propose <change-name>
+  → OpenSpec produces its proposal artifacts under its changes directory
+    (the harness does not define what files are produced)
+  → drafter SendMessages the lead with the change-name and folder path
+  → lead presents to user
+  → human approves
+                ↓
+features.json updated:
+  spec_path: "openspec/changes/F003-session-rotation/"
+  (status unchanged; now claimable by an implementer)
+                ↓
+Implementer spawned with spec_path in prompt
+  → Reads spec FIRST (mechanical in v3.9.0; prose in v3.7.0)
+  → writes failing test
+  → implements
+  → tests pass
+                ↓
+features.json updated:
+  status: "passing"
+  spec_path: unchanged (still inside changes/)
+                ↓
+PR opened, reviewed, possibly delta updated alongside code changes
+                ↓
+PR merged → invoke OpenSpec's archive flow (/opsx:sync then /opsx:archive,
+  or whatever OpenSpec's current canonical sequence is)
+  → OpenSpec promotes the delta into the source-of-truth spec
+                ↓
+features.json updated:
+  spec_path: updated to point at the archived capability spec returned by OpenSpec
+  (now points permanently at archived capability — exact path is OpenSpec's
+   convention, not the harness's)
+```
+
+Five transitions. Each one explicit. Each one git-blame-able. No invented intent.
+
+## 6. Phased rollout
+
+Three releases, each independently shippable. Earlier phases must not regress when later phases ship.
+
+---
+
+### v3.7.0 — Linkage Layer
+
+**Goal:** features.json knows about specs; agents see the spec_path in their spawn prompt and have prose instructions to read it before writing code. No mechanical enforcement.
+
+**Ship criterion:** A fresh `harness-init` on a new project, opting into OpenSpec, produces correct structure. A subsequent session claims a feature with `spec_path` set, the spawn prompt includes the path, and the agent reads the spec file before its first Edit/Write tool call. Verified by inspecting agent transcripts on at least one real project.
+
+#### Files to change
+
+| File | Change |
+|---|---|
+| `claude/skills/harness-init/SKILL.md` | Add Step 1.5 (OpenSpec opt-in prompt). Update Step 3 (`.harness/harness.json` and `features.json` schemas with new fields). Add Step 3.1 (create `.harness/openspec.sh` shim from inlined template; run `sync-config` to populate paths). Update Step 7 if it documents schema. |
+| `claude/skills/harness-continue/SKILL.md` | Add Step 0 (read `harness.json` openspec block; verify CLI presence if `cli_required: true`; run `.harness/openspec.sh sync-config` to refresh mirrored paths). Update Step 1 to surface `spec_path` per feature when summarizing state. |
+| `claude/rules/agent-teams-protocol.md` | Update spawn prompt template (Lead Agent Responsibilities section) to include "Spec: `<spec_path>`" line and "Before writing any code, Read the spec at `<spec_path>`. Do not proceed on intuition." instruction. Update Teammate Responsibilities to make the read step explicit. |
+| `claude/CLAUDE.md` | Add `## Spec Discipline` section between `## Operating Modes` and `## Testing Standards`. Document the linkage convention, default-on `spec_required`, the read-first protocol. |
+| `README.md` | Add v3.7.0 changelog section. Update version badge. Add brief "OpenSpec integration" subsection to evolution narrative. |
+| `INSTALL.md` | Add OpenSpec prerequisite note (optional dependency). Note that `openspec init` installs its own artifacts into `.claude/skills/openspec-*/SKILL.md` and `.claude/commands/opsx/` — these sit alongside the harness's `harness-init` and `harness-continue` skills with distinct names, so no collision is expected. Document install order: install harness first, then `openspec init` per-project when opting in. |
+| `install` script | No change unless adding new files (none in v3.7.0). |
+
+#### Concrete prompt additions
+
+**Spawn prompt template addition (in `agent-teams-protocol.md`):**
+
+```
+Feature: F003 — Add session token rotation
+Scope: src/auth/, tests/auth/
+Spec: openspec/changes/add-session-rotation/  (OpenSpec change folder)
+
+BEFORE writing any code:
+1. Read the spec materials at the path above. The folder structure follows
+   OpenSpec's conventions for that change — read whatever files OpenSpec
+   placed there. If you need a canonical view, you can also invoke OpenSpec's
+   own commands (e.g., `/opsx:apply <change-name>` to follow OpenSpec's
+   implementation flow).
+2. If the spec is missing, ambiguous, or contradicts this feature description,
+   SendMessage to the lead and stop.
+3. Do not proceed on intuition. The spec is the source of truth for intent.
+```
+
+The prompt names the path and the responsibility (read before write). It does NOT enumerate which files exist inside the change folder — that's OpenSpec's content model, and the harness must not duplicate it. If OpenSpec adds or renames artifacts, the prompt stays correct.
+
+**`harness-init` opt-in prompt (Step 1.5):**
+
+```
+Optional: enable OpenSpec spec traceability for this project?
+
+OpenSpec is a lightweight spec-driven framework that pairs well with the harness.
+When enabled:
+- Each feature points at a spec via the spec_path field.
+- Agents read the spec before writing code.
+- Specs are checked into git as living documentation.
+
+Recommended for: projects spanning >2 weeks, multi-developer projects, projects
+where intent fidelity matters (security, compliance, public APIs).
+Skip for: throwaway prototypes, single-session work, formatting-only repos.
+
+Enable OpenSpec? (yes/no)
+```
+
+**`CLAUDE.md` template — new `## Spec Discipline` section:**
+
+```markdown
+## Spec Discipline
+
+If `harness.json` has `openspec.enabled: true`, every feature has either:
+- `spec_path` pointing inside OpenSpec's changes directory (in-flight), or
+- `spec_path` pointing inside OpenSpec's specs directory (archived), or
+- `spec_required: false` (explicit opt-out for trivial work).
+
+The exact directory paths come from OpenSpec's configuration; the harness does not
+define them. The two states are distinguished by which configured directory the path
+lives under.
+
+A feature with `spec_required: true` and `spec_path: null` is BLOCKED. Implementation
+cannot start. The harness-continue protocol triggers a spec-drafting pass first.
+
+**Before writing any code on a claimed feature**: Read the spec materials at `spec_path`.
+The folder structure follows OpenSpec's conventions — read whatever files OpenSpec placed
+there. Do not proceed on intuition. If the spec is unclear, ask before coding.
+
+**On feature pass**: spec_path remains unchanged (still in OpenSpec's changes directory).
+The review window between tests-green and PR-merged is when reviewers may demand spec
+updates.
+
+**On PR merge**: invoke OpenSpec's archive flow (e.g., `/opsx:sync` then `/opsx:archive`,
+or whatever OpenSpec's current canonical sequence is — defer to OpenSpec's docs and the
+`.harness/openspec.sh` shim). Then update the feature's spec_path to the path OpenSpec
+returned. This is the long-term traceability anchor.
+```
+
+#### The OpenSpec shim
+
+`.harness/openspec.sh` is the single integration boundary between the harness and OpenSpec. All OpenSpec invocations from harness code go through it. When OpenSpec changes (CLI verbs, config layout, slash command names), only this file changes.
+
+The shim is created by `harness-init` from a template inlined in `claude/skills/harness-init/SKILL.md`, written to `.harness/openspec.sh` in the user's project, and made executable. It is committed to the project repo (it's part of the harness's per-project state, not user-edited config).
+
+**Verbs the shim must expose:**
+
+| Verb | Purpose | Used by |
+|---|---|---|
+| `sync-config` | Query OpenSpec for its current configured paths; write `specs_dir`, `changes_dir`, and `config_synced_at` into `harness.json`'s openspec block. Idempotent. | `harness-init` Step 3.1; `harness-continue` Phase 0 |
+| `validate <change-name>` | Delegate to OpenSpec's validator (current: `openspec validate <name>` or equivalent). Exit 0 on success, non-zero with stderr message on failure. | `verify-task-quality.sh` (v3.9.0) |
+| `verify <change-name>` | Delegate to OpenSpec's implementation-vs-artifacts check (current: `/opsx:verify` or CLI equivalent). Exit 0 on success, non-zero with message on failure. If OpenSpec doesn't expose this verb, exit 0 with a stderr note (degrades to no-op). | `pre-archive-check.sh` (v3.9.0) |
+| `archive <change-name>` | Delegate to OpenSpec's archive flow (current: `/opsx:sync` then `/opsx:archive`, or whatever OpenSpec's canonical sequence is). Print the resulting archived spec path on stdout for the caller to capture. | post-merge archive automation (v3.8.0+) |
+
+**Implementation notes:**
+
+- The shim is a single bash script. All OpenSpec-version-specific logic lives in it.
+- When OpenSpec ships a breaking change, only the shim updates. Harness logic, prompts, and hooks are unaffected.
+- The shim should `set -euo pipefail` and emit useful diagnostics on failure.
+- The `sync-config` verb is the most version-sensitive (it depends on how OpenSpec exposes its config). For v3.7.0, implement it by parsing the output of whichever current OpenSpec command reveals config (e.g., `openspec config show` or reading a config file directly). Document the assumption in the shim itself so future maintainers know what to update.
+
+#### Validation for v3.7.0
+
+1. Run modified `harness-init` on a fresh project, opt into OpenSpec, confirm `harness.json` and `features.json` have correct structure. Confirm `.harness/openspec.sh` was created and is executable. Confirm `sync-config` ran and `specs_dir` / `changes_dir` are populated with OpenSpec's actual configured paths (not hardcoded defaults).
+2. Run `.harness/openspec.sh sync-config` manually a second time — confirm idempotent (no errors, `config_synced_at` updates).
+3. Add a feature manually with `spec_path` pointing at a real change folder.
+4. Run `harness-continue`, confirm Phase 0 invokes `sync-config` and refreshes the timestamp. Claim the feature, confirm spawn prompt includes spec path and read instruction.
+5. In agent transcript, confirm `Read` tool was called on a file inside `spec_path` before any `Edit`/`Write` on scope files. (Which file OpenSpec produced is OpenSpec's business; the harness only checks that *something* under the spec_path was read.)
+6. Run on a v3.6.0 project (no OpenSpec opt-in) — confirm zero behavior change. Phase 0 detects no openspec block and skips shim invocation.
+7. Manually change OpenSpec's configured paths (rename `openspec/` to `specs/` via OpenSpec config). Run `harness-continue` again — confirm Phase 0 picks up the new paths via `sync-config`, drift detection reflects the new layout.
+
+---
+
+### v3.8.0 — Spec-Drafting & Sync
+
+**Goal:** Handle the "no spec yet" case explicitly. Sync archive to the right moment. Detect drift between features.json and the openspec/ tree.
+
+**Ship criterion:** A project with a feature `spec_required: true, spec_path: null` runs `harness-continue` and the protocol blocks implementation, runs a separate spec-drafting pass with a human approval gate, then unblocks. PR-merge archive updates spec_path correctly. Drift report appears at session start.
+
+#### New protocol elements
+
+**Spec-drafting pass.** A new role, distinct from implementer. The drafter's job is to *invoke OpenSpec's own proposal flow* — not to write proposal artifacts directly. Prompt template:
+
+```
+You are a spec drafter for feature [F003]: [description].
+
+Invoke OpenSpec's proposal flow:
+  /opsx:propose [change-name]
+
+Where [change-name] is a kebab-case identifier you choose for this feature
+(e.g., add-session-rotation). Follow OpenSpec's prompts. OpenSpec owns the
+content, format, and structure of the proposal — your job is to drive its
+flow, answer its questions accurately, and let it produce its artifacts.
+
+When OpenSpec signals completion (the change folder exists at the path
+OpenSpec reports), validate it:
+  openspec validate [change-name]
+  (or invoke /opsx:verify if your project has it)
+
+Then SendMessage to the lead with:
+  - The change-name
+  - The folder path OpenSpec produced
+  - A one-paragraph summary of intent (in your own words, for the human
+    approval gate — not a replacement for the spec OpenSpec just wrote)
+
+DO NOT:
+- Write or modify proposal/spec/design files manually. OpenSpec writes them.
+- Bypass OpenSpec's flow with manual file creation in openspec/changes/.
+- Define proposal format yourself — that's OpenSpec's job.
+- Touch any files outside openspec/.
+- Write code or tests (this is the drafting phase, not implementation).
+```
+
+The lead receives the SendMessage, presents the draft to Ovidiu (who reads what OpenSpec produced, not a harness-formatted summary), approves or requests revision. Only after approval does features.json get updated with `spec_path`.
+
+If OpenSpec's slash command names change in a future release, only the prompt template above needs updating — none of the harness's logic depends on `proposal.md` existing or having any particular structure.
+
+**Drift detection at session start.** New step in `harness-continue` Phase 1:
+
+```bash
+# Pseudo-logic. CHANGES_DIR and SPECS_DIR are read from harness.json's
+# openspec block (which mirrors OpenSpec's configured paths) — never
+# hardcoded.
+
+for feature in features.json:
+  if feature.spec_path is set:
+    if not file_exists(feature.spec_path):
+      flag "feature F003 spec_path points at missing file"
+
+for change_dir in $CHANGES_DIR/*:
+  if no feature in features.json has spec_path matching change_dir:
+    flag "orphan change: no feature implements [change_dir]"
+
+for spec_file in $SPECS_DIR/*:
+  if no feature in features.json has spec_path matching spec_file:
+    # not necessarily a problem — old archived specs may have no live feature
+    note "no live feature points at [spec_file] (informational)"
+```
+
+Flags surface in the session-start summary. Drift = surfaced for resolution, not blocking.
+
+**Archive flow on PR merge.** Primary mechanism: git post-merge hook in `.harness/`. Manual step is documented as a fallback only.
+
+**Primary: `.harness/post-merge.sh`** (installed by harness-init when openspec is enabled). On `main` branch merge:
+1. Parse the merged commits for `[F00X]` references via `git log` since last sync.
+2. For each referenced feature: read its `spec_path` from features.json. If it points inside OpenSpec's changes directory, invoke `.harness/openspec.sh archive <change-name>`.
+3. Capture the archived path the shim returns on stdout.
+4. Update features.json: rewrite `spec_path` to the archived path.
+5. Commit the features.json update with message `docs: archive specs for [F003, F004, ...]` (separate commit from the merge itself).
+
+If the hook fails for any feature (shim returns non-zero, OpenSpec rejects the archive), the hook surfaces the failure but does not abort the merge. Failed archives go into a queue file `.harness/.pending-archives.json` for the next `harness-continue` session to retry.
+
+**Fallback (manual step in session-end checklist):** for cases where the post-merge hook didn't run (merge performed on remote without local hook execution, force-push scenarios, etc.). The checklist instructs the user to invoke OpenSpec's archive flow manually for each merged feature and update spec_path by hand.
+
+The harness never decides what "archive" means — it just calls OpenSpec via the shim and records where OpenSpec moved the spec. If OpenSpec changes its archive flow (e.g., merges sync and archive into one command, splits into three), only the shim updates.
+
+This is a behavioral change from the prior plan draft: archive automation lands in v3.8.0, not deferred to v3.9.0. The shim's `archive` verb is therefore a v3.8.0 ship requirement.
+
+**Retrospective additions.** `Phase 5.5` (retrospective) gets a new "Spec Lineage" section:
+
+```markdown
+### Spec Lineage (this session)
+- Capabilities touched: [list]
+- Changes archived: [list]
+- Drift detected: [count, surfaced where]
+- Spec drafts approved on first pass: [N/M]
+- Spec drafts rejected and revised: [N/M]
+```
+
+Patterns ("spec drafts in scope X always need 2+ revisions") feed Meta-Patterns for future model selection.
+
+#### Files to change
+
+| File | Change |
+|---|---|
+| `claude/skills/harness-continue/SKILL.md` | New Phase 1 substep: spec-state check (block if drafting needed). New Phase 1 substep: drift detection. New Phase 1 substep: replay `.harness/.pending-archives.json` if non-empty. New role section: spec-drafter. New Phase 5.5 substep: Spec Lineage retrospective. |
+| `claude/rules/agent-teams-protocol.md` | New "Spec Drafter" role section (default model: Opus). New "Plan Approval" subcase: spec drafts always require approval. |
+| `claude/CLAUDE.md` | Expand `## Spec Discipline` with drafting protocol, archive timing, and the post-merge hook behavior. |
+| `claude/skills/harness-init/SKILL.md` | Extend Step 3.1 (shim creation) to add the `archive` verb to the inlined shim template. Add Step 3.6 (install `.harness/post-merge.sh` hook) when openspec is enabled. |
+| `claude/scripts/post-merge.sh` (template) | NEW — installed at `.harness/post-merge.sh` per project. Parses commits, invokes shim's archive verb, updates features.json, queues failures. |
+| `claude/skills/harness-init/templates/migrate-to-openspec.sh` | NEW — optional migration script for existing v3.6.0 projects. Walks features.json, prompts the user to invoke `/opsx:propose` for each `passing` feature, records resulting `spec_path`. |
+| `README.md` | v3.8.0 changelog. |
+
+#### Validation for v3.8.0
+
+1. Project with `spec_required: true, spec_path: null` for some feature: confirm implementation is blocked, drafter spawns (on Opus), approval gate works, post-approval implementation proceeds normally.
+2. Manually break a `spec_path` (rename the change folder): confirm drift detection flags it.
+3. Add a change folder not referenced by any feature: confirm orphan flag.
+4. Complete a feature, merge a PR locally on `main`: confirm `.harness/post-merge.sh` fires, invokes `.harness/openspec.sh archive`, captures the returned path, updates `spec_path` in features.json, commits the update with `docs:` prefix.
+5. Force a shim archive failure (e.g., manually corrupt the change folder before merge): confirm post-merge.sh appends to `.harness/.pending-archives.json` and does not abort the merge. Run `harness-continue` next session: confirm Phase 1 replays the queue and surfaces the failure.
+6. Run `harness-migrate-to-openspec.sh` on a copy of an existing v3.6.0 project with passing features: confirm it loops over features, prompts for each, records spec_path correctly when the user invokes `/opsx:propose`.
+7. Retrospective output includes Spec Lineage section.
+
+---
+
+### v3.9.0 — Mechanical Enforcement
+
+**Goal:** Promote spec discipline from prose to physical mechanism. An agent that tries to skip the spec read is blocked at the tool layer.
+
+**Ship criterion:** PreToolUse hook blocks Edit/Write to scope files unless `spec_path` was Read in the current session, OR the user has activated `--bypass-spec-check` for the current session/window. TaskCompleted hook delegates validation to OpenSpec via the shim. Pre-archive gate delegates implementation-vs-artifacts checking to OpenSpec's `/opsx:verify` (or its CLI equivalent) — the harness does not roll its own heuristic.
+
+#### New hooks
+
+**1. `enforce-spec-read.sh` (PreToolUse on Edit/Write):**
+
+```
+Inputs: tool name, file path, current session's tool call history.
+Logic:
+  - Read .harness/harness.json: if openspec.enabled false, exit 0.
+  - Check for active bypass: if .harness/.bypass-spec-check exists and is
+    not expired (TTL or remaining-call-count not exhausted), decrement the
+    counter, log the bypass to .harness/bypass-usage.log, exit 0.
+  - Read .harness/teammate-feature.txt: get current feature_id (set by lead
+    at spawn).
+  - Read features.json: get feature.spec_path and feature.spec_required.
+  - If spec_required false, exit 0.
+  - If spec_path null, exit 2 with feedback: "Feature requires a spec.
+    spec_path is null. Cannot proceed."
+  - If file path matches feature.scope:
+    - Check session's prior Read tool calls. If spec_path is a folder, any
+      Read inside that folder counts (the harness does not assert which file
+      OpenSpec produced). If spec_path is a file (post-archive), only a Read
+      of that file counts.
+    - If no qualifying Read found, exit 2 with feedback: "Read the spec at
+      [path] before editing scope files. To bypass for emergencies, run:
+      .harness/bypass-spec-check --enable [--calls=N | --duration=Tm]"
+  - Otherwise exit 0.
+```
+
+**Override mechanism (`--bypass-spec-check`):** A small CLI utility installed at `.harness/bypass-spec-check` accepts:
+
+- `--enable [--calls=N] [--duration=Tm]` — write `.harness/.bypass-spec-check` marker file with TTL (default: 5 calls or 10 minutes, whichever expires first). Mutually-exclusive constraint to prevent permanent disablement.
+- `--disable` — remove the marker.
+- `--status` — show current state.
+
+The hook reads the marker, decrements the call counter, and self-clears when exhausted. Each bypass is logged to `.harness/bypass-usage.log` (one line: timestamp, feature_id, file_path, reason if provided). The retrospective reads this log and emits a "bypass rate" metric: bypasses per total scope-file edits. If >5%, the calibration is off (per §9 risk row).
+
+The flag is not an environment variable because env vars persist across sessions and are easy to forget; the marker-file approach is auditable and self-clearing.
+
+This is the load-bearing mechanism. Without it, prose discipline drifts within 2 sessions on tired Fridays.
+
+**2. Spec validation extension to existing `verify-task-quality.sh`:**
+
+After tests pass, if feature has `spec_path` inside the OpenSpec changes directory, delegate to OpenSpec's own validator:
+```bash
+# Pseudo — actual call goes through .harness/openspec.sh shim
+.harness/openspec.sh validate "$change_name" || {
+  echo "OpenSpec validation failed. Fix before marking complete." >&2
+  exit 2
+}
+```
+
+The harness does not define what "valid" means. OpenSpec does. The shim wraps whichever CLI verb OpenSpec exposes for validation (`openspec validate`, `openspec verify`, or future equivalents).
+
+**3. `pre-archive-check.sh` (called by archive automation):**
+
+Before invoking OpenSpec's archive flow, run OpenSpec's own implementation-vs-artifacts check via the shim:
+```bash
+# Pseudo
+.harness/openspec.sh verify "$change_name"
+```
+
+OpenSpec's `/opsx:verify` (or its CLI equivalent) is documented as "Validate implementation matches artifacts" — exactly the check we need. The harness must not roll its own heuristic for this. If the shim call returns failure, surface the message as a warning (not a blocker — humans may legitimately need to override). If OpenSpec doesn't expose a verify verb in some future release, the shim degrades to a no-op and the check is skipped.
+
+#### Files to change
+
+| File | Change |
+|---|---|
+| `claude/hooks/enforce-spec-read.sh` | NEW — PreToolUse hook on Edit/Write. |
+| `claude/hooks/verify-task-quality.sh` | Extend with spec validation step (delegate to shim). |
+| `claude/hooks/pre-archive-check.sh` | NEW — invoked by archive automation. Delegates to shim's `verify` verb. |
+| `claude/scripts/bypass-spec-check.sh` (template) | NEW — installed at `.harness/bypass-spec-check` per project. Toggles TTL'd marker file, logs usage. |
+| `claude/skills/harness-init/SKILL.md` | Install new hooks and bypass utility during init when openspec_enabled. Extend shim template with `validate` and `verify` verbs. Update post-merge.sh template to invoke `pre-archive-check.sh` before calling the shim's archive verb. Add hook verification step. |
+| `claude/skills/harness-continue/SKILL.md` | Reference new hook behavior in Phase 0 verification. Phase 5.5 retrospective reads bypass-usage.log and emits bypass-rate metric. |
+| `claude/rules/agent-teams-protocol.md` | Document `teammate-feature.txt` (the per-spawn marker file). |
+| `README.md` | v3.9.0 changelog. |
+
+#### Per-spawn marker file
+
+The `enforce-spec-read.sh` hook needs to know which feature the current agent is working on. The lead writes `.harness/teammate-feature.txt` (or similar) when spawning each teammate, mirroring the existing `.claude/teammate-scope.txt` pattern documented in `agent-teams-protocol.md`. Single-line file, just the feature ID.
+
+#### Validation for v3.9.0
+
+1. Spawn an agent on a feature with valid spec_path. Try to Edit a scope file before reading the spec — confirm hook blocks.
+2. Read the spec, then Edit — confirm hook allows.
+3. Mark a task complete with an invalid delta (manually corrupt) — confirm validate-spec-on-complete rejects.
+4. Run pre-archive-check on a clean change — passes. Run on a divergent change — surfaces warning.
+5. Run on a non-OpenSpec project — all hooks no-op cleanly.
+
+---
+
+## 7. Backwards compatibility & migration
+
+**v3.6.0 projects without OpenSpec opt-in:** zero changes. The new fields are nullable; absent `harness.json` openspec block disables all spec logic. v3.7.0 → v3.9.0 are pure additions for non-OpenSpec projects.
+
+**Existing harness projects opting in mid-stream:** add the openspec block to `harness.json`, run `openspec init`, set `spec_required: true` for new features, leave existing features at `spec_required: false` (they were built without specs and trying to retrofit specs to passing code creates fiction). The retrospective `Spec Lineage` section will show "0/N features had specs at session start" for the first session, gradually filling in as new features are added.
+
+**Migration script (ships in v3.8.0):** `harness-migrate-to-openspec.sh` walks features.json and, for each `passing` feature, prompts the user to invoke OpenSpec's proposal flow (`/opsx:propose <name>`) to write a retroactive spec, then records the resulting `spec_path`. The script orchestrates the loop; OpenSpec writes the specs. Treated as documentation work, not code work. Optional from the user's perspective (they can opt in feature-by-feature or skip), but the tooling itself is shipped — not gated on "if demand exists."
+
+## 8. Testing strategy
+
+This repo has no application tests because it's a distribution repo. Validation must happen in real harness projects.
+
+**Test matrix per phase:**
+
+| Test | v3.7.0 | v3.8.0 | v3.9.0 |
+|---|---|---|---|
+| Fresh init, OpenSpec enabled, schema correct | ✓ | ✓ | ✓ |
+| Fresh init, OpenSpec disabled, behaves as v3.5.0 | ✓ | ✓ | ✓ |
+| Existing v3.6.0 project unchanged after upgrade | ✓ | ✓ | ✓ |
+| Spawn prompt includes spec_path | ✓ | ✓ | ✓ |
+| Agent reads spec before edit (transcript verified) | ✓ | ✓ | ✓ |
+| Spec-drafting blocks implementation when needed | — | ✓ | ✓ |
+| Drift detection surfaces broken pointers | — | ✓ | ✓ |
+| Post-merge archive updates spec_path | — | ✓ | ✓ |
+| Hook blocks edit without spec read | — | — | ✓ |
+| Hook validates spec on task complete | — | — | ✓ |
+| Pre-archive check surfaces divergence | — | — | ✓ |
+
+**Validation projects:** propose two real projects to dogfood each phase before tagging release. v3.7.0 on a small project to validate prose layer; v3.8.0 on a multi-week project to validate drafting and drift; v3.9.0 on a security-sensitive project where mechanical enforcement earns its complexity.
+
+## 9. Risks & mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| OpenSpec API churn (CLI breaking changes) | Medium | High | Wrap all `openspec` calls in `.harness/openspec.sh` shim. One file changes when CLI shifts. |
+| OpenSpec abandoned upstream | Low | High | Specs are plain Markdown in git; archive lineage survives. `cli_required: false` mode lets workflow continue without the CLI. |
+| Spec drafting becomes tedious paperwork, team skips it | Medium | High | Resist mandatory templates. proposal.md can be 3 lines if intent is simple. Default-on `spec_required` is the floor, not the ceiling. Retrospective tracks "spec drafts approved first pass" as a fluency metric. |
+| `enforce-spec-read.sh` hook false-positives on legitimate edits | Medium | Medium | Hook only fires on files matching feature.scope. Override via `.harness/bypass-spec-check --enable` (TTL'd marker file with call-count or duration limit; self-clearing; not an env var, to avoid persistent disablement). Each bypass logged to `.harness/bypass-usage.log`. Retrospective tracks bypass rate; if >5%, the hook is mis-calibrated. |
+| 1:1 feature:change assumption breaks for big changes | Medium | Low | Convention not constraint. Multiple features can share `spec_path` (same change folder). Retrospective flags features with shared spec_path as candidates for splitting. |
+| Pre-merge spec drift (code changes during review without delta updates) | High | Medium | Pre-archive check is a heuristic warning, not a blocker. Reviewers are the real check. Document the responsibility in CLAUDE.md. |
+| OpenSpec installation friction blocks adoption | Medium | Low | Opt-in, not default. INSTALL.md notes it's optional. Projects without OpenSpec keep working. |
+| Spec-drafter agent invents intent the same way | Medium | High | Drafter prompt explicitly forbids implementation thinking and forbids manual file creation (must go through OpenSpec's `/opsx:propose`). Human approval gate is mandatory. Drafter has no Edit/Write access outside the change folder OpenSpec produced. Default model: Opus (drafting is reasoning-heavy on intent capture; cost is worth it). Implementer remains on Sonnet by default. |
+
+## 10. Adjacent improvements (parking lot, not committed)
+
+Surfaced from reading v3.5.0 and the README evolution narrative. Not part of v3.6–3.8 but worth tracking:
+
+1. **Smoke test caching.** v3.5.0 makes smoke test mandatory at session start. If init.sh is slow on some projects, cache last-run hash and skip if no relevant files changed. Optimization, not correctness.
+2. **Compaction-aware retrospective.** Currently the retrospective runs at session end. If session compacts mid-flight, retrospective signals get lost. Consider a "mini retrospective" snapshot at compaction points.
+3. **Dynamic model selection enrichment.** v3.3 introduced operational metrics for model selection. Could fold spec_required and spec drafting outcomes into the same signal (a feature whose spec required 3 revisions probably needs Opus for implementation too).
+4. **Agent Teams permissions hardening.** Teammates inherit lead permission mode. Worth documenting which permissions to deny by default for spec drafters (no Edit access outside changes/<id>/).
+5. **MCP server for harness state.** Surfacing features.json, context_summary.md, and spec state through an MCP server would let agents query state with structured tools instead of cat-ing files. Worth prototyping after v3.9.0 ships.
+6. **Cost telemetry.** No real measurement of "how much does Agent Teams cost vs single session" exists. Adding a token/cost summary to the retrospective would let dynamic model selection optimize for cost too.
+
+These are scoped out of this plan deliberately — each could be its own minor release.
+
+## 11. Open questions (all resolved as of 2026-05-02)
+
+All decisions made. Plan is executable.
+
+1. **Default `spec_required` for features added mid-project (not at init)?** RESOLVED. Default-on confirmed. Setting to false requires a deliberate edit per feature. This is consistent with §3 Principle 2.
+2. **Spec-drafter model:** RESOLVED. Default = Opus. Drafting is reasoning-heavy on intent capture and the cost is worth it. Per-project override possible by setting model in the spawn call, but Opus is the recommended default. This affects model selection logic in `harness-continue` Phase 1 when the drafter is spawned.
+3. **Archive trigger:** RESOLVED. Git post-merge hook ships in v3.8.0 (not deferred to v3.9.0). The shim's `archive` verb is required for v3.8.0 ship. Manual fallback documented for cases where the hook can't run (e.g., merges done outside local git).
+4. **Hook override mechanism:** RESOLVED. `--bypass-spec-check` flag. Implementation: a small CLI utility (`.harness/bypass-spec-check`) toggles a TTL'd marker file (`.harness/.bypass-spec-check`) that `enforce-spec-read.sh` checks for and respects. Self-clearing after a small number of tool calls or session end, whichever comes first, to prevent permanent disablement. Override usage tracked for the >5% calibration metric.
+5. **Multi-repo / monorepo / non-default OpenSpec layouts:** RESOLVED. The `.harness/openspec.sh` shim exposes a `sync-config` verb that queries OpenSpec for its configured paths and writes them into `harness.json`'s openspec block. `harness-init` runs it during setup; `harness-continue` runs it in Phase 0 every session to keep the mirror fresh. Harness code reads `specs_dir` / `changes_dir` from harness.json — never hardcoded. Monorepo edge case (per-package OpenSpec configs) handled if OpenSpec itself supports it; the shim relays whatever OpenSpec reports. See §6 v3.7.0 — The OpenSpec shim.
+6. **Spec versioning:** RESOLVED. spec_path points at the *current* archived capability spec (live file in OpenSpec's specs directory). When a capability is later modified by another change, spec_path continues to track the live file — the historical version a feature originally implemented is recoverable via OpenSpec's archive lineage and git history of the spec file, both of which OpenSpec owns. The harness does not version or snapshot spec contents.
+7. **Onboarding existing harness projects:** RESOLVED. The optional migration script ships in v3.8.0 (not v3.7.0). v3.7.0 ships only the linkage layer for new projects and projects opting in fresh. Existing v3.6.0 projects can opt in mid-stream by running the v3.8.0 migration script, which orchestrates retroactive `/opsx:propose` invocations for `passing` features. v3.7.0 is intentionally narrow — get the schema and prompt layer right first, before tackling retroactive migration.
+
+## 12. Success criteria (six months out)
+
+Ship is complete and successful when, six months after v3.9.0 lands:
+
+- At least three real projects use OpenSpec integration through full feature lifecycle (drafting → implementation → archive).
+- "What spec does this code satisfy?" answerable in <30 seconds via three deterministic queries (grep + jq + read).
+- Zero reported cases of LLM-invents-intent on opted-in projects with `spec_required: true`.
+- Hook override rate <5% on opted-in projects (mechanical enforcement is well-calibrated).
+- Retrospective Spec Lineage data shows >70% of spec drafts approved on first pass (drafter prompt is well-calibrated).
+- v3.6.0 projects opted out: zero behavior change reports.
+
+If success criteria are not met after six months, re-open this plan and revise. Specifically: if intent-fidelity failures are still happening on opted-in projects, the read-before-write protocol is insufficient and a more aggressive intervention is needed (e.g., surfacing spec content directly in spawn prompt body, not just as a path).
+
+---
+
+## Appendix A: File-by-file change manifest summary
+
+| File | v3.7.0 | v3.8.0 | v3.9.0 |
+|---|---|---|---|
+| `claude/skills/harness-init/SKILL.md` | Schema + opt-in prompt + inlined `openspec.sh` shim template + Step 3.1 (create shim) | Extend shim template with `archive` verb; install post-merge hook + migration script | Extend shim template with `validate` and `verify` verbs; install enforce-spec-read hook + bypass utility |
+| `claude/skills/harness-continue/SKILL.md` | Phase 0 (shim sync-config) + spec_path surfacing | Drafting blocker + drift detection + pending-archives replay + Spec Lineage retrospective | Hook references; bypass-rate metric in retrospective |
+| `claude/rules/agent-teams-protocol.md` | Spawn prompt addition | Drafter role (Opus default) | `teammate-feature.txt` marker docs |
+| `claude/CLAUDE.md` | New `## Spec Discipline` section | Expand drafting protocol + post-merge hook docs | (no change) |
+| `.harness/openspec.sh` (per-project) | NEW — verbs: sync-config | + verb: archive | + verbs: validate, verify |
+| `.harness/post-merge.sh` (per-project) | — | NEW — git post-merge hook | — |
+| `.harness/bypass-spec-check` (per-project) | — | — | NEW — TTL'd override CLI |
+| `claude/scripts/post-merge.sh` (template) | — | NEW | — |
+| `claude/scripts/bypass-spec-check.sh` (template) | — | — | NEW |
+| `claude/skills/harness-init/templates/migrate-to-openspec.sh` | — | NEW — optional migration for v3.6.0 projects | — |
+| `claude/hooks/enforce-spec-read.sh` | — | — | NEW |
+| `claude/hooks/verify-task-quality.sh` | — | — | Extend (delegate to shim) |
+| `claude/hooks/pre-archive-check.sh` | — | — | NEW (delegates to shim) |
+| `README.md` | Changelog | Changelog | Changelog |
+| `INSTALL.md` | Optional dep note | — | Hook docs |
+| `install` script | — | — | Deploy new hooks |
+
+## Appendix B: Sequencing & dependencies
+
+```
+v3.7.0 — independent. Ships first.
+  ↓
+v3.8.0 — depends on v3.7.0 schema + spawn prompts.
+  ↓
+v3.9.0 — depends on v3.8.0 drift detection + archive flow.
+```
+
+Each phase is independently shippable in the sense that v3.7.0 alone is useful (spec linkage + prose discipline). But sequencing is strict: don't ship v3.8.0 before v3.7.0 has been validated on at least one real project, and don't ship v3.9.0 (mechanical hooks) before v3.8.0's manual archive flow has been observed working.
+
+## Appendix C: `spec_path` value conventions
+
+`spec_path` holds a path string the harness reads from features.json and passes to agents. The path structure follows OpenSpec's own directory layout — the harness does not define it.
+
+Currently observed shapes (per OpenSpec's current conventions):
+
+- During drafting/implementation: typically `"<openspec-changes-dir>/<change-name>/"` — points at the change folder.
+- After archive: typically `"<openspec-specs-dir>/<capability>.md"` — points at the archived capability spec.
+- Trivial work / opted out: `null` with `spec_required: false`.
+
+The exact directory names and structure come from OpenSpec; if OpenSpec changes them, the harness keeps working as long as the shim and `harness.json` openspec block reflect the new layout. Drift detection only checks file existence at the recorded path — it does not validate the path's shape.
+
+Schema enforcement (the only thing the harness asserts): `spec_path` is either `null` or a string pointing at an existing file or folder under the `openspec_dir` declared in `harness.json`. Anything else is a schema violation.


### PR DESCRIPTION
## Summary

Optional OpenSpec integration so features point at authoritative specs that live in git as living documentation, instead of agents inventing intent from one-line `features.json` descriptions. Backwards compatible: harness projects without OpenSpec opt-in keep working unchanged.

This is the **linkage layer** of a phased rollout (v3.7.0 → v3.9.0). v3.7.0 ships schema + shim + prose protocol; v3.8.0 ships drafting + drift detection + post-merge auto-archive; v3.9.0 ships mechanical enforcement (PreToolUse hooks, bypass mechanism, validate/verify shim verbs).

Full plan in [`docs/IMPROVEMENT-PLAN-v3.7-v3.9.md`](https://github.com/oeftimie/vv-claude-harness/blob/release-v3.7.0/docs/IMPROVEMENT-PLAN-v3.7-v3.9.md).

## What's in v3.7.0

**Schema additions (in `harness-init`):**
- `spec_path` (per feature, nullable string) — path to spec materials
- `spec_required` (per feature, boolean, default `true` when OpenSpec enabled) — opt-out for trivial work
- `openspec` block in `harness.json` — `enabled`, `cli_required`, `specs_dir`, `changes_dir`, `config_synced_at`

**Integration boundary:**
- `.harness/openspec.sh` shim is the single point of contact with OpenSpec
- v3.7.0 ships `sync-config` verb; future verbs (`archive`, `validate`, `verify`) ship in v3.8.0+
- When OpenSpec changes, only the shim updates

**Protocol:**
- `harness-init` Step 1.5: OpenSpec opt-in prompt (default no, so existing projects unaffected)
- `harness-init` Step 3.1: create shim, run sync-config to populate paths
- `harness-continue` Phase 0: verify CLI presence, refresh mirrored config every session
- `agent-teams-protocol.md`: spawn prompt template includes `spec_path` and read-before-write instruction when OpenSpec is enabled
- `claude/CLAUDE.md`: new `## Spec Discipline` section documenting state machine, no-inline-drafting rule, sync-on-PR-merge timing, delegate-to-OpenSpec principle

## Notable design choices

1. **Link, don't merge** — features.json owns execution state; OpenSpec owns intent state. Two pointer fields plus a read-before-write protocol; nothing more.
2. **Default-on `spec_required`** when OpenSpec is enabled. Opting out is per-feature and deliberate.
3. **Path encodes state** — no redundant `spec_archived` field. spec_path inside changes_dir = in-flight; inside specs_dir = archived.
4. **Delegate domain logic to OpenSpec** — never duplicate proposal format, validation rules, or path conventions in harness prompts/code. If OpenSpec has a verb (`/opsx:propose`, `/opsx:verify`, `/opsx:archive`), invoke it via the shim.
5. **Mechanical only after prose has been validated** — hooks land in v3.9.0, not v3.7.0. Validate the prompt-layer convention works in real projects first.

## Backwards compatibility

- Existing v3.6.0 projects without OpenSpec opt-in: zero behavior change.
- New schema fields are nullable; absent `harness.json` openspec block disables all spec logic.
- v3.7.0 → v3.9.0 are pure additions for non-OpenSpec projects.

## Test plan

- [ ] Run modified `harness-init` on a fresh project, opt into OpenSpec, confirm `harness.json` openspec block present, `features.json` has `spec_path` + `spec_required` fields, `.harness/openspec.sh` exists and is executable.
- [ ] Run `.harness/openspec.sh sync-config` manually a second time — confirm idempotent.
- [ ] Run `harness-continue` Phase 0 on the same project — confirm sync-config runs and timestamp updates.
- [ ] Run `harness-init` opting OUT of OpenSpec — confirm zero openspec artifacts created, behavior matches v3.6.0.
- [ ] Run `harness-continue` on a v3.6.0 project (no OpenSpec opt-in, no openspec block in harness.json) — confirm Phase 0 detects absence and skips silently, all other steps unchanged.
- [ ] Spawn a teammate via Agent Teams on a feature with valid `spec_path`. Inspect spawn prompt — confirm it includes the path and the read-before-write instruction.
- [ ] Verify shim bash syntax: `bash -n .harness/openspec.sh` exits 0.

## Files touched

- `claude/CLAUDE.md` — new `## Spec Discipline` section, frontmatter version bump
- `claude/skills/harness-init/SKILL.md` — Step 1.5 (opt-in), Step 3 schema additions, Step 3.1 (shim creation with full bash template inlined), version refs
- `claude/skills/harness-continue/SKILL.md` — Step 0 (CLI check + sync-config), state summary surfaces spec_path
- `claude/rules/agent-teams-protocol.md` — Lead/Teammate responsibilities for spec_path, new "Spawn Prompt Template (OpenSpec-aware)" section
- `README.md` — version line, evolution narrative, v3.7.0 changelog, download URLs
- `INSTALL.md` — version, OpenSpec optional dependency note, "What Changed in v3.7.0"
- 3 hook templates — version bumps in comment headers
- `docs/IMPROVEMENT-PLAN-v3.7-v3.9.md` — full design document for the three-release rollout

## Notes

The branch carries one preliminary commit (`02aa66b docs: add API spec grounding rule and session resume discipline`) that landed on the old `release-v3.5.0` branch before this work. Its agent-teams-protocol change is superseded by this PR (the broader spec_path rule subsumes the API-specific rule); its CLAUDE.md Session Resume contribution is preserved.

Recommend squash-merge so the merged commit is a single coherent v3.7.0 atom.