### PR TITLE
Rename issue-prep/issue-debug to harness-issue-prep/harness-issue-debug (v4.2.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vv-harness",
   "displayName": "VV Claude Code Harness",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Multi-session continuity, parallel Agent Teams coordination, and mechanical quality enforcement for Claude Code.",
   "author": {
     "name": "oeftimie",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Version history for the VV Claude Code Harness. The current version lives in `.claude-plugin/plugin.json`.
 
+### v4.2.0 (2026-07-03)
+
+**Skill rename for discoverability.** `issue-prep` and `issue-debug` are now
+`harness-issue-prep` and `harness-issue-debug`, so every harness skill shares the
+`harness-` prefix and typing `/h` surfaces the whole toolkit (`harness-init`,
+`harness-continue`, `harness-issue-prep`, `harness-issue-debug`) without memorizing
+names. Behavior is unchanged; all cross-references in the agents, hooks, schema,
+protocol, docs, and tests are updated. If you learned the v4.1.0 names, they are gone:
+there is no alias, per the replace-don't-deprecate rule. The v4.1.0 entry below is left
+as written; it describes that release accurately.
+
 ### v4.1.0 (2026-07-03)
 
 **The spec gate.** The harness had one verified intake gap: `/harness-init` Step 5 wrote

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -216,7 +216,7 @@ breakdown view is available on subscription plans (Pro/Max/Team/Enterprise).
 
 Everything below is optional and macOS-specific (it uses the Keychain and `launchctl`).
 Skip it entirely if you only use the spec gate locally: `/harness-init` Step 5.1 and
-`issue-prep` work with no configuration, writing an unsigned `spec` field to
+`harness-issue-prep` work with no configuration, writing an unsigned `spec` field to
 `features.json`. Configure this section only if a separate, external issue-to-PR runner
 needs a trustworthy signal that a Linear issue is ready for unattended implementation.
 
@@ -243,7 +243,7 @@ failing:
 }
 ```
 
-- `prep.linear`: labels `issue-prep` applies to a Linear issue as it moves through the
+- `prep.linear`: labels `harness-issue-prep` applies to a Linear issue as it moves through the
   gate. Omit it and labeling is skipped.
 - `prep.stamp`: enables minting a signed readiness stamp. Requires a one-time Keychain
   setup, done by hand and never automated:
@@ -253,10 +253,10 @@ failing:
   ```
 
   `keychain_service` must match the service name used above (`vv-harness-stamp` by
-  default). If the key is unreadable at stamp time, `issue-prep` aborts stamping (the
+  default). If the key is unreadable at stamp time, `harness-issue-prep` aborts stamping (the
   spec stays normalized, no label is applied) and prints this same setup command.
 - `prep.runner`: set `enabled: true` and `kickstart_label` to the `Label` in your
-  runner's launchd plist to have `issue-prep` nudge it after a successful stamp
+  runner's launchd plist to have `harness-issue-prep` nudge it after a successful stamp
   (`launchctl kickstart -k "gui/$(id -u)/<kickstart_label>"`). A failed kickstart is a
   one-line note, never fatal; the runner's own poll cycle is the fallback path.
 

--- a/README.md
+++ b/README.md
@@ -334,8 +334,8 @@ claude
 |-----------|---------|
 | `skills/harness-init/` | Project initialization with hooks and scaffolding |
 | `skills/harness-continue/` | Session continuation with team spawn prompts and the subagent fallback |
-| `skills/issue-prep/` | Verify and normalize a spec (Linear issue, pasted text, or a feature), then mark it ready for implementation |
-| `skills/issue-debug/` | Open a failed feature or a runner-parked Linear issue in a live repair session |
+| `skills/harness-issue-prep/` | Verify and normalize a spec (Linear issue, pasted text, or a feature), then mark it ready for implementation |
+| `skills/harness-issue-debug/` | Open a failed feature or a runner-parked Linear issue in a live repair session |
 | `agents/` | Declarative teammate definitions (feature-implementer, layer-implementer, researcher, reviewer, spec-verification, reverification-guard) |
 | `schemas/` | Data contracts published for external consumers (readiness stamp, park/resolution formats) |
 | `hooks/` | Plugin continuity hooks: session-start, session-end, statusline |
@@ -346,7 +346,7 @@ claude
 
 ### The spec gate
 
-`/harness-init` Step 5.1 and the `issue-prep` skill spawn the `spec-verification` and
+`/harness-init` Step 5.1 and the `harness-issue-prep` skill spawn the `spec-verification` and
 `reverification-guard` agents (read-only, spec-in-prompt) to verify a specification is
 testable, unambiguous, and internally consistent before any implementation starts. The
 harness is the **mint**: it verifies specs interactively, where human judgment is cheap,

--- a/agents/reverification-guard.md
+++ b/agents/reverification-guard.md
@@ -4,7 +4,7 @@ description: >-
   Integrity check on the spec gate's human loop. Runs when a human answers or amends a
   spec that spec-verification questioned: re-runs every SV check on the amended text,
   hosts the anti-sycophancy and anti-capitulation clauses, and refuses to advance on
-  pressure alone. Spawned read-only by the issue-prep skill on every revision cycle.
+  pressure alone. Spawned read-only by the harness-issue-prep skill on every revision cycle.
   Verdicts: PASS / ASK / BLOCK.
 model: sonnet
 tools: Read, Grep
@@ -84,7 +84,7 @@ STILL-OPEN QUESTIONS (numbered, only if ASK/BLOCK)
   1. [SV-0x] ...
 
 OPERATING CONTEXT (vv-harness)
-You are spawned as a read-only subagent by the issue-prep skill, once per revision cycle,
+You are spawned as a read-only subagent by the harness-issue-prep skill, once per revision cycle,
 capped at five cycles. Your final message IS your report; emit the fixed block above and
 nothing after it. The pressure you are built to resist is live and in the room: the human
 amending the spec is the same human waiting on your verdict. Hold the line anyway.

--- a/agents/spec-verification.md
+++ b/agents/spec-verification.md
@@ -4,7 +4,7 @@ description: >-
   Spec gate of the vv-harness pipeline. Proves a specification (a Linear issue or a
   proposed features.json feature set) is complete, testable, and unambiguous before any
   implementation starts, or returns precise numbered questions to a human. Spawned
-  read-only by /harness-init Step 5.1 and the issue-prep skill with the spec in the
+  read-only by /harness-init Step 5.1 and the harness-issue-prep skill with the spec in the
   prompt. Verdicts: PASS / ASK / BLOCK.
 model: opus
 tools: Read, Grep, Glob
@@ -86,7 +86,7 @@ OPEN QUESTIONS (numbered, only if ASK/BLOCK)
 OPERATING CONTEXT (vv-harness)
 You are spawned as a read-only subagent; your tools cannot modify anything, and that is
 by construction, not courtesy. Your final message IS your report; emit the fixed block
-above and nothing after it. In the interactive flows (/harness-init, issue-prep) a human
+above and nothing after it. In the interactive flows (/harness-init, harness-issue-prep) a human
 answers your questions live; in the external runner the same report format is parsed
 mechanically and quoted spans are verified against the source, so keep quotes exact.
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -71,7 +71,7 @@ try:
         print("")
         print("WARNING: spec drift: description changed after verification for "
               + ", ".join(drifted[:5]) + ".")
-        print("Re-run the spec gate (issue-prep) before implementing these.")
+        print("Re-run the spec gate (harness-issue-prep) before implementing these.")
 except Exception:
     pass
 PYEOF

--- a/rules/agent-teams-protocol.md
+++ b/rules/agent-teams-protocol.md
@@ -96,7 +96,7 @@ Every feature in `.harness/features.json` uses this shape:
 - `discovered_via` — lead sets this when adding a feature that emerged from another feature's implementation. Value is the source feature's ID (e.g., `"F002"`). Different from `depends_on` (technical dependency) — this is discovery lineage.
 
 **Spec verification** (optional): when a feature's spec has passed the verification gate
-(`/harness-init` Step 5.1 or the `issue-prep` skill), it carries a `spec` object:
+(`/harness-init` Step 5.1 or the `harness-issue-prep` skill), it carries a `spec` object:
 `{"hash", "verdict", "sv_version", "verified_at", "source"}`. `hash` is sha256 over the
 `description` string exactly as stored (see `schemas/readiness-stamp.md` for the canonical
 recipe); editing the description invalidates it, and the SessionStart orientation warns on

--- a/schemas/readiness-stamp.md
+++ b/schemas/readiness-stamp.md
@@ -2,7 +2,7 @@
 
 Version-bearing contracts between the vv-harness spec gate (the mint) and any external
 consumer, primarily an autonomous issue-to-PR runner. The runner validates these formats;
-it imports no code from this repository. Producers: the `issue-prep` and `issue-debug`
+it imports no code from this repository. Producers: the `harness-issue-prep` and `harness-issue-debug`
 skills. This document is the single source of truth for field meanings and the canonical
 hash and HMAC recipes.
 
@@ -91,11 +91,11 @@ Posted by the runner when it parks an issue after exhausting self-heal attempts.
 }
 ```
 
-Consumed by the `issue-debug` skill, which opens the branch and works the findings live.
+Consumed by the `harness-issue-debug` skill, which opens the branch and works the findings live.
 
-## Debug resolution v1 (issue-debug -> runner)
+## Debug resolution v1 (harness-issue-debug -> runner)
 
-Posted by `issue-debug` when a repair session concludes. Line 1:
+Posted by `harness-issue-debug` when a repair session concludes. Line 1:
 `vv-harness-debug-resolution v1`, then one fenced json block:
 
 ```json
