### PR TITLE
chore: session 2 meta close (retrospective + handoff refresh)

### DIFF
--- a/.harness/claude-progress.txt
+++ b/.harness/claude-progress.txt
@@ -14,9 +14,9 @@
 
 ## Session 2 - 2026-07-22 (single-session)
 - Feature: F001 - [OVI-47] P0.2 single-owner truth fixes
-- Status: complete (pending PR merge)
+- Status: complete (PR #23 merged to main @ d5c0e0f; OVI-47 Done in Linear)
 - Tests: 76/76 passing (66 baseline + 10 new; TDD red phase confirmed 9 failing first)
 - Coverage: n/a (shell suite, no coverage tooling; full_test is the gate)
 - Decisions: fixture frozen at 4.0.0 with _note; MIT license; README v2.x dates live under "The evolution" heading (see context_summary.md)
-- Next: Ovidiu merges the OVI-47 PR, then move OVI-47 to Done in Linear and prep the next issue (F002) via /harness-issue-prep
-- Blockers: none (gh pr merge remains blocked for Claude; merge is Ovidiu's step)
+- Next: fresh session — /harness-issue-prep on the next P0 issue (F002), then /harness-continue; bootstrap-era spec hashes on F002-F021 are cosmetic, prep each before implementing
+- Blockers: none (gh pr merge is permitted via .claude/settings.json; Claude completes the loop through merge)

--- a/.harness/context_summary.md
+++ b/.harness/context_summary.md
@@ -35,7 +35,11 @@ This file is referenced in CLAUDE.md and loaded every session.
 <!-- Coordination insights that apply across features — NOT domain-specific.
      Populated by the retrospective step at session end.
      These transfer to new projects: harness-init can import them as starting context. -->
-- (none yet — first retrospective will populate this)
+- Capability-block memories decay: before telling the user something is blocked
+  (permissions, tooling), re-verify against current .claude/settings.json and repo
+  state — a one-line grep beats a wasted round-trip.
+- Small independent-edit batches (docs, hook guards, rule text) fit single-session
+  mode regardless of file count; reserve teams for genuinely parallel feature work.
 
 ## Meta-Session 2026-07-22
 - Scope accuracy: bootstrap session touched only .harness/ and .claude/ as planned; prep
@@ -50,4 +54,14 @@ This file is referenced in CLAUDE.md and loaded every session.
 - Approach patterns: per-issue prep loop (SV → human answers → RV → normalize) closed in
   one revision cycle; presenting SV questions verbatim got decisive one-line answers.
 - Plan approval: PASS verdicts now carry implicit go-ahead for write-back (owner
-  decision 2026-07-22); ASK/BLOCK still stop for Ovidiu.
+  decision 2026-07-22); ASK/BLOCK still stop for Ovidiu. Extended same day: clean
+  orientation + a plan with no open questions = default go-ahead, no wait.
+- Implementation phase (added post-merge): TDD red (9 failing) → green 77/77 in one
+  pass; single-session mode was right for a 10-file batch of small independent edits —
+  team overhead would have exceeded the work.
+- Review value: opus adversarial reviewer approved with 2 nits and caught a genuinely
+  untested boundary (empty-string env var) even on a docs-heavy batch; worth the spawn.
+- Stale-memory cost: a session memory claimed gh pr merge was blocked; the permission
+  had landed in .claude/settings.json (PR #22) before this session, and trusting the
+  memory cost one needless ask. Verify capability-block memories against current
+  settings/repo state before acting on them — they decay fast.


### PR DESCRIPTION
## What changed

.harness metadata only, no code:

- Meta-Session 2026-07-22 amended to cover the implementation, review, and merge phases (the entry predated them): TDD outcome, reviewer value, and the stale-memory lesson that cost a needless merge ask.
- First two Meta-Patterns seeded (re-verify capability-block assumptions against settings; single-session fits small independent-edit batches).
- Session 2 handoff updated: PR #23 merged, OVI-47 Done, next step is prepping F002 in a fresh session.

## Testing

Full suite 77/77 (no code touched).

## Dependencies

None.