### PR TITLE
refactor: trim templates/CLAUDE.md, extract two harness rule files (v4.0.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vv-harness",
   "displayName": "VV Claude Code Harness",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Multi-session continuity, parallel Agent Teams coordination, and mechanical quality enforcement for Claude Code.",
   "author": {
     "name": "oeftimie",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Version history for the VV Claude Code Harness. The current version lives in `.claude-plugin/plugin.json`.
 
+### v4.1.0 (2026-07-01)
+
+**`templates/CLAUDE.md` trimmed from 461 to 356 lines.** Two reference-heavy blocks that only matter at specific moments — the full `context_summary.md` template and the task completion checklist — moved out of the always-on core into plugin rule files, and verbose always-on sections (systematic debugging, sub-agent failure handling, error recovery) were condensed in place without losing substance.
+
+**Two new plugin rule files** carry the extracted detail, surfaced the same way `code-quality.md` and `agent-teams-protocol.md` already are (no auto-loading — there is no manifest key for it):
+- `rules/context-summary.md` — the full `context_summary.md` template and section-by-section update rules.
+- `rules/task-completion.md` — the base completion checklist plus the harness-specific additions.
+
+**Wiring** — `hooks/session-start.sh` injects pointers to both new rules in the harness orientation block, and `skills/harness-continue/SKILL.md` references them at the context-update and session-end steps. `templates/CLAUDE.md` gains a Rule Index table mapping each rule file to when it should be read.
+
+**Why not a full split** — the core-standards file ships as a manually copied `~/.claude/CLAUDE.md` with no auto-loader, so always-on content (invariants, TDD, debugging, git identity, security) stays in the template; only genuinely on-demand reference material was extracted. This adapts PR #8's routing-table idea to the v4.0 plugin model.
+
+**Tests** — `test/run-tests.sh` gains assertions that the SessionStart orientation includes the two new rule pointers.
+
 ### v4.0.0 (2026-06-30)
 
 **The harness is now a native Claude Code plugin.** The story of every version since v3.1 has been promoting rules from instructional to mechanical enforcement. v4.0 applies that to the harness itself: distribution, session orientation, post-compaction recovery, discipline auditing, progress visibility, and teammate tool posture — all carried by prose and a custom installer until now — are handed to the platform. This release ships what was planned as the v4.0–v4.3 milestone series in one release.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A harness system for Claude Code that solves multi-session continuity, parallel agent coordination, and automated quality enforcement. Built on Anthropic's research for long-running tasks, evolved through four major versions into a native Claude Code plugin built on the platform's Agent Teams primitives.
 
-**Current version: v4.0.0** — The harness is now a native Claude Code plugin (`/plugin install vv-harness`). The platform owns what prose and a custom installer used to carry: distribution and atomic updates, session orientation and post-compaction recovery (a SessionStart hook), session-end discipline auditing (a SessionEnd hook), live feature progress (a statusLine), and teammate tool posture (declarative `vv-harness:*` agents). The v3 installer is retired; migration steps are in [INSTALL.md](./INSTALL.md). Full history in [CHANGELOG.md](./CHANGELOG.md).
+**Current version: v4.1.0** — `templates/CLAUDE.md` trimmed from 461 to 356 lines: reference-heavy blocks (the full `context_summary.md` template, the task completion checklist) moved into new plugin rule files surfaced by the SessionStart hook, and verbose always-on sections condensed in place. Adapts PR #8's routing-table idea to the v4.0 plugin model, which has no rule auto-loader. Full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ---
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -87,5 +87,9 @@ echo ""
 echo "Agent Teams protocol: read $PLUGIN_ROOT/rules/agent-teams-protocol.md" \
   "before spawning teammates."
 echo "Code-quality limits: $PLUGIN_ROOT/rules/code-quality.md (read before writing code)."
+echo "Context summary format: $PLUGIN_ROOT/rules/context-summary.md" \
+  "(read before editing context_summary.md)."
+echo "Completion checklist: $PLUGIN_ROOT/rules/task-completion.md" \
+  "(read before declaring work complete)."
 echo "Run /harness-continue for the full interactive flow (mode choice, smoke test, team plan)."
 exit 0

--- a/rules/context-summary.md
+++ b/rules/context-summary.md
@@ -1,0 +1,66 @@
+<!-- Shipped with the vv-harness plugin. There is no auto-loading: the SessionStart
+orientation injects this file's absolute path, and the harness skills instruct the lead
+to read it when working with context_summary.md. -->
+
+# context_summary.md
+
+Used in ALL projects (harness and non-harness). The single persistent knowledge store across sessions.
+
+In harness projects: `.harness/context_summary.md`. In non-harness projects: `./context_summary.md` in the project root.
+
+Create once, update continuously.
+
+```markdown
+# Context Summary
+
+## Active Context
+<!-- Max 500 tokens. Current focus, immediate priorities. Refresh frequently. -->
+- Currently working on: [active task]
+- Blocking issues: [if any]
+- Next up: [queued work]
+
+## Cross-Cutting Concerns
+<!-- Security, performance, compatibility constraints that affect all work -->
+- [Concern]: [how it affects decisions]
+
+## Domain: [Name]
+<!-- One section per major domain/module. Add as needed. -->
+
+### Decisions
+- [Decision]: [rationale] (date)
+
+### Patterns
+- [Pattern name]: [when to use]
+
+### Gotchas
+- [Gotcha]: [how to avoid]
+
+## Meta-Patterns
+<!-- Coordination insights that apply across features — NOT domain-specific.
+     Written by the retrospective step at session end. These transfer to new
+     projects: harness-init can import them as starting context.
+     Examples: when to use Opus, how to scope work, when plan_approval pays off. -->
+- (none yet)
+
+## Meta-Session [DATE]
+<!-- One section per completed session's retrospective. Written at session end.
+     Analyzes correction_cycles, scope_expansions, model fit, discovery lineage.
+     Feeds the Meta-Patterns section with generalizable coordination insights. -->
+- Scope accuracy: [findings]
+- Model calibration: [findings]
+- Discovery lineage: [findings]
+- Approach patterns: [what worked, what failed]
+- Plan approval: [was it worth the overhead for which feature types]
+
+## Closed Work Streams
+<!-- Completed features. Reference only if dependency exists. -->
+- [Feature]: completed [date], see [PR/commit]
+```
+
+**Update when:** a decision is made, a pattern is discovered, a gotcha is encountered, a work stream completes, active context shifts, or a session retrospective completes.
+
+**Do NOT add:** progress updates ("completed task X"), completed todos, conversation summaries, or anything already tracked in `claude-progress.txt`. This file is for decisions, patterns, gotchas, and coordination retrospectives — not a journal.
+
+**Size discipline:** if a domain section exceeds ~300 tokens, summarize or split. Meta-Session entries older than 3 sessions can be summarized into Meta-Patterns and removed.
+
+**Keep Active Context fresh:** this section should reflect right now, not last week.

--- a/rules/task-completion.md
+++ b/rules/task-completion.md
@@ -1,0 +1,22 @@
+<!-- Shipped with the vv-harness plugin. There is no auto-loading: the SessionStart
+orientation injects this file's absolute path, and the harness skills instruct the lead
+to read it before declaring work complete. -->
+
+# Task Completion Checklist
+
+Before declaring ANY task complete:
+- [ ] All tests pass (including new tests written via TDD)
+- [ ] No uncommitted changes remain
+- [ ] Sub-agent/teammate work validated against lead context
+- [ ] Documentation updated (existing docs only)
+- [ ] `context_summary.md` updated with decisions, patterns, or gotchas discovered
+- [ ] {{USER_NAME}} informed of what changed
+
+Additional for harness projects:
+- [ ] `features.json` audited against actual work done — every touched feature has updated status, test_file, coverage; unmapped work gets a new feature entry with `discovered_via`
+- [ ] `context_summary.md` has any non-obvious root causes, gotchas, or patterns discovered this session
+- [ ] Retrospective written to `context_summary.md` under `## Meta-Session [DATE]` (mandatory even for single-session work)
+- [ ] `claude-progress.txt` has session handoff
+- [ ] Task list is current — no stale in-progress or pending tasks that no longer reflect reality
+
+Do NOT skip this checklist.

--- a/skills/harness-continue/SKILL.md
+++ b/skills/harness-continue/SKILL.md
@@ -145,6 +145,8 @@ No exceptions unless tooling is broken.
 
 Treat `context_summary.md` updates as part of the task, not after the task. Specifically: after every bug fix that reveals a non-obvious root cause, write the gotcha to `context_summary.md` BEFORE moving to the next request. The cost is 30 seconds; the value is permanent. A future session will benefit from knowing the root cause without re-discovering it.
 
+For the `context_summary.md` structure and section-by-section update rules, read `${CLAUDE_PLUGIN_ROOT}/rules/context-summary.md`.
+
 ### When Feature Passes
 
 1. Update `.harness/features.json`: set status to `"passing"`, add `test_file` and `coverage`, clear `assigned_to`. Also populate `approaches_tried` with a brief note on what worked (even for single-session work — this feeds the retrospective).
@@ -187,6 +189,8 @@ Active Context and the task list. Follow it — it's your recovery path.
    - Blockers: [any blockers]
    ```
 5. Git commit (see Commit Hygiene rules — separate harness metadata from code commits)
+
+Before declaring the session complete, work through the full checklist in `${CLAUDE_PLUGIN_ROOT}/rules/task-completion.md` (base checklist plus the harness-specific additions).
 
 ---
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -169,30 +169,10 @@ For non-harness projects: match the project's existing test patterns for file na
 
 YOU MUST find the root cause. NEVER fix a symptom or add a workaround.
 
-### Phase 1: Root Cause Investigation (BEFORE attempting fixes)
-- Read error messages carefully; they often contain the exact solution
-- Reproduce consistently before investigating
-- Check recent changes: git diff, recent commits
-- For user-reported bugs: state your diagnosis and proposed fix in 2-3 sentences BEFORE editing code. ("I think the crash is X because Y, I'll fix it by Z.") This gives the user a chance to correct your understanding and costs one message.
-
-### Phase 2: Pattern Analysis
-- Find working examples in the same codebase
-- Compare against references; read implementation completely
-- Identify differences between working and broken code
-- Understand dependencies
-
-### Phase 3: Hypothesis and Testing
-1. Form single hypothesis; state it clearly
-2. Make smallest possible change to test hypothesis
-3. Verify before continuing; if it didn't work, form new hypothesis
-4. Say "I don't understand X" rather than pretending to know
-
-### Phase 4: Implementation Rules
-- ALWAYS have the simplest possible failing test case
-- NEVER add multiple fixes at once
-- NEVER claim to implement a pattern without reading it completely
-- ALWAYS test after each change
-- IF first fix doesn't work, STOP and re-analyze
+1. **Investigate first.** Read the error message (it often names the fix), reproduce consistently, check recent changes (`git diff`, recent commits). For user-reported bugs, state your diagnosis and proposed fix in 2-3 sentences BEFORE editing ("I think the crash is X because Y, I'll fix it by Z") — one message that lets the user correct you.
+2. **Analyze the pattern.** Find a working example in the same codebase, read it completely, and identify what differs from the broken code.
+3. **Test one hypothesis at a time.** State it, make the smallest change that tests it, verify before continuing. Say "I don't understand X" rather than pretending to know.
+4. **Implement disciplined.** Keep the simplest failing test case; one fix at a time; test after each change; if the first fix doesn't work, STOP and re-analyze.
 
 ---
 
@@ -232,21 +212,10 @@ These apply to both Agent Teams teammates (in harness projects) and general sub-
 - Correlate outputs: sub-agent plans must align with the lead's context
 
 ### Sub-Agent Failure Handling
-1. Assess: transient or structural?
-2. If transient: allow one retry
-3. If structural: provide specific feedback and request correction
-4. Maximum 4 correction cycles; after 4 failures, declare failure and terminate
-5. On termination: report what was attempted, why it failed, preserve findings
-
-Do not let a failing sub-agent block other parallel work.
+Assess whether a failure is transient (allow one retry) or structural (give specific feedback and request correction). Maximum 4 correction cycles; after 4 failures, declare failure, report what was attempted and why it failed, and preserve findings. Do not let a failing sub-agent block other parallel work.
 
 ### Partial Success in Parallel Work
-1. Merge successful work into codebase
-2. Verify merged work passes tests independently
-3. Re-assess failed work with new context
-4. Spawn new sub-agents with revised prompts
-5. Do NOT block successful work waiting for failed streams
-6. Do NOT abandon failed work without {{USER_NAME}}'s approval
+Merge successful work and verify it passes tests independently; re-assess failed work with new context and respawn with revised prompts. Do NOT block successful work waiting for failed streams, and do NOT abandon failed work without {{USER_NAME}}'s approval.
 
 ### Agent Teams (Harness Projects Only)
 
@@ -268,28 +237,9 @@ Limit web fetches to essential sources. Quality over quantity.
 
 A broken codebase is worse than a paused task. Fail fast, fail loud, fail safe.
 
-### Retry (Autonomous, Limited)
+**Retry autonomously (limited):** network timeouts (max 2), rate limiting (backoff, max 3), tool crashes with no state change (once). **Never retry:** test failures, build errors, permission denied, or anything that failed the same way twice.
 
-Retry automatically for:
-- Network timeouts (max 2 retries)
-- Rate limiting (backoff, max 3 attempts)
-- Tool crashes with no state change (once)
-
-Do NOT retry:
-- Test failures
-- Build errors
-- Permission denied
-- Anything that failed the same way twice
-
-### Report (Default for Non-Transient)
-
-Immediately report:
-- Sub-agent at 4 correction cycles
-- Missing tools or capabilities
-- Ambiguity revealed by failure
-- Conflicts between sub-agent output and constraints
-
-Report format: what was attempted, what failed and why, options (retry differently, user intervention, abandon), recommended path.
+**Report immediately** for non-transient failures — a sub-agent at 4 correction cycles, missing tools, ambiguity revealed by failure, or conflicts between sub-agent output and constraints. Report format: what was attempted, what failed and why, the options (retry differently / user intervention / abandon), and your recommended path.
 
 ---
 
@@ -378,84 +328,29 @@ If project-level CLAUDE.md conflicts with this core file:
 
 ## context_summary.md
 
-This file is used in ALL projects (harness and non-harness). It's the single persistent knowledge store across sessions.
+The single persistent knowledge store across sessions, used in ALL projects. In harness projects it lives at `.harness/context_summary.md`; in non-harness projects at `./context_summary.md`. Create once, update continuously.
 
-In harness projects, it lives at `.harness/context_summary.md`. In non-harness projects, it lives at `./context_summary.md` in the project root.
+Sections: **Active Context** (current focus, refreshed frequently), **Cross-Cutting Concerns**, per-**Domain** Decisions/Patterns/Gotchas, **Meta-Patterns** and **Meta-Session** retrospectives, **Closed Work Streams**. Record decisions, patterns, gotchas, and retrospectives — not progress updates or completed-todo journals (those live in `claude-progress.txt`).
 
-Create once, update continuously.
-
-```markdown
-# Context Summary
-
-## Active Context
-<!-- Max 500 tokens. Current focus, immediate priorities. Refresh frequently. -->
-- Currently working on: [active task]
-- Blocking issues: [if any]
-- Next up: [queued work]
-
-## Cross-Cutting Concerns
-<!-- Security, performance, compatibility constraints that affect all work -->
-- [Concern]: [how it affects decisions]
-
-## Domain: [Name]
-<!-- One section per major domain/module. Add as needed. -->
-
-### Decisions
-- [Decision]: [rationale] (date)
-
-### Patterns
-- [Pattern name]: [when to use]
-
-### Gotchas
-- [Gotcha]: [how to avoid]
-
-## Meta-Patterns
-<!-- Coordination insights that apply across features — NOT domain-specific.
-     Written by the retrospective step at session end. These transfer to new
-     projects: harness-init can import them as starting context.
-     Examples: when to use Opus, how to scope work, when plan_approval pays off. -->
-- (none yet)
-
-## Meta-Session [DATE]
-<!-- One section per completed session's retrospective. Written at session end.
-     Analyzes correction_cycles, scope_expansions, model fit, discovery lineage.
-     Feeds the Meta-Patterns section with generalizable coordination insights. -->
-- Scope accuracy: [findings]
-- Model calibration: [findings]
-- Discovery lineage: [findings]
-- Approach patterns: [what worked, what failed]
-- Plan approval: [was it worth the overhead for which feature types]
-
-## Closed Work Streams
-<!-- Completed features. Reference only if dependency exists. -->
-- [Feature]: completed [date], see [PR/commit]
-```
-
-**Update when:** a decision is made, a pattern is discovered, a gotcha is encountered, a work stream completes, active context shifts, or a session retrospective completes.
-
-**Do NOT add:** progress updates ("completed task X"), completed todos, conversation summaries, or anything already tracked in `claude-progress.txt`. This file is for decisions, patterns, gotchas, and coordination retrospectives — not a journal.
-
-**Size discipline:** if a domain section exceeds ~300 tokens, summarize or split. Meta-Session entries older than 3 sessions can be summarized into Meta-Patterns and removed.
-
-**Keep Active Context fresh:** this section should reflect right now, not last week.
+For the full template block and section-by-section update rules, see `rules/context-summary.md` (the vv-harness plugin surfaces its absolute path via the SessionStart hook in harness projects).
 
 ---
 
 ## Task Completion Checklist
 
-Before declaring ANY task complete:
-- [ ] All tests pass (including new tests written via TDD)
-- [ ] No uncommitted changes remain
-- [ ] Sub-agent/teammate work validated against lead context
-- [ ] Documentation updated (existing docs only)
-- [ ] `context_summary.md` updated with decisions, patterns, or gotchas discovered
-- [ ] {{USER_NAME}} informed of what changed
+Before declaring ANY task complete: all tests pass, no uncommitted changes remain, sub-agent work validated, existing docs updated, `context_summary.md` updated with decisions/patterns/gotchas, and {{USER_NAME}} informed of what changed.
 
-Additional for harness projects:
-- [ ] `features.json` audited against actual work done — every touched feature has updated status, test_file, coverage; unmapped work gets a new feature entry with `discovered_via`
-- [ ] `context_summary.md` has any non-obvious root causes, gotchas, or patterns discovered this session
-- [ ] Retrospective written to `context_summary.md` under `## Meta-Session [DATE]` (mandatory even for single-session work)
-- [ ] `claude-progress.txt` has session handoff
-- [ ] Task list is current — no stale in-progress or pending tasks that no longer reflect reality
+Harness projects add: `features.json` audited against actual work, retrospective written under `## Meta-Session [DATE]`, `claude-progress.txt` handoff, and a current task list. For the full checklist, see `rules/task-completion.md`. Do NOT skip it.
 
-Do NOT skip this checklist.
+---
+
+## Rule Index
+
+Deeper procedures ship as separate rule files in the vv-harness plugin. There is no auto-loading: in harness projects the SessionStart hook injects their absolute paths, and the harness skills instruct the lead to read them at the relevant step. This file stays self-contained for every session; the rule files carry the reference-heavy detail.
+
+| Rule file | Read when |
+|-----------|-----------|
+| `rules/code-quality.md` | Before writing code (mechanical limits, naming, comments) |
+| `rules/agent-teams-protocol.md` | Before spawning teammates for parallel work |
+| `rules/context-summary.md` | Before editing `context_summary.md` (full template + update rules) |
+| `rules/task-completion.md` | Before declaring work complete (full checklist) |

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -126,6 +126,10 @@ else
 fi
 assert_contains "$OUT" "rules/code-quality.md (read before writing code)" \
   "o: orientation includes the code-quality pointer"
+assert_contains "$OUT" "rules/context-summary.md" \
+  "o: orientation includes the context-summary pointer"
+assert_contains "$OUT" "rules/task-completion.md" \
+  "o: orientation includes the task-completion pointer"
 
 echo ""
 echo "== session-end.sh =="


### PR DESCRIPTION
## Summary

Adapts the useful idea from #8 (route procedural detail out of the always-on core into rule files) to the **v4.0 plugin model**, which has **no rule auto-loader**. #8's `globs:` mechanism is inert in this repo — rule files reach the model only via SessionStart-hook path injection and skill-directed reads, both harness-scoped. So this is a targeted extraction, not a full gut.

`templates/CLAUDE.md`: **461 → 356 lines**, with **no always-on content lost**.

## What moved out (to new plugin rule files)

Only reference-heavy blocks that matter at a specific moment, not on every prompt:

| New file | Content |
|----------|---------|
| `rules/context-summary.md` | Full `context_summary.md` template + section-by-section update rules |
| `rules/task-completion.md` | Base completion checklist + harness-specific additions |

Both are surfaced the same way `code-quality.md` / `agent-teams-protocol.md` already are — no `globs:`, no auto-loading.

## Wiring (the real v4.0 mechanism)

- `hooks/session-start.sh` — injects pointers to both new rules in the harness orientation block.
- `skills/harness-continue/SKILL.md` — references them at the context-update and session-end steps.
- `templates/CLAUDE.md` — gains a **Rule Index** table mapping each rule file to when it should be read.

## What stayed in the template (and why)

Always-on content — Critical Invariants, TDD, systematic debugging, git identity verification, security — stays inline because the manually-copied `~/.claude/CLAUDE.md` has no auto-loader; nothing would re-inject it in a plain non-harness session. Verbose sections (debugging phases, sub-agent failure handling, error recovery) were **condensed in place**, not moved.

## Tests

`test/run-tests.sh`: **53/53** (added 2 assertions for the new SessionStart pointers). Startup orientation stays at 1085 chars (<4000 guard).

## Version

`plugin.json` 4.0.0 → **4.1.0** (single source of truth). README + CHANGELOG updated.

## Supersedes #8

#8 targets the dead v3.5 `claude/` layout, is conflicting, and its `globs:` premise doesn't hold here. Recommend closing it in favor of this.