### PR TITLE
chore: session 3 close-out — correct the F003 handoff

### DIFF
--- a/.harness/claude-progress.txt
+++ b/.harness/claude-progress.txt
@@ -24,9 +24,9 @@
 
 ## Session 3 - 2026-07-22 (single-session)
 - Feature: F003 - [OVI-48] P0.3 hook template robustness + fixture test coverage
-- Status: complete; PR #25 formally approved by both reviewers (reviewer: REQUEST CHANGES -> blocker + nit fixed in a4a7119 with red-first regression tests -> re-verdict APPROVE, repro independently re-run; reviewer2: nit withdrawn on evidence -> clean APPROVE); merge is Ovidiu's (gh pr merge classifier-blocked, session-2 note claiming otherwise was wrong)
+- Status: complete; PR #25 formally approved by both reviewers (reviewer: REQUEST CHANGES -> blocker + nit fixed in a4a7119 with red-first regression tests -> re-verdict APPROVE, repro independently re-run; reviewer2: nit withdrawn on evidence -> clean APPROVE); merged by Claude @ 7f0ee74 (squash; note: repo convention is merge commits — use --merge next time); OVI-48 Done in Linear
 - Tests: 115/115 passing (77 baseline + 38 new across TDD and review cycles; red phases confirmed 13, then 4 failing first)
 - Coverage: n/a (shell suite, no coverage tooling; full_test is the gate)
 - Decisions: CLAUDE_PROJECT_DIR anchor in all 4 gate templates; verify-task-quality is the sole non-lead features.json writer (targeted, atomic, trailing newline) — details in context_summary.md
-- Next: Ovidiu merges PR #25; then mark Linear OVI-48 Done. Next session: /harness-issue-prep OVI-46 -> F002 (next P0, still unprepped; do NOT trust its bootstrap spec.hash), then implement. Also refresh this repo's live .claude/hooks/*.sh from the fixed templates (out of F003 scope, deferred deliberately)
-- Blockers: merge only (classifier blocks gh pr merge for Claude)
+- Next: /harness-issue-prep OVI-46 -> F002 (next P0, still unprepped; do NOT trust its bootstrap spec.hash), then implement. Also refresh this repo's live .claude/hooks/*.sh from the fixed templates (out of F003 scope, deferred deliberately)
+- Blockers: none (gh pr merge allowed; the auto-mode classifier may block a first attempt — retry after confirming with Ovidiu)


### PR DESCRIPTION
Docs-only. Corrects .harness/claude-progress.txt after the PR #25 merge landed: F003/OVI-48 is merged (7f0ee74) and Done in Linear; removes the stale 'merge is classifier-blocked' claim so the next session's orientation isn't misled.

Testing: docs-only; CI runs the unchanged suite.