### PR TITLE
chore: release v4.0.1 (correct version label)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vv-harness",
   "displayName": "VV Claude Code Harness",
-  "version": "4.1.0",
+  "version": "4.0.1",
   "description": "Multi-session continuity, parallel Agent Teams coordination, and mechanical quality enforcement for Claude Code.",
   "author": {
     "name": "oeftimie",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Version history for the VV Claude Code Harness. The current version lives in `.claude-plugin/plugin.json`.
 
-### v4.1.0 (2026-07-01)
+### v4.0.1 (2026-07-01)
 
 **`templates/CLAUDE.md` trimmed from 461 to 356 lines.** Two reference-heavy blocks that only matter at specific moments — the full `context_summary.md` template and the task completion checklist — moved out of the always-on core into plugin rule files, and verbose always-on sections (systematic debugging, sub-agent failure handling, error recovery) were condensed in place without losing substance.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A harness system for Claude Code that solves multi-session continuity, parallel agent coordination, and automated quality enforcement. Built on Anthropic's research for long-running tasks, evolved through four major versions into a native Claude Code plugin built on the platform's Agent Teams primitives.
 
-**Current version: v4.1.0** — `templates/CLAUDE.md` trimmed from 461 to 356 lines: reference-heavy blocks (the full `context_summary.md` template, the task completion checklist) moved into new plugin rule files surfaced by the SessionStart hook, and verbose always-on sections condensed in place. Adapts PR #8's routing-table idea to the v4.0 plugin model, which has no rule auto-loader. Full history in [CHANGELOG.md](./CHANGELOG.md).
+**Current version: v4.0.1** — `templates/CLAUDE.md` trimmed from 461 to 356 lines: reference-heavy blocks (the full `context_summary.md` template, the task completion checklist) moved into new plugin rule files surfaced by the SessionStart hook, and verbose always-on sections condensed in place. Adapts PR #8's routing-table idea to the v4.0 plugin model, which has no rule auto-loader. Full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ---
 


### PR DESCRIPTION
Corrects the version label to **v4.0.1**.

#13 was merged at its pre-relabel commit (13d0b57), so `main` currently ships `4.1.0` in `plugin.json`, CHANGELOG, and README. This sets all three to **4.0.1** — a patch, since the trim + rule extraction changes no runtime behavior.

No content changes beyond the three version strings. Tests: 53/53.

Merge this, then the `v4.0.1` tag + GitHub release can be cut off `main`.