### PR TITLE
Resolve schema references via CLAUDE_PLUGIN_ROOT (v4.2.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vv-harness",
   "displayName": "VV Claude Code Harness",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Multi-session continuity, parallel Agent Teams coordination, and mechanical quality enforcement for Claude Code.",
   "author": {
     "name": "oeftimie",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Version history for the VV Claude Code Harness. The current version lives in `.claude-plugin/plugin.json`.
 
+### v4.2.1 (2026-07-03)
+
+**Fix: plugin-internal references now resolve for installed users.** The spec-gate
+skills and the Agent Teams protocol referenced `schemas/readiness-stamp.md` as a bare
+relative path. That resolves inside this repo, but in an installed plugin the session
+would look for it in the user's project and fail. All eight references now use
+`${CLAUDE_PLUGIN_ROOT}/schemas/readiness-stamp.md`, the same convention the other
+skills already use for cross-plugin paths. No behavior change on this repo; a
+works-for-everyone fix for installed users.
+
 ### v4.2.0 (2026-07-03)
 
 **Skill rename for discoverability.** `issue-prep` and `issue-debug` are now

--- a/rules/agent-teams-protocol.md
+++ b/rules/agent-teams-protocol.md
@@ -98,7 +98,7 @@ Every feature in `.harness/features.json` uses this shape:
 **Spec verification** (optional): when a feature's spec has passed the verification gate
 (`/harness-init` Step 5.1 or the `harness-issue-prep` skill), it carries a `spec` object:
 `{"hash", "verdict", "sv_version", "verified_at", "source"}`. `hash` is sha256 over the
-`description` string exactly as stored (see `schemas/readiness-stamp.md` for the canonical
+`description` string exactly as stored (see `${CLAUDE_PLUGIN_ROOT}/schemas/readiness-stamp.md` for the canonical
 recipe); editing the description invalidates it, and the SessionStart orientation warns on
 that drift. Absent or `null` means unverified. Hooks and the lead must tolerate all three
 states. A stamp-sourced `risk: "elevated"` maps to `require_plan_approval: true` plus an

--- a/skills/harness-init/SKILL.md
+++ b/skills/harness-init/SKILL.md
@@ -472,7 +472,7 @@ Route on the report's VERDICT:
 - **PASS**: write `features.json`. For each feature, populate `spec` with
   `{"hash": sha256(description), "verdict": "PASS", "sv_version": "1.0",
   "verified_at": ISO8601-UTC, "source": "conversation"}` (canonical hash recipe:
-  `schemas/readiness-stamp.md`).
+  `${CLAUDE_PLUGIN_ROOT}/schemas/readiness-stamp.md`).
 - **ASK**: relay the numbered OPEN QUESTIONS to the user verbatim; iterate the feature
   descriptions with their answers; re-run the gate on the amended proposal. Do not
   write `features.json` until the gate passes.

--- a/skills/harness-issue-debug/SKILL.md
+++ b/skills/harness-issue-debug/SKILL.md
@@ -65,7 +65,7 @@ description and comments.
 
 **Step 2: Find the park bundle.** Locate the newest comment whose first line is the
 literal marker `vv-harness-park v1`. Parse its fenced json block per the
-`schemas/readiness-stamp.md` contract: `branch`, `confirmed_findings`, `heal_attempts`,
+`${CLAUDE_PLUGIN_ROOT}/schemas/readiness-stamp.md` contract: `branch`, `confirmed_findings`, `heal_attempts`,
 `transcript_hint`.
 
 If no such comment exists, or it exists but the json does not parse: say so plainly, offer
@@ -88,7 +88,7 @@ signal that the earlier findings may need more than a local patch.
 ceremony.
 
 **Step 6: Post the resolution.** When the session concludes, post a comment on the issue
-per the `vv-harness-debug-resolution v1` contract in `schemas/readiness-stamp.md`: line 1
+per the `vv-harness-debug-resolution v1` contract in `${CLAUDE_PLUGIN_ROOT}/schemas/readiness-stamp.md`: line 1
 is the literal marker `vv-harness-debug-resolution v1`, followed by one fenced json block.
 Disposition is exactly one of:
 
@@ -118,7 +118,7 @@ Disposition is exactly one of:
   the comment with no `hmac`.
 
 Runner-side consumption of this comment (deciding to act on a `resume`, reconciling its
-own state) is out of scope for this skill; the contract in `schemas/readiness-stamp.md` is
+own state) is out of scope for this skill; the contract in `${CLAUDE_PLUGIN_ROOT}/schemas/readiness-stamp.md` is
 the deliverable, not a running consumer.
 
 ## Degradation

--- a/skills/harness-issue-prep/SKILL.md
+++ b/skills/harness-issue-prep/SKILL.md
@@ -50,7 +50,7 @@ Three sources, selected by the argument passed to this skill:
   naming which capability was missing. If all four resolve, fetch the issue and hold
   `title` and `description` exactly as returned: no trimming, no whitespace
   normalization, ever. The stamp's `spec_hash` depends on the exact bytes (see
-  `schemas/readiness-stamp.md`).
+  `${CLAUDE_PLUGIN_ROOT}/schemas/readiness-stamp.md`).
 - **`F0NN`**: local mode. Load that feature from `.harness/features.json`; the spec under
   test is its `description` field. Its `scope` and `depends_on` travel along as context
   for the verification agent, not as part of the hashed spec.
@@ -172,7 +172,7 @@ git ls-remote <repo_url> HEAD | cut -f1
 ```
 
 If this fails or returns nothing, use the literal string `unknown`; consumers treat drift
-checks as skipped-with-note in that case (`schemas/readiness-stamp.md`).
+checks as skipped-with-note in that case (`${CLAUDE_PLUGIN_ROOT}/schemas/readiness-stamp.md`).
 
 Compute the HMAC:
 
@@ -194,7 +194,7 @@ below, skip stamping entirely, and finish in a normalized-but-unstamped state:
 security add-generic-password -a "$USER" -s vv-harness-stamp -w "$(openssl rand -hex 32)"
 ```
 
-On success, assemble the stamp JSON (shape in `schemas/readiness-stamp.md`), with `ts` in
+On success, assemble the stamp JSON (shape in `${CLAUDE_PLUGIN_ROOT}/schemas/readiness-stamp.md`), with `ts` in
 ISO8601 UTC:
 
 ```json


### PR DESCRIPTION
## What changed

The spec-gate skills (`harness-issue-prep`, `harness-issue-debug`, `harness-init` Step 5.1) and `rules/agent-teams-protocol.md` referenced `schemas/readiness-stamp.md` as a bare relative path. Inside this repo that resolves; in an installed plugin the session looks for it in the user's project and fails. All eight references now use `${CLAUDE_PLUGIN_ROOT}/schemas/readiness-stamp.md`, matching the convention already used for other cross-plugin paths (e.g. harness-continue's protocol reference, harness-init's statusline copy). Version bumped to 4.2.1 so installed users receive it.

## Testing

`bash test/run-tests.sh`: 66/66. A repo-wide grep confirms no bare cross-plugin references remain in `skills/` or `rules/`; README/INSTALL keep repo-relative links, which is correct for GitHub rendering.

## Dependencies

None.