@@ -111,7 +111,7 @@ Posted by `issue-debug` when a repair session concludes. Line 1:
 ```
 
 Dispositions: `resume` (branch pushed, findings addressed; runner re-verifies and
-re-arms), `reprep` (the spec was the problem; a fresh stamp will follow via issue-prep),
+re-arms), `reprep` (the spec was the problem; a fresh stamp will follow via harness-issue-prep),
 `abandon` (runner closes out; humans decide the issue's fate).
 
 ## Versioning policy

--- a/skills/harness-issue-debug/SKILL.md
+++ b/skills/harness-issue-debug/SKILL.md
@@ -1,14 +1,14 @@
 ---
-name: issue-debug
-description: Open a failed or parked piece of work in a live repair session. Input is a features.json feature id (harness project) or a Linear issue key parked by the external runner. Loads the failure context, checks out the branch, iterates the fix with the human, and exits by resuming the runner, routing back through issue-prep, or marking the work failed. Use when a feature is status failed or a runner-parked issue needs hands-on debugging.
+name: harness-issue-debug
+description: Open a failed or parked piece of work in a live repair session. Input is a features.json feature id (harness project) or a Linear issue key parked by the external runner. Loads the failure context, checks out the branch, iterates the fix with the human, and exits by resuming the runner, routing back through harness-issue-prep, or marking the work failed. Use when a feature is status failed or a runner-parked issue needs hands-on debugging.
 ---
 
 # Issue Debug
 
 Opens a live, interactive repair session on a piece of work that stopped: a harness
 feature marked `failed`, or a Linear issue the external runner parked after exhausting
-its self-heal attempts. This skill is the hands-on counterpart to `issue-prep`: where
-`issue-prep` fixes a spec before implementation starts, `issue-debug` fixes an
+its self-heal attempts. This skill is the hands-on counterpart to `harness-issue-prep`: where
+`harness-issue-prep` fixes a spec before implementation starts, `harness-issue-debug` fixes an
 implementation (or the spec behind it) after something already went wrong.
 
 Mode is selected by the shape of the argument:
@@ -49,7 +49,7 @@ other feature work is that it starts from a known failure instead of a blank fea
 - **Fixed and the human is satisfied.** Set `status` to `"pending"`, not `"passing"`; the
   quality gate (`verify-task-quality.sh` on `TaskCompleted`) is what earns `"passing"`,
   and this skill does not shortcut it. Clear `failure_reason`.
-- **The spec was the real problem, not the code.** Run `issue-prep F0NN` to fix the
+- **The spec was the real problem, not the code.** Run `harness-issue-prep F0NN` to fix the
   description before any further implementation attempt.
 - **Abandoned this session.** Keep `status: "failed"`. Update `failure_reason` with what
   was learned this round, even if the answer is still "unresolved": a stale
@@ -113,7 +113,7 @@ Disposition is exactly one of:
   Keychain key is unreadable, do not post a `resume` disposition; report the failure and
   offer `reprep` or `abandon` instead.
 - **`reprep`**: the spec, not the code, turned out to be the problem. Post the comment
-  with no `hmac`, then run `issue-prep ISSUE-KEY` to fix the spec and re-stamp it.
+  with no `hmac`, then run `harness-issue-prep ISSUE-KEY` to fix the spec and re-stamp it.
 - **`abandon`**: the runner should stop trying and a human decides the issue's fate. Post
   the comment with no `hmac`.
 

--- a/skills/harness-issue-prep/SKILL.md
+++ b/skills/harness-issue-prep/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: issue-prep
+name: harness-issue-prep
 description: Interactively verify a spec until it is buildable, then mark it ready for implementation. Sources: a Linear issue (via the Linear MCP), a pasted spec, or an existing features.json feature. On PASS it normalizes the spec, records verification (spec field locally; a signed readiness stamp plus label on Linear), and can kick the external runner. Use when an issue or feature needs to be made ready for unattended or team implementation.
 ---
 

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -421,7 +421,7 @@ import os
 import sys
 
 root = sys.argv[1]
-for skill_dir in ("issue-prep", "issue-debug"):
+for skill_dir in ("harness-issue-prep", "harness-issue-debug"):
     path = os.path.join(root, "skills", skill_dir, "SKILL.md")
     if not os.path.isfile(path):
         print(f"missing: {path}")
@@ -444,7 +444,7 @@ for skill_dir in ("issue-prep", "issue-debug"):
 PYEOF
 )
 if [ -z "$SKILL_ERRORS" ]; then
-  pass "w: issue-prep and issue-debug SKILL.md files have sane frontmatter"
+  pass "w: harness-issue-prep and harness-issue-debug SKILL.md files have sane frontmatter"
 else
   fail "w: skill frontmatter -- $SKILL_ERRORS"
 fi


### PR DESCRIPTION
## What changed

Renames the two v4.1.0 skills so every harness skill shares the `harness-` prefix and `/h` autocompletes the full toolkit: `skills/issue-prep/` is now `skills/harness-issue-prep/` and `skills/issue-debug/` is now `skills/harness-issue-debug/`, with matching frontmatter `name:` fields. No behavior change.

All cross-references updated: both skills' own text, `rules/agent-teams-protocol.md`, both agent definitions, the SessionStart drift warning, `schemas/readiness-stamp.md`, README, INSTALL, and the test suite's frontmatter checks. No alias for the old names (replace, don't deprecate). The v4.1.0 CHANGELOG entry keeps the old names since it describes that release as shipped; the rename gets its own v4.2.0 entry. Version bumped to 4.2.0 so installed users receive the rename.

## Testing

`bash test/run-tests.sh`: 66/66 (the skill-frontmatter test enforces name == directory on the new paths). `bash -n` clean on the edited hook; `plugin.json` parses with only the version line changed. Repo-wide grep confirms no un-prefixed `issue-prep`/`issue-debug` references remain outside CHANGELOG history.

## Dependencies

None.