### PR TITLE
chore: initialize vv-harness scaffolding (OVI-44 step 0)

### DIFF
--- a/.claude/hooks/check-remaining-tasks.sh
+++ b/.claude/hooks/check-remaining-tasks.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# VV Claude Code Harness - TeammateIdle hook
+# Runs when a teammate is about to go idle.
+# Exit code 0 = allow idle (no more work)
+# Exit code 2 = send feedback, keep teammate working
+
+set -euo pipefail
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$PROJECT_ROOT"
+
+# Read hook input from stdin
+INPUT=$(cat)
+
+# Check features.json for remaining work
+# Status enum: pending, in-progress, blocked, passing, failed
+# Claimable statuses: pending (ready for work), failed (needs re-attempt)
+if [ -f ".harness/features.json" ]; then
+    CLAIMABLE=$(cat .harness/features.json | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+features = data.get('features', [])
+passing_ids = {f['id'] for f in features if f['status'] == 'passing'}
+claimable = [
+    f for f in features
+    if f['status'] in ('pending', 'failed')
+    and all(dep in passing_ids for dep in f.get('depends_on', []))
+]
+print(len(claimable))
+" 2>/dev/null || echo "0")
+
+    if [ "$CLAIMABLE" -gt 0 ]; then
+        # Find the highest priority claimable feature whose dependencies are met
+        NEXT=$(cat .harness/features.json | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+features = data.get('features', [])
+passing_ids = {f['id'] for f in features if f['status'] == 'passing'}
+claimable = [
+    f for f in features
+    if f['status'] in ('pending', 'failed')
+    and all(dep in passing_ids for dep in f.get('depends_on', []))
+]
+if claimable:
+    claimable.sort(key=lambda f: f.get('priority', 999))
+    f = claimable[0]
+    status_note = ' (retry)' if f['status'] == 'failed' else ''
+    scope = ', '.join(f.get('scope', [])) if f.get('scope') else 'no scope defined'
+    print(f'{f[\"id\"]}: {f[\"description\"]} (priority {f.get(\"priority\", \"unset\")}){status_note} [scope: {scope}]')
+" 2>/dev/null || echo "")
+
+        if [ -n "$NEXT" ]; then
+            echo "There are $CLAIMABLE claimable feature(s). Pick up the next one: $NEXT"
+            echo "Read .harness/features.json for full details, then claim it via TaskUpdate."
+            exit 2
+        fi
+    fi
+fi
+
+# No remaining work
+exit 0

--- a/.claude/hooks/enforce-scope.sh
+++ b/.claude/hooks/enforce-scope.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# VV Claude Code Harness - PreToolUse scope enforcement hook
+# Runs before Edit/Write tool calls when a teammate scope file exists.
+# Exit code 0 = allow edit
+# Exit code 2 = block edit (file outside scope)
+
+# Read hook input from stdin
+INPUT=$(cat)
+
+# Only enforce if a scope file exists (teammates only, not lead agents)
+SCOPE_FILE=".claude/teammate-scope.txt"
+if [ ! -f "$SCOPE_FILE" ]; then
+    exit 0
+fi
+
+# Extract file path from tool input
+FILE_PATH=$(echo "$INPUT" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(data.get('tool_input', {}).get('file_path', ''))
+" 2>/dev/null)
+
+if [ -z "$FILE_PATH" ]; then
+    exit 0
+fi
+
+# Normalize absolute paths to relative (tool input uses absolute paths,
+# scope patterns use relative paths like "src/auth/")
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+if [[ "$FILE_PATH" == "$PROJECT_ROOT/"* ]]; then
+    FILE_PATH="${FILE_PATH#$PROJECT_ROOT/}"
+fi
+
+# Check if file path matches any scope pattern
+while IFS= read -r pattern || [ -n "$pattern" ]; do
+    # Skip empty lines and comments
+    [[ -z "$pattern" || "$pattern" =~ ^# ]] && continue
+    # Use bash pattern matching
+    if [[ "$FILE_PATH" == $pattern* ]]; then
+        exit 0
+    fi
+done < "$SCOPE_FILE"
+
+echo "Edit blocked: $FILE_PATH is outside your assigned scope."
+echo "Your scope (from $SCOPE_FILE):"
+cat "$SCOPE_FILE" | grep -v '^#' | grep -v '^$'
+echo ""
+echo "If you need access to this file, message the lead: SendMessage({ type: \"message\", recipient: \"team-lead\", content: \"Need access to $FILE_PATH because [reason].\" })"
+exit 2

--- a/.claude/hooks/statusline.sh
+++ b/.claude/hooks/statusline.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# statusLine command: renders live harness feature progress for the current project.
+# Reads session JSON on stdin; locates .harness/ via workspace.project_dir (fallback: cwd).
+# Prints one line, or an empty line when there is no harness or the input is malformed.
+python3 -c '
+import json, os, sys
+
+
+def render():
+    data = json.load(sys.stdin)
+    root = (data.get("workspace") or {}).get("project_dir") or data.get("cwd") or ""
+    harness = os.path.join(root, ".harness")
+    if not root or not os.path.isdir(harness):
+        return ""
+    feats = json.load(open(os.path.join(harness, "features.json"))).get("features", [])
+    passing = sum(1 for f in feats if f.get("status") == "passing")
+    line = f"⬡ {passing}/{len(feats)} passing"
+    wip = [str(f.get("id", "?")) for f in feats if f.get("status") == "in-progress"]
+    if wip:
+        line += " · " + ",".join(wip) + " in-progress"
+    if os.path.exists(os.path.join(harness, "SESSION_INCOMPLETE")):
+        line += " · ⚠ last session incomplete"
+    return line
+
+
+try:
+    print(render())
+except Exception:
+    print("")
+' 2>/dev/null || true
+exit 0

--- a/.claude/hooks/verify-git-identity.sh
+++ b/.claude/hooks/verify-git-identity.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# VV Claude Code Harness - PreToolUse git identity verification hook
+# Runs before Bash tool calls that contain git push/pull/clone.
+# Exit code 0 = allow
+# Exit code 2 = block (identity mismatch)
+
+# Read hook input from stdin
+INPUT=$(cat)
+
+# Extract the command from tool input
+COMMAND=$(echo "$INPUT" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(data.get('tool_input', {}).get('command', ''))
+" 2>/dev/null)
+
+# Only check git push, pull, clone, fetch commands
+if ! echo "$COMMAND" | grep -qE 'git\s+(push|pull|clone|fetch)'; then
+    exit 0
+fi
+
+# Check if harness.json exists with git identity
+if [ ! -f ".harness/harness.json" ]; then
+    exit 0
+fi
+
+# Extract expected identity from harness.json
+EXPECTED_NAME=$(python3 -c "
+import json
+with open('.harness/harness.json') as f:
+    data = json.load(f)
+print(data.get('git_identity', {}).get('user_name', ''))
+" 2>/dev/null)
+
+EXPECTED_EMAIL=$(python3 -c "
+import json
+with open('.harness/harness.json') as f:
+    data = json.load(f)
+print(data.get('git_identity', {}).get('user_email', ''))
+" 2>/dev/null)
+
+if [ -z "$EXPECTED_NAME" ] || [ -z "$EXPECTED_EMAIL" ]; then
+    exit 0
+fi
+
+# Check current git identity
+CURRENT_NAME=$(git config user.name 2>/dev/null)
+CURRENT_EMAIL=$(git config user.email 2>/dev/null)
+
+if [ "$CURRENT_NAME" != "$EXPECTED_NAME" ] || [ "$CURRENT_EMAIL" != "$EXPECTED_EMAIL" ]; then
+    echo "Git push blocked: identity mismatch."
+    echo ""
+    echo "Expected (from .harness/harness.json):"
+    echo "  $EXPECTED_NAME <$EXPECTED_EMAIL>"
+    echo ""
+    echo "Current:"
+    echo "  $CURRENT_NAME <$CURRENT_EMAIL>"
+    echo ""
+    echo "Fix with: git config user.name \"$EXPECTED_NAME\" && git config user.email \"$EXPECTED_EMAIL\""
+    exit 2
+fi
+
+exit 0

--- a/.claude/hooks/verify-task-quality.sh
+++ b/.claude/hooks/verify-task-quality.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Harness - TaskCompleted quality gate hook
+# Runs when a teammate marks a task as complete.
+# Exit code 0 = accept completion
+# Exit code 2 = reject completion, send feedback to teammate
+#
+# Staged evaluation (inspired by HyperAgents):
+#   Stage 1: smoke_test — fast compile/syntax check
+#   Stage 2: full_test  — complete suite with coverage
+# Failing at Stage 1 avoids the cost of a full test run.
+# correction_cycles is incremented in features.json on any rejection.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$PROJECT_ROOT"
+
+# Read hook input from stdin
+INPUT=$(cat)
+
+# Try to extract feature ID from task metadata (if TaskCreate used metadata.feature_id)
+FEATURE_ID=$(echo "$INPUT" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+# Check task metadata first, then fall back to parsing task subject for 'FXXX:'
+metadata = data.get('task', {}).get('metadata', {})
+feature_id = metadata.get('feature_id', '')
+if not feature_id:
+    subject = data.get('task', {}).get('subject', '')
+    if ':' in subject:
+        candidate = subject.split(':')[0].strip()
+        if candidate.startswith('F') and candidate[1:].isdigit():
+            feature_id = candidate
+print(feature_id)
+" 2>/dev/null || echo "")
+
+if [ ! -f ".harness/init.sh" ]; then
+    echo "Task rejected: .harness/init.sh not found. Cannot verify tests pass."
+    echo "Run /harness-init to create the test script, or create it manually."
+    exit 2
+fi
+
+# Increment correction_cycles for all in-progress features.
+# This tracks how many times the quality gate rejected completion —
+# useful for retrospectives and dynamic model selection.
+increment_correction_cycles() {
+    if [ -f ".harness/features.json" ]; then
+        python3 - "$FEATURE_ID" <<'PYEOF'
+import json, sys
+target_id = sys.argv[1] if len(sys.argv) > 1 and sys.argv[1] else None
+try:
+    with open('.harness/features.json', 'r') as f:
+        data = json.load(f)
+    changed = False
+    for feature in data.get('features', []):
+        if feature.get('status') == 'in-progress':
+            if target_id is None or feature.get('id') == target_id:
+                feature['correction_cycles'] = feature.get('correction_cycles', 0) + 1
+                changed = True
+    if changed:
+        with open('.harness/features.json', 'w') as f:
+            json.dump(data, f, indent=2)
+except Exception as e:
+    pass  # Don't fail the hook on JSON errors
+PYEOF
+    fi
+}
+
+# Stage 1: Smoke test (fast compile/syntax check)
+echo "Stage 1: Smoke test..." >&2
+SMOKE_OUTPUT=$(bash .harness/init.sh smoke_test 2>&1) || {
+    echo "Task rejected: smoke test failed. Fix compilation errors before marking complete."
+    echo ""
+    echo "Smoke test output:"
+    echo "$SMOKE_OUTPUT" | tail -20
+    increment_correction_cycles
+    exit 2
+}
+
+# Stage 2: Full test suite
+echo "Stage 2: Full test suite..." >&2
+FULL_OUTPUT=$(bash .harness/init.sh full_test 2>&1) || {
+    echo "Task rejected: tests are failing. Fix the failures before marking complete."
+    echo ""
+    echo "Test output (last 20 lines):"
+    echo "$FULL_OUTPUT" | tail -20
+    increment_correction_cycles
+    exit 2
+}
+
+# Remind about stale in-progress features
+if [ -f ".harness/features.json" ]; then
+    IN_PROGRESS=$(python3 -c "
+import json, sys
+with open('.harness/features.json') as f:
+    data = json.load(f)
+in_progress = [f for f in data.get('features', []) if f['status'] == 'in-progress']
+print(len(in_progress))
+" 2>/dev/null || echo "0")
+    if [ "$IN_PROGRESS" -gt 0 ]; then
+        echo "Note: $IN_PROGRESS feature(s) still marked in-progress. Update features.json if your feature is complete."
+    fi
+fi
+
+# All checks passed
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,75 @@
+{
+  "statusLine": {
+    "type": "command",
+    "command": "bash .claude/hooks/statusline.sh"
+  },
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "permissions": {
+    "allow": [
+      "Bash(bash .harness/init.sh*)",
+      "Bash(bash .claude/hooks/*.sh)",
+      "Bash(git config user.name)",
+      "Bash(git config user.email)",
+      "Bash(git rev-parse*)",
+      "Bash(git log*)",
+      "Bash(git status*)",
+      "Read(./.harness/**)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/enforce-scope.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/verify-git-identity.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE=$(cat | jq -r '.tool_input.file_path // empty'); if [ -n \"$FILE\" ]; then case \"$FILE\" in *.sh) bash -n \"$FILE\" 2>&1 ;; *.json) python3 -m json.tool \"$FILE\" > /dev/null 2>&1 || echo \"JSON syntax error: $FILE\" ;; esac; fi",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/verify-task-quality.sh"
+          }
+        ]
+      }
+    ],
+    "TeammateIdle": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/check-remaining-tasks.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
-# Claude Code local config
-.claude/
+# Claude Code local config (shared hooks and settings are committed)
+.claude/*
+!.claude/hooks/
+!.claude/settings.json
+.claude/settings.local.json
+
+# Harness transient session state
+.harness/SESSION_INCOMPLETE
 
 # OS files
 .DS_Store

--- a/.harness/claude-progress.txt
+++ b/.harness/claude-progress.txt
@@ -1,0 +1,12 @@
+# Claude Progress Log
+# Project: vv-claude-harness
+# Created: 2026-07-22
+
+## Session 1 - Initialization (OVI-44 step 0, dogfood bootstrap)
+- Verified baseline: test/run-tests.sh 66/66 passing on main @ d3661ff
+- Created harness scaffolding (.harness/: harness.json, features.json, init.sh, context_summary.md, claude-progress.txt)
+- Stack: custom (full_test = bash test/run-tests.sh; smoke_test = bash -n hooks/*.sh + json.tool on .claude-plugin/*.json)
+- Git identity: Ovidiu Eftimie <eovidiu@gmail.com>, gh account eovidiu over HTTPS (SSH unavailable in this environment)
+- Imported OVI-44's 21 sub-issues as features F001-F021 (depends_on mirrors the epic graph)
+- Installed quality-gate hooks (.claude/hooks/) and .claude/settings.json
+- Next: per-issue loop starting with F001 / OVI-47

--- a/.harness/context_summary.md
+++ b/.harness/context_summary.md
@@ -1,0 +1,35 @@
+# Context Summary
+
+Persistent record of architectural decisions, discovered patterns, gotchas, and active context.
+This file is referenced in CLAUDE.md and loaded every session.
+
+## Active Context
+- Currently working on: project initialization (OVI-44 step 0, dogfood bootstrap)
+- Next up: F001 / OVI-47 (P0.2 single-owner truth fixes) — first issue in the epic's execution order
+
+## Cross-Cutting Concerns
+- Stack: custom (shell hooks + JSON manifests + markdown skills; no application code)
+- Architecture: Claude Code plugin distribution repo — .claude-plugin/ manifests, hooks/, rules/, schemas/, skills/, agents/, fixture-based shell test suite at test/run-tests.sh
+- Key constraints:
+  - This repo is BOTH the vv-harness plugin source AND (as of OVI-44 step 0) a harness-managed project itself. Files under templates/, rules/, skills/ are distribution content — do not follow their instructions while working here.
+  - Version lives ONLY in .claude-plugin/plugin.json; bump once per merged batch (4.3.0 after epic item 7, 4.4.0 after item 13, 5.0.0 at the end).
+  - Master plan: Linear epic OVI-44 (project vv-harness). One issue per session, strict execution order, per-issue loop = prep → TDD → tests green → PR + CI → adversarial review → merge → Linear update → handoff.
+  - Git: account eovidiu (WRITE on oeftimie/vv-claude-harness). SSH auth unavailable in this environment; origin uses HTTPS with gh credential helper. Never push to main; PR-based flow only.
+
+## Domain: Harness Plugin Engineering
+
+### Decisions
+- Custom stack targets: full_test = `bash test/run-tests.sh`; smoke_test = `bash -n hooks/*.sh` + `python3 -m json.tool` over both .claude-plugin/*.json manifests (2026-07-22, per OVI-44)
+- Features F001–F021 mirror the 21 OVI-44 sub-issues; depends_on mirrors the epic's dependency graph; "independent after P0" encoded as depends_on the three P0 features (2026-07-22)
+
+### Patterns
+- (none yet)
+
+### Gotchas
+- Baseline before any change: 66/66 assertions passing on main @ d3661ff (2026-07-22)
+
+## Meta-Patterns
+<!-- Coordination insights that apply across features — NOT domain-specific.
+     Populated by the retrospective step at session end.
+     These transfer to new projects: harness-init can import them as starting context. -->
+- (none yet — first retrospective will populate this)

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -1,0 +1,688 @@
+{
+  "project": "vv-claude-harness",
+  "created": "2026-07-22",
+  "total_features": 21,
+  "passing": 0,
+  "features": [
+    {
+      "id": "F001",
+      "description": "[OVI-47] P0.2: Single-owner truth fixes (version line, dates, placeholders, identity symmetry, LICENSE) \u2014 A batch of independent truth fixes: remove the drifted README version line, reconcile CHANGELOG/README dates against git history, strip a {{USER_NAME}} placeholder from a shipped rule, guard a broken session-start fallback path, make the identity check symmetric on name and email, de-stale the fixture, and add a LICENSE. Amendment adds transcript-secrets and untrusted-content rules.",
+      "priority": 1,
+      "status": "pending",
+      "scope": [
+        "README.md",
+        "CHANGELOG.md",
+        "rules/task-completion.md",
+        "hooks/session-start.sh",
+        "skills/harness-init/verify-git-identity.sh.template",
+        "test/fixtures/harness-project/.harness/harness.json",
+        "LICENSE",
+        "test/run-tests.sh",
+        "templates/CLAUDE.md",
+        "agents/researcher.md"
+      ],
+      "depends_on": [],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-47. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "5f842486384c853b7bc3c21824ac26963806456eab777a0a116077bc3fbb6ed9",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-47"
+      }
+    },
+    {
+      "id": "F002",
+      "description": "[OVI-46] P0.1: Arm scope enforcement in the operational spawn path \u2014 Make mechanical scope enforcement actually fire in the Agent Teams spawn path: write .claude/teammate-scope.txt from each feature's scope array before every teammate spawn, rewrite on reassignment, delete at teardown, and add a session-start warning when scope enforcement is unarmed for in-progress assigned features.",
+      "priority": 2,
+      "status": "pending",
+      "scope": [
+        "skills/harness-continue/SKILL.md",
+        "skills/harness-continue/team-spawn-prompts.md",
+        "hooks/session-start.sh",
+        "rules/agent-teams-protocol.md",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-46. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "51d8c735b838e909b8b704b7aa960fcc561cfb02f8891429a3899af7ab7f9c80",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-46"
+      }
+    },
+    {
+      "id": "F003",
+      "description": "[OVI-48] P0.3: Hook robustness + test coverage for the 5 per-project hook templates \u2014 Harden the 5 per-project hook templates and give them fixture test coverage: switch check-remaining-tasks to tolerant .get() parsing, fix verify-task-quality's metric corruption and make its features.json write atomic with trailing newline, and extend run-tests.sh with bash -n and exit-code fixtures for all templates. Amendment requires CLAUDE_PROJECT_DIR-absolute hook invocation.",
+      "priority": 3,
+      "status": "pending",
+      "scope": [
+        "skills/harness-init/check-remaining-tasks.sh.template",
+        "skills/harness-init/verify-task-quality.sh.template",
+        "skills/harness-init/enforce-scope.sh.template",
+        "skills/harness-init/verify-git-identity.sh.template",
+        "skills/harness-init/init.sh.template",
+        "test/run-tests.sh",
+        "skills/harness-init/SKILL.md"
+      ],
+      "depends_on": [],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-48. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "dff38aa4526c4fbc3a985a69d2a60acf4896e45307b97def84a1401445151947",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-48"
+      }
+    },
+    {
+      "id": "F004",
+      "description": "[OVI-49] P1.1: Canonical feature schema (one owner) + stdlib validator \u2014 Create schemas/feature.schema.json as the single authoritative definition of the features.json envelope and 16-field feature object, plus a stdlib-only scripts/validate-features.py validator with location-aware errors. Deduplicate the field-by-field prose from the protocol, harness-init SKILL, and README into schema links, and wire validation into the test suite.",
+      "priority": 4,
+      "status": "pending",
+      "scope": [
+        "schemas/feature.schema.json",
+        "scripts/validate-features.py",
+        "rules/agent-teams-protocol.md",
+        "skills/harness-init/SKILL.md",
+        "README.md",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-49. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "eca202c2e63ac1c6b45911be12047f6f5c305efb052a0a310645862b575222b6",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-49"
+      }
+    },
+    {
+      "id": "F005",
+      "description": "[OVI-61] S1: Hostile-gate tests + cold-start dogfood release gate \u2014 Add an adversarial section to test/run-tests.sh where real attacks (out-of-scope edits, state-file writes, git push under mismatched identity, failing-smoke commits, secret-shaped staged additions) must be denied with the invariant named, and add docs/release-checklist.md defining a cold-start dogfood gate recorded to MAINTENANCE_LOG.md, run once as run #0. Ownership note: this issue CREATES MAINTENANCE_LOG.md and writes the dogfood-gate series' run #0; per OVI-61 the log is OVI-56's durable state, and dogfood entries are a distinct record series from OVI-56's maintenance-probe runs.",
+      "priority": 5,
+      "status": "pending",
+      "scope": [
+        "test/run-tests.sh",
+        "docs/release-checklist.md",
+        "MAINTENANCE_LOG.md",
+        "CLAUDE.md"
+      ],
+      "depends_on": [
+        "F003"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-61. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "c020766fcf257b100fa06ea45b601d4914a55ebe73a51bdb9b0bde0665e88773",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-61"
+      }
+    },
+    {
+      "id": "F006",
+      "description": "[OVI-62] S2: /harness-doctor: instance health check + the upgrade engine \u2014 Add skills/harness-doctor/SKILL.md, a report-first idempotent instance health check (python3/git presence, hook set and executability, settings.json wiring, gitignore rules, harness/features validation, version drift, mld non-injection) that classifies committed vs local drift and offers a --fix upgrade mode. Replace INSTALL.md's manual upgrade steps and wire into harness-continue Step 2.5.",
+      "priority": 6,
+      "status": "pending",
+      "scope": [
+        "skills/harness-doctor/SKILL.md",
+        "INSTALL.md",
+        "skills/harness-continue/SKILL.md",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F004"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-62. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "34890e1939fef0f44d5bd917e2abd9c8cd9a2b2b103e930d30b80096a88de134",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-62"
+      }
+    },
+    {
+      "id": "F007",
+      "description": "[OVI-56] P4.1: Platform-drift maintenance loop (runbook + weekly CI cron + workaround retirement) \u2014 Add docs/maintenance-runbook.md answering HE's five loop questions plus a probe checklist with explicit workaround-retirement conditions, a weekly .github/workflows/maintenance.yml cron that runs the suite and probes the latest CLI, a seeded MAINTENANCE_LOG.md run #0, and a repo rule requiring every workaround to carry a retirement condition. Ownership note: MAINTENANCE_LOG.md already exists when this issue runs (created by OVI-61/F005 with dogfood run #0); this issue formalizes the log format (newest first, one entry per run) and APPENDS the maintenance-probe series' run #0 \u2014 it must not re-create the file.",
+      "priority": 7,
+      "status": "pending",
+      "scope": [
+        "docs/maintenance-runbook.md",
+        ".github/workflows/maintenance.yml",
+        "MAINTENANCE_LOG.md",
+        "CLAUDE.md",
+        "rules/agent-teams-protocol.md",
+        "skills/harness-continue/team-spawn-prompts.md",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F001",
+        "F002",
+        "F003",
+        "F005"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-56. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "4498887aa93923f6b5031bfe2db8a5bf27d519e39c8ce46173cbb6a627604233",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-56"
+      }
+    },
+    {
+      "id": "F008",
+      "description": "[OVI-50] P1.2: One state boundary: shared harness_state.py for per-project hooks \u2014 Introduce skills/harness-init/harness_state.py.template as the single stdlib state boundary (load, next-claimable, counts, atomic increment-correction-cycles) installed to .claude/hooks/. Refactor check-remaining-tasks and verify-task-quality templates to call it, enforce a single features.json writer, and delegate session-start's next-claimable algorithm to it when present.",
+      "priority": 8,
+      "status": "pending",
+      "scope": [
+        "skills/harness-init/harness_state.py.template",
+        "skills/harness-init/check-remaining-tasks.sh.template",
+        "skills/harness-init/verify-task-quality.sh.template",
+        "hooks/session-start.sh",
+        "skills/harness-init/SKILL.md",
+        "INSTALL.md",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F003",
+        "F004"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-50. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "518945e505ecc0dd2168a64814a08e18586fc4d442e4ab9c276b2f0500ce5161",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-50"
+      }
+    },
+    {
+      "id": "F009",
+      "description": "[OVI-51] P2.1: Mechanize lead-only state ownership + best-effort Bash write boundary \u2014 Extend enforce-scope.sh to deny Edit/Write to lead-owned state files (features.json, context_summary.md, claude-progress.txt) and register it on the Bash matcher to best-effort block write commands (redirects, tee, cp, mv, sed -i, rm) outside scope. Amendment adds JSON permissionDecision deny form, compound-command segmentation, and Failure posture header lint.",
+      "priority": 9,
+      "status": "pending",
+      "scope": [
+        "skills/harness-init/enforce-scope.sh.template",
+        "skills/harness-init/SKILL.md",
+        "agents/reviewer.md",
+        "README.md",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F002"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-51. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "4596d60e282d0f4322fa9461524a2df7fb3566306f9311bc795641f16ec1b122",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-51"
+      }
+    },
+    {
+      "id": "F010",
+      "description": "[OVI-52] P2.2: Claim-matched proof, per-feature coverage target, delivery closure \u2014 Extend the feature schema with optional proof, coverage_target, and delivered fields; make the protocol the single owner of the passing/done/shipped definition via a completion proof packet; have verify-task-quality honor coverage_target and warn on passing-without-proof; and extend session-end gap detection. Amendment adds QA binding, design_contract, and the conformance evidence_type.",
+      "priority": 10,
+      "status": "pending",
+      "scope": [
+        "schemas/feature.schema.json",
+        "rules/agent-teams-protocol.md",
+        "skills/harness-init/verify-task-quality.sh.template",
+        "hooks/session-end.sh",
+        "skills/harness-issue-prep/SKILL.md",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F004"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-52. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "34df31c97207cc6eba72e4f469ed557754be290ef58a2805ca23a5501afb4dae",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-52"
+      }
+    },
+    {
+      "id": "F011",
+      "description": "[OVI-64] S4: Commit-content gate (secret scan + compound stage-and-commit denial) \u2014 Add skills/harness-init/commit-gate.sh.template, a PreToolUse Bash gate firing only on git commit that denies compound stage-and-commit forms, scans staged additions for secret shapes, and offers an opt-in house-style scan, emitting JSON permissionDecision denials with findings and repairs. Extend the fixture harness with six cases and document the tier in README and templates/CLAUDE.md.",
+      "priority": 11,
+      "status": "pending",
+      "scope": [
+        "skills/harness-init/commit-gate.sh.template",
+        "test/run-tests.sh",
+        "README.md",
+        "templates/CLAUDE.md"
+      ],
+      "depends_on": [
+        "F009"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-64. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "939030bcda3f62f3de0dd3d18bc2ce99f5b816f480bb24aa104a87a5c4335f7b",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-64"
+      }
+    },
+    {
+      "id": "F012",
+      "description": "[OVI-53] P2.3: Portable readiness-stamp signing (Linux/CI parity for the spec gate) \u2014 Make readiness-stamp HMAC signing portable off macOS: implement a secret resolution chain (Keychain, then a 0600 key file, then env var), compute HMAC via python3 stdlib, generalize the runner kick to a configurable prep.kick_command, enforce key hygiene/redaction, and exercise mint+verify against all 6 consumer rules on ubuntu CI.",
+      "priority": 12,
+      "status": "pending",
+      "scope": [
+        "schemas/readiness-stamp.md",
+        "skills/harness-issue-prep/SKILL.md",
+        "skills/harness-issue-debug/SKILL.md",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F001",
+        "F002",
+        "F003"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-53. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "5522141843d428f3446dba06aad18a89b39140d2630a14eb32ce2a6a514ba504",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-53"
+      }
+    },
+    {
+      "id": "F013",
+      "description": "[OVI-63] S3: Mechanical stamp for /harness-init (+ upgrade mode) \u2014 Add scripts/stamp.sh that deterministically emits every framework-fixed file (settings.json from templates, byte-verbatim hooks, harness.json/features.json skeletons, gitignore line) from an answers file with new/upgrade collision handling, moving the 5 inline settings JSON variants into skills/harness-init/templates/ and shrinking harness-init SKILL.md Steps 3/3.5/3.6 to gather-answers-and-stamp.",
+      "priority": 13,
+      "status": "pending",
+      "scope": [
+        "scripts/stamp.sh",
+        "skills/harness-init/SKILL.md",
+        "skills/harness-init/templates/",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F008",
+        "F009"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-63. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "8b7ce73c52e6dae706e5ca0390f6682e3afbcb67bdc4672b58b87097be105747",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-63"
+      }
+    },
+    {
+      "id": "F014",
+      "description": "[OVI-54] P3.1: MLD builder telemetry (.harness/mld/) with a hard non-injection guarantee \u2014 Add lead-only MLD telemetry: at session end append .harness/mld/YYYY-MM-DD-<id>.md with Mistakes/Learnings/Desires sections, with a hard guarantee that session-start never reads mld/ (tested across all SessionStart sources). Add rules/mld-review.md defining the review cadence and disposition, and document committing mld/ by default.",
+      "priority": 14,
+      "status": "pending",
+      "scope": [
+        "rules/task-completion.md",
+        "skills/harness-continue/SKILL.md",
+        "hooks/session-start.sh",
+        "hooks/session-end.sh",
+        "rules/mld-review.md",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F001",
+        "F002",
+        "F003"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-54. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "f89fce81a27b939cabfaa5817a7fbaa22e494b9fd143b684344ed1e9a37ad9a3",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-54"
+      }
+    },
+    {
+      "id": "F015",
+      "description": "[OVI-55] P3.2: Promotion ladder + ablation pass in the Phase 5.5 retrospective \u2014 Add two mandatory retrospective passes to harness-continue Phase 5.5: a promotion pass classifying each pattern/MLD entry to its smallest durable owner, and an ablation pass retiring controls that no longer earn their cost, with candidates written to a new .harness/HARNESS_BACKLOG.md. Amendment adds candidate lifecycle (score/status/last_seen), 60-day decay, a capped canon, and gap entries.",
+      "priority": 15,
+      "status": "pending",
+      "scope": [
+        "skills/harness-continue/SKILL.md",
+        "rules/context-summary.md",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F001",
+        "F002",
+        "F003"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-55. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "88f515e7df12ee2b0e74f17003930bbaedc3f2c7054ee3ad4cacb134f47fc14d",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-55"
+      }
+    },
+    {
+      "id": "F016",
+      "description": "[OVI-57] P4.2: Worker epoch record + requalification checklist (with subtraction pass) \u2014 Add an optional harness.json worker block recording CLI version and per-role models, an epoch check in harness-continue (Step 2.6) that prompts requalification on large version deltas, and docs/requalification.md with a subtraction pass listing removal candidates. Amendment adds a single bindings table, verified-live annotations, and the CLAUDE_CODE_SUBAGENT_MODEL warning.",
+      "priority": 16,
+      "status": "pending",
+      "scope": [
+        "schemas/feature.schema.json",
+        "skills/harness-continue/SKILL.md",
+        "docs/requalification.md",
+        "rules/agent-teams-protocol.md",
+        "templates/CLAUDE.md",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F004"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-57. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "245d02932b5bdca60dd2796f0e23cec1e1d268bb8a8f23c88f5e0f550261dea4",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-57"
+      }
+    },
+    {
+      "id": "F017",
+      "description": "[OVI-65] A1: Author-blind conformance tester (anti-reward-hacking gate) \u2014 Add agents/conformance-tester.md (vv-harness:conformance-tester), an agent that derives behavior tests from the verified feature description alone, forbidden from reading the implementation diff, completion message, or implementer tests, writes conformance tests, and reports PASS/FAIL/NOT-TESTABLE per criterion. Wire an optional harness-continue Phase 4 spawn for elevated-risk features recording evidence_type conformance.",
+      "priority": 17,
+      "status": "pending",
+      "scope": [
+        "agents/conformance-tester.md",
+        "skills/harness-continue/SKILL.md",
+        "schemas/feature.schema.json",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F010"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-65. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "be98562a1518d4602f76dc08d3fa5096d1f3cc91b0a45fec4f1ec304dde7e791",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-65"
+      }
+    },
+    {
+      "id": "F018",
+      "description": "[OVI-66] A2: Optional dual-engine review (Codex second reviewer + synthesizer rules) \u2014 Add an optional harness.json review block enabling a blind second-engine (Codex CLI) review run in parallel with the Claude reviewer, with explicit skip-with-note when the CLI is absent, plus synthesizer rules (dedupe by defect, single-engine CRITICAL survives, cross-engine agreement raises confidence, provenance verified via git show merge-base). Document in the protocol and README.",
+      "priority": 18,
+      "status": "pending",
+      "scope": [
+        "rules/agent-teams-protocol.md",
+        "agents/reviewer.md",
+        "README.md",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-66. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "d00ea3fcf1bc87eb0cb93a6fa10dc1537927aaa522143e2270c87b301fc903dd",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-66"
+      }
+    },
+    {
+      "id": "F019",
+      "description": "[OVI-58] P5.1: AGENTS.md routing layer for the distribution repo (cross-agent legibility) \u2014 Add a root AGENTS.md agent-agnostic operating guide (repo identity, distribution-vs-config distinction, test command, single-version rule, routing) and rewrite CLAUDE.md to a one-line @AGENTS.md import plus Claude-specific overlay with zero duplicated sentences, optionally adding up to two nested guides. Verify the import works on the current CLI.",
+      "priority": 19,
+      "status": "pending",
+      "scope": [
+        "AGENTS.md",
+        "CLAUDE.md",
+        "skills/AGENTS.md",
+        "test/AGENTS.md"
+      ],
+      "depends_on": [
+        "F001",
+        "F002",
+        "F003"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-58. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "8faf04032ef83ec0ff9e83b40c77a21a0ee6609aac71266b39000b1ab5d313ac",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-58"
+      }
+    },
+    {
+      "id": "F020",
+      "description": "[OVI-59] P5.2: New skill harness-improve (HE's improve-one-harnessed-job loop) \u2014 Add skills/harness-improve/SKILL.md implementing an observation-first improvement loop in 7 steps (job contract, baseline from vv evidence, earliest failed handoff classified to a vv-native owner, one hypothesis, smallest change, fresh-session rerun, retain/revise/remove), with an embedded result-record template, guardrail sentences, and grep/frontmatter test coverage.",
+      "priority": 20,
+      "status": "pending",
+      "scope": [
+        "skills/harness-improve/SKILL.md",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F001",
+        "F002",
+        "F003"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-59. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "351f88f5510033bfa4208175e23d3de604bb0045e423c39567c8aafaf121f9fc",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-59"
+      }
+    },
+    {
+      "id": "F021",
+      "description": "[OVI-60] P5.3: Eval method doc + first behavioral eval (orientation recovery A/B) \u2014 Add evals/README.md defining vv's proportionate eval contract (decision-first, one intervention, fresh sessions, separate availability/retrieval/relevance facts, invalid-result checklist, fixed-worker recording) and evals/orientation-recovery.md, an executed A/B on whether SessionStart orientation changes next-session behavior, with a committed results table and a stated decision.",
+      "priority": 21,
+      "status": "pending",
+      "scope": [
+        "evals/README.md",
+        "evals/orientation-recovery.md",
+        "README.md",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F001",
+        "F002",
+        "F003"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Linear: OVI-60. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": null,
+      "spec": {
+        "hash": "3bae3e5248a5fa98c76f04c51e2587826a62dfbcb176483e4532983b50a2ed1c",
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-07-22T18:15:31Z",
+        "source": "linear:OVI-60"
+      }
+    }
+  ]
+}

--- a/.harness/harness.json
+++ b/.harness/harness.json
@@ -1,0 +1,13 @@
+{
+  "project": "vv-claude-harness",
+  "stack": "custom",
+  "created": "2026-07-22",
+  "harness": "vv-harness",
+  "git_identity": {
+    "user_name": "Ovidiu Eftimie",
+    "user_email": "eovidiu@gmail.com",
+    "ssh_key": "none (SSH unavailable; HTTPS via gh credential helper, account eovidiu)",
+    "ssh_host": "github.com"
+  },
+  "team_structure": null
+}

--- a/.harness/init.sh
+++ b/.harness/init.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Harness init.sh - build/test runner for vv-claude-harness (stack: custom)
+# Usage: .harness/init.sh [smoke_test|full_test]
+# Default: full_test
+#
+# smoke_test — fast syntax/manifest check (<15s). Used by the
+#              TaskCompleted hook as a first-pass rejection gate.
+# full_test  — complete fixture-based test suite. Used by the lead's
+#              synthesis step and session-end validation.
+
+set -e
+
+TARGET=${1:-full_test}
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+echo "=== Harness ${TARGET} ==="
+echo "Project: $PROJECT_ROOT"
+echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo ""
+
+case "$TARGET" in
+    smoke_test)
+        echo "--- Shell Syntax Check (hooks/) ---"
+        for f in hooks/*.sh; do
+            bash -n "$f"
+            echo "OK: $f"
+        done
+        echo ""
+        echo "--- Plugin Manifest JSON Check ---"
+        python3 -m json.tool .claude-plugin/plugin.json > /dev/null
+        echo "OK: .claude-plugin/plugin.json"
+        python3 -m json.tool .claude-plugin/marketplace.json > /dev/null
+        echo "OK: .claude-plugin/marketplace.json"
+        ;;
+    full_test)
+        echo "--- Test Suite ---"
+        bash test/run-tests.sh
+        ;;
+    *)
+        echo "ERROR: unknown target '$TARGET' (expected smoke_test or full_test)" >&2
+        exit 1
+        ;;
+esac
+
+echo ""
+echo "=== ${TARGET} Complete ==="

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,3 +32,17 @@ Files under `templates/`, `rules/`, and `skills/` are **distribution content**, 
 - Other changes are documentation and template edits
 - The version number lives ONLY in `.claude-plugin/plugin.json` (`version`). It is the canonical plugin version and the update cache key: users only receive updates when it is bumped. Do not introduce other version locations that need syncing.
 - `templates/CLAUDE.md` keeps its `{{USER_NAME}}` placeholders; personalization is a documented manual step in INSTALL.md, not installer templating
+
+## Harness
+
+This project uses the Long-Running Agent Harness (vv-harness plugin) to manage its own v5 upgrade (Linear epic OVI-44). The distribution-content caveat above still applies: `templates/`, `rules/`, and `skills/` remain plugin source, but `.harness/` and `.claude/` are live project state for this repo.
+
+- Feature tracking: `.harness/features.json` (F001–F021 mirror the OVI-44 sub-issues)
+- Context and decisions: `.harness/context_summary.md` (READ THIS at session start)
+- Progress handoff: `.harness/claude-progress.txt`
+- Build/test: `.harness/init.sh` (`smoke_test` = shell syntax + manifest JSON checks; `full_test` = `bash test/run-tests.sh`)
+- Quality gates: `.claude/hooks/` (TaskCompleted, TeammateIdle, scope, git identity)
+
+## Git Identity
+
+This project uses: Ovidiu Eftimie <eovidiu@gmail.com> (GitHub account `eovidiu`) over HTTPS with the gh credential helper; SSH is not available in this environment. Always verify identity before push/pull/clone operations. Never push directly to main — PR-based flow only.


### PR DESCRIPTION
## What changed

Dogfood bootstrap per Linear epic OVI-44 step 0: this repo becomes a harness-managed project for its own v5 upgrade.

- `.harness/` scaffolding: `harness.json` (stack: custom), `init.sh` (`full_test` = `bash test/run-tests.sh`; `smoke_test` = `bash -n hooks/*.sh` + `python3 -m json.tool` on both `.claude-plugin/*.json`), `context_summary.md`, `claude-progress.txt`
- `.harness/features.json`: 21 features (F001–F021) imported 1:1 from the OVI-44 sub-issues (OVI-46..66), `depends_on` mirroring the epic's dependency graph, each carrying a spec-gate PASS stamp
- `.claude/hooks/` + `.claude/settings.json`: per-project quality gates (scope enforcement, git identity, TaskCompleted test gate, TeammateIdle, status line) installed from the plugin's own harness-init templates
- `.gitignore`: un-ignores the shared `.claude/` hooks/settings, ignores `.claude/settings.local.json` and transient `.harness/SESSION_INCOMPLETE`
- `CLAUDE.md`: harness + git identity sections appended

## Why

OVI-44's self-execution protocol: the upgrade runs under the harness it upgrades, so retrospectives and operational metrics accumulate from the first issue onward.

## Testing

- `bash test/run-tests.sh`: 66/66 passing before and after (scaffolding touches no plugin source)
- `.harness/init.sh smoke_test` and `full_test` both verified
- All five hooks execute with expected exit codes on empty payloads
- Spec gate (vv-harness:spec-verification, one ASK round resolved from Linear primary text): final verdict PASS

## Dependencies

None. First PR of the epic; per-issue work starts with OVI-47 after merge.