### PR TITLE
chore: allow gh pr merge in project permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,7 @@
       "Bash(git rev-parse*)",
       "Bash(git log*)",
       "Bash(git status*)",
+      "Bash(gh pr merge*)",
       "Read(./.harness/**)"
     ]
   },


### PR DESCRIPTION
## What changed

Adds `Bash(gh pr merge*)` to the permission allowlist in `.claude/settings.json`, so sessions on this project can merge reviewed PRs without a manual permission grant each time.

## Why

Requested by Ovidiu after the OVI-44 step-0 merge was blocked by the permission classifier. The per-issue loop ends in a merge every session; this removes the recurring manual step while leaving all other gates (CI, adversarial review) in place.

## Testing

`jq -e` validates the settings file; the allowlist parses and contains the new rule.