### PR TITLE
Durable go-ahead: stop re-asking at phase transitions (v4.2.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vv-harness",
   "displayName": "VV Claude Code Harness",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Multi-session continuity, parallel Agent Teams coordination, and mechanical quality enforcement for Claude Code.",
   "author": {
     "name": "oeftimie",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Version history for the VV Claude Code Harness. The current version lives in `.claude-plugin/plugin.json`.
 
+### v4.2.2 (2026-07-04)
+
+**A go-ahead is durable.** In practice, sessions governed by the template's "present a
+plan and wait for Go ahead" invariant were stopping at every phase transition of
+/harness-continue and asking again, because each phase looked like new non-trivial work.
+Both sides now state the principle explicitly: the Phase 1 plan approval covers execution
+through to the approved goal's completion, and the lead returns to the user only when the
+goal is accomplished, the work is blocked, or the approved plan itself must change.
+`templates/CLAUDE.md` gains the same durability clause on the invariant, so the rule and
+the workflow no longer fight each other. Gate the intake, not the execution.
+
 ### v4.2.1 (2026-07-03)
 
 **Fix: plugin-internal references now resolve for installed users.** The spec-gate

--- a/skills/harness-continue/SKILL.md
+++ b/skills/harness-continue/SKILL.md
@@ -240,7 +240,10 @@ Note: Opus lead runs for the full session; total cost depends on session length,
 Approve this plan?
 ```
 
-Wait for user approval before proceeding to Phase 2.
+Wait for user approval before proceeding to Phase 2. That approval is durable: it covers
+execution through to the approved goal's completion. Do not stop for further go-aheads at
+phase transitions; return to the user only when the goal is accomplished, the work is
+blocked, or the approved plan itself must change.
 
 ### Phase 2: Execute
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -13,7 +13,7 @@ supplements: Project-level CLAUDE.md files in individual repositories
 
 **ALWAYS, without exception:**
 - Address me as "{{USER_NAME}}" at all times
-- Present a plan and wait for explicit "Go ahead" before executing non-trivial work **when interacting directly with {{USER_NAME}}**. When spawned as a sub-agent or teammate, execute immediately per the Agent Autonomy rules.
+- Present a plan and wait for explicit "Go ahead" before executing non-trivial work **when interacting directly with {{USER_NAME}}**. A go-ahead is durable: it covers the approved work until its goal is accomplished; do not re-ask at intermediate steps or phase transitions. Stop again only when the goal is reached, the work is blocked, or the plan itself must change. When spawned as a sub-agent or teammate, execute immediately per the Agent Autonomy rules.
 - Verify git identity before any push/pull/clone (see Git Workflow)
 - Run existing tests before committing changes
 - Write output to files before reporting success (results must survive unexpected termination)


### PR DESCRIPTION
## What changed

Sessions governed by the template's "present a plan and wait for Go ahead" invariant were stopping at every /harness-continue phase transition to ask again, because each phase looked like new non-trivial work. The harness's design is one gate at intake, autonomy after.

- `skills/harness-continue/SKILL.md`: the Phase 1 approval is now explicitly durable; it covers execution through to the approved goal's completion, and the lead returns to the user only when the goal is accomplished, the work is blocked, or the approved plan itself must change.
- `templates/CLAUDE.md`: the Go-ahead invariant gains the same durability clause, so the personal-standards rule and the workflow no longer fight each other.
- Version 4.2.2, CHANGELOG entry.

## Testing

`bash test/run-tests.sh`: 66/66. Prose-only change; no executable content touched.

## Dependencies

None.