### PR TITLE
P1.1: Canonical feature schema (one owner) + stdlib validator

### DIFF
--- a/.harness/claude-progress.txt
+++ b/.harness/claude-progress.txt
@@ -41,3 +41,20 @@
 - Next: /harness-issue-prep the next P0 issue, then implement. Also refresh this repo's live .claude/hooks/*.sh from F003's fixed templates (still deferred)
 - Blockers: none
 - 2026-07-23 F002/OVI-46 merged @ 434308b; adversarial reviewer never reported after ~80 min despite a ping, so a lead self-review (with Ovidiu's explicit go-ahead, checked twice via AskUserQuestion) ran instead, found + fixed one real gap (assigned_to truthy check vs. spec's literal "!= null"), then merged on green CI; Linear OVI-46 Done
+
+## Session 5 - 2026-07-23 (single-session)
+- Feature: F004 - [OVI-49] P1.1 canonical feature schema (one owner) + stdlib validator
+- Status: implementation complete; PR pending, CI + adversarial review + merge in progress this session
+- Tests: 145/145 passing (124 baseline + 21 new; TDD red phase confirmed all new fsv/z checks failing first)
+- Coverage: n/a (shell suite, no coverage tooling; full_test 145/145 is the gate)
+- Decisions: schemas/feature.schema.json (draft 2020-12) is the canonical envelope+16-field
+  definition; scripts/validate-features.py hand-implements the same checks in stdlib Python
+  (no jsonschema dep, per spec); only the 10 pre-v3.3 core fields are required, the 5 metric
+  fields + spec are optional/type-checked-if-present for backward compat — details in
+  context_summary.md
+- Discovered: F022 (coverage field type: spec says number|null, this repo's own F001-F004
+  store a descriptive string) — filed, not fixed, deliberately out of F004's scope
+- Next: /harness-issue-prep the next P1 issue (this is P1.1; P1.2 and P2.2 both depend on
+  this schema per the ticket's "Dependencies" note), then implement. Also refresh this
+  repo's live .claude/hooks/*.sh from F003's fixed templates (still deferred); decide F022
+- Blockers: none

--- a/.harness/context_summary.md
+++ b/.harness/context_summary.md
@@ -4,8 +4,8 @@ Persistent record of architectural decisions, discovered patterns, gotchas, and 
 This file is referenced in CLAUDE.md and loaded every session.
 
 ## Active Context
-- Currently working on: F002 / OVI-46 merged (434308b), OVI-46 Done in Linear
-- Next up: /harness-issue-prep the next P0 issue, then implement; also refresh live .claude/hooks/*.sh from F003's fixed templates
+- Currently working on: F004 / OVI-49 implemented this session (schema + validator + doc dedup); PR pending, CI + review in progress
+- Next up: /harness-issue-prep the next P0/P1 issue, then implement; also refresh live .claude/hooks/*.sh from F003's fixed templates; F022 (discovered_via F004) needs a decision on the `coverage` field's type vs. this repo's own descriptive-string values
 
 ## Cross-Cutting Concerns
 - Stack: custom (shell hooks + JSON manifests + markdown skills; no application code)
@@ -25,6 +25,8 @@ This file is referenced in CLAUDE.md and loaded every session.
 - LICENSE: MIT, owner decision recorded in the OVI-47 assumptions ledger (2026-07-22)
 - All four per-project hook templates anchor to `PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"` and cd there — hooks must not depend on the session's cwd; settings.json invokes them as `"$CLAUDE_PROJECT_DIR"/.claude/hooks/<name>.sh` (2026-07-22, OVI-48)
 - verify-task-quality is the only features.json writer besides the lead: targeted feature only, indent=2, trailing newline, atomic .tmp + mv (2026-07-22, OVI-48)
+- schemas/feature.schema.json (JSON Schema draft 2020-12) is now the single owner of the features.json envelope + 16-field feature object; scripts/validate-features.py hand-implements the same checks in stdlib Python (no jsonschema dependency, per spec) rather than loading the schema at runtime — the schema documents intent for humans/external tools, the script enforces it (2026-07-23, F004/OVI-49)
+- Only the 10 pre-v3.3 core fields are required in the schema/validator; the 5 operational metrics + `spec` are optional and type-checked only when present, so the existing shared test fixture (test/fixtures/harness-project/.harness/features.json, which predates v3.3 and has no envelope fields either) validates unmodified — kept envelope fields (project/created/total_features/passing) optional too for the same backward-compat reason (2026-07-23, F004)
 
 ### Patterns
 - Tests must pin env vars the hooks read: run_session_start forces CLAUDE_PLUGIN_ROOT unset (env -u), run_session_start_with_root sets it — never inherit the test shell's env for hook behavior assertions (2026-07-22)
@@ -36,6 +38,7 @@ This file is referenced in CLAUDE.md and loaded every session.
 - macOS resolves `/var` → `/private/var`, so `git rev-parse --show-toplevel` returns a different prefix than an unresolved `$TMPDIR`/CLAUDE_PROJECT_DIR path — absolute-path prefix-stripping against the git toplevel silently fails on macOS; prefer CLAUDE_PROJECT_DIR (2026-07-22)
 - session-start.sh's own warning blocks are the reference pattern for new orientation checks: wrap the whole python heredoc body in try/except pass AND pipe stderr to /dev/null with `|| true` at the shell level — belt-and-suspenders against a malformed features.json ever leaking a traceback into model context (2026-07-23, F002)
 - This repo's live .claude/hooks/*.sh lag the fixed templates: the old verify-task-quality corrupted correction_cycles (F003 +1, no trailing newline) when the gate rejected a TDD red-phase task completion; reset to 0 as a false positive. Refresh live hooks from templates after OVI-48 merges (2026-07-22)
+- Dogfooding scripts/validate-features.py against this repo's own live .harness/features.json (not required by F004's acceptance criteria, just a sanity check) found F001-F004's `coverage` field holds a descriptive string ("n/a (shell suite, no coverage tooling; full_test N/N is the gate)"), not the number|null the OVI-49 spec types verbatim. Did not loosen the schema or rewrite the live data to make this pass — filed as F022 (discovered_via F004) instead, since silently relaxing a just-verified spec to match existing non-conformant data would be gaming the check, not fixing it (2026-07-23, F004)
 
 ## Meta-Patterns
 <!-- Coordination insights that apply across features — NOT domain-specific.
@@ -117,3 +120,30 @@ This file is referenced in CLAUDE.md and loaded every session.
   again this session, exactly as logged in session 3's retrospective. This is now a
   confirmed recurring pattern, not a one-off — the fix is procedural (mark red-phase
   tasks complete only after green), not a hook bug.
+
+## Meta-Session 2026-07-23 (session 5, F004/OVI-49)
+- Scope accuracy: F004's scope array (6 files/dirs) matched the work exactly — 2 new
+  files (schema, validator) plus edits to the 4 listed docs/tests; zero expansions.
+- Model calibration: single-session, one correction_cycles increment on F004 — the same
+  documented TDD-red-phase false-rejection (marked the "write failing tests" task
+  complete while the suite was intentionally red). Third session in a row hitting this;
+  the procedural fix (mark red-phase tasks complete only after green) is confirmed but
+  still occasionally slips — worth tightening the harness-continue skill's task template
+  wording rather than relying on memory alone.
+- Discovery lineage: dogfooding the new validator against this repo's own live
+  .harness/features.json (not part of F004's acceptance criteria) surfaced a real
+  spec-vs-reality gap: `coverage` is typed number|null per the OVI-49 spec, but this
+  project's own F001-F004 store a descriptive string there since it has no coverage
+  tooling. Filed as F022 (discovered_via F004) rather than silently loosening the schema
+  to match — a just-verified spec shouldn't bend to accommodate pre-existing drift
+  without a deliberate decision.
+- Approach patterns: designing the validator as hand-rolled stdlib checks (not a
+  jsonschema-loader reading the schema file) works cleanly once the two are written
+  side by side from the same field list; the schema stays the human/external-tool
+  reference, the script is the enforcement, and the spec explicitly asked for this
+  split (no jsonschema dependency) rather than treating it as duplication to avoid.
+- Approach patterns: keeping the 5 v3.3 operational-metric fields (plus `spec`) optional
+  and type-checked-only-when-present let the existing shared test fixture
+  (test/fixtures/harness-project/.harness/features.json, pre-v3.3 shape, no envelope
+  fields) validate without modification — avoided scope creep onto test/fixtures/, which
+  wasn't in F004's scope list and is used by many unrelated hook tests.

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -1,8 +1,8 @@
 {
   "project": "vv-claude-harness",
   "created": "2026-07-22",
-  "total_features": 21,
-  "passing": 0,
+  "total_features": 22,
+  "passing": 4,
   "features": [
     {
       "id": "F001",
@@ -116,7 +116,7 @@
       "id": "F004",
       "description": "[OVI-49] P1.1: Canonical feature schema (one owner) + stdlib validator \u2014 Create schemas/feature.schema.json as the single authoritative definition of the features.json envelope and 16-field feature object, plus a stdlib-only scripts/validate-features.py validator with location-aware errors. Deduplicate the field-by-field prose from the protocol, harness-init SKILL, and README into schema links, and wire validation into the test suite.",
       "priority": 4,
-      "status": "pending",
+      "status": "passing",
       "scope": [
         "schemas/feature.schema.json",
         "scripts/validate-features.py",
@@ -127,12 +127,15 @@
       ],
       "depends_on": [],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
+      "test_file": "test/run-tests.sh (== feature schema validator == and z: dedup checks)",
+      "coverage": "n/a (shell suite, no coverage tooling; full_test 145/145 is the gate)",
       "notes": "Linear: OVI-49. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
-      "correction_cycles": 0,
+      "correction_cycles": 1,
       "scope_expansions": [],
-      "approaches_tried": [],
+      "approaches_tried": [
+        "Hand-rolled stdlib validator (no jsonschema dep) mirroring the schema's checks, per spec; schema itself stays the human/external-tool-facing authority.",
+        "Required only the 10 pre-v3.3 core fields; the 5 operational metrics + spec are optional/type-checked-if-present so the existing shared test fixture (pre-v3.3 shape) validates unmodified -- avoided touching test/fixtures/ out of scope."
+      ],
       "failure_reason": null,
       "discovered_via": null,
       "spec": {
@@ -694,6 +697,29 @@
         "verified_at": "2026-07-22T18:15:31Z",
         "source": "linear:OVI-60"
       }
+    },
+    {
+      "id": "F022",
+      "description": "[discovered via F004] .harness/features.json's own `coverage` field (F001-F003) holds a descriptive string (\"n/a (shell suite, no coverage tooling; full_test N/N is the gate)\") but schemas/feature.schema.json (F004) types `coverage` as number|null per the OVI-49 spec verbatim. Decide and apply one fix: relax the schema to allow a string, or replace the live features.json coverage strings with null and move the explanation into `notes`.",
+      "priority": 4,
+      "status": "pending",
+      "scope": [
+        "schemas/feature.schema.json",
+        ".harness/features.json"
+      ],
+      "depends_on": [
+        "F004"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Discovered while dogfooding scripts/validate-features.py against the live features.json during F004; not fixed there since it's outside F004's scope.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": "F004",
+      "spec": null
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ vv-harness/                                            # Plugin root
 │   ├── context-summary.md                             # context_summary.md template + update rules
 │   └── task-completion.md                             # Completion checklist
 ├── schemas/
-│   └── readiness-stamp.md                             # Stamp, hashing, HMAC, park/resolution contracts
+│   ├── readiness-stamp.md                             # Stamp, hashing, HMAC, park/resolution contracts
+│   └── feature.schema.json                            # Canonical features.json envelope + feature object
 └── templates/
     └── CLAUDE.md                                      # Core standards template (manual copy to ~/.claude/)
 ```
@@ -406,6 +407,13 @@ readiness stamp posted to a Linear issue. An external issue-to-PR runner (out of
 for this repo) is a **consumer**: it validates the stamp's hash and HMAC before trusting
 an issue as ready for unattended work. See [schemas/readiness-stamp.md](./schemas/readiness-stamp.md)
 for the stamp shape, the canonical hashing recipe, and the consumer verification rules.
+
+The `features.json` envelope and the 16-field feature object have a single owner too:
+[schemas/feature.schema.json](./schemas/feature.schema.json) is the canonical definition;
+`scripts/validate-features.py` enforces it (stdlib only, no `jsonschema` dependency) and is
+wired into `test/run-tests.sh`. The worked example lives in the Feature Schema section of
+`rules/agent-teams-protocol.md` — this README and `skills/harness-init/SKILL.md` link there
+instead of restating the field list.
 
 ## Some screenshots from my sessions
 

--- a/rules/agent-teams-protocol.md
+++ b/rules/agent-teams-protocol.md
@@ -75,6 +75,11 @@ Every feature in `.harness/features.json` uses this shape:
 }
 ```
 
+This is the one worked example; `${CLAUDE_PLUGIN_ROOT}/schemas/feature.schema.json` is the
+authoritative field-by-field definition (types, patterns, required vs. optional) that this
+example illustrates. The prose below only covers semantics the schema can't express (who
+writes a field, when).
+
 **Status values** (exhaustive enum):
 - `pending`: ready for work, no one has claimed it
 - `in-progress`: a teammate or single-session agent is actively working on it

--- a/schemas/feature.schema.json
+++ b/schemas/feature.schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/oeftimie/vv-claude-harness/schemas/feature.schema.json",
+  "title": "vv-harness features.json",
+  "description": "Canonical definition of the .harness/features.json envelope and the feature object it contains. This is the single authoritative source for the field list; rules/agent-teams-protocol.md and skills/harness-init/SKILL.md link here instead of restating it. scripts/validate-features.py implements these checks by hand (stdlib only, no jsonschema dependency) so this file documents intent for humans and external tools rather than being loaded at validation time.",
+  "type": "object",
+  "required": ["features"],
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "Project name, set once at /harness-init time."
+    },
+    "created": {
+      "type": "string",
+      "description": "ISO date the harness was initialized for this project."
+    },
+    "total_features": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Count of entries in features[]. Kept in sync by whoever adds or removes a feature."
+    },
+    "passing": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Count of features with status \"passing\". Kept in sync alongside total_features."
+    },
+    "features": {
+      "type": "array",
+      "description": "The tracked feature list. Each entry is a feature object (see $defs/feature).",
+      "items": { "$ref": "#/$defs/feature" }
+    }
+  },
+  "$defs": {
+    "feature": {
+      "type": "object",
+      "required": [
+        "id", "description", "priority", "status", "scope",
+        "depends_on", "assigned_to", "test_file", "coverage", "notes"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^F[0-9]{3}$",
+          "description": "Unique feature id, e.g. F001. Lead assigns at feature-creation time; never reused."
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "What the feature is. Once a spec object is attached, editing this string invalidates spec.hash."
+        },
+        "priority": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Lower numbers claim first. Lead sets at creation time."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["pending", "in-progress", "blocked", "passing", "failed"],
+          "description": "Exhaustive enum. See the Feature Schema section of agent-teams-protocol.md for the meaning of each value."
+        },
+        "scope": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Directories and files this feature owns. Used in spawn prompts to define teammate boundaries."
+        },
+        "depends_on": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^F[0-9]{3}$" },
+          "description": "Feature ids that must reach status \"passing\" before this one may start."
+        },
+        "assigned_to": {
+          "type": ["string", "null"],
+          "description": "Teammate name when Agent Teams is active, or \"single-session\"; null otherwise."
+        },
+        "test_file": {
+          "type": ["string", "null"],
+          "description": "Path to the test file proving this feature. Required non-null once status is \"passing\"."
+        },
+        "coverage": {
+          "type": ["number", "null"],
+          "description": "Coverage percentage on touched code. Required non-null once status is \"passing\"."
+        },
+        "notes": {
+          "type": ["string", "null"],
+          "description": "Free-form context: Linear issue id, decisions, anything not captured by other fields."
+        },
+        "correction_cycles": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Operational metric, optional for backward compatibility with pre-v3.3 features.json files. Incremented automatically by verify-task-quality.sh on each TaskCompleted rejection. Never manually set."
+        },
+        "scope_expansions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Operational metric, optional for backward compatibility. Files/directories added to scope after initial assignment."
+        },
+        "approaches_tried": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Operational metric, optional for backward compatibility. Brief notes on approaches attempted before the passing implementation."
+        },
+        "failure_reason": {
+          "type": ["string", "null"],
+          "description": "Operational metric, optional for backward compatibility. Why the feature reached status \"failed\"."
+        },
+        "discovered_via": {
+          "type": ["string", "null"],
+          "description": "Operational metric, optional for backward compatibility. Id of the feature whose implementation revealed the need for this one."
+        },
+        "spec": {
+          "type": ["object", "null"],
+          "description": "Optional spec-verification record; absent or null means unverified. See schemas/readiness-stamp.md for the canonical hashing recipe.",
+          "properties": {
+            "hash": { "type": "string", "description": "sha256 of the description string exactly as stored." },
+            "verdict": { "type": "string", "enum": ["PASS", "ASK", "BLOCK"] },
+            "sv_version": { "type": "string" },
+            "verified_at": { "type": "string" },
+            "source": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate-features.py
+++ b/scripts/validate-features.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+import json
+import re
+import sys
+
+FEATURE_ID_RE = re.compile(r"^F[0-9]{3}$")
+STATUS_VALUES = {"pending", "in-progress", "blocked", "passing", "failed"}
+SPEC_VERDICTS = (None, "PASS", "ASK", "BLOCK")
+
+REQUIRED_FEATURE_FIELDS = (
+    "id", "description", "priority", "status", "scope",
+    "depends_on", "assigned_to", "test_file", "coverage", "notes",
+)
+OPTIONAL_FEATURE_FIELDS = (
+    "correction_cycles", "scope_expansions", "approaches_tried",
+    "failure_reason", "discovered_via", "spec",
+)
+KNOWN_FEATURE_FIELDS = set(REQUIRED_FEATURE_FIELDS) | set(OPTIONAL_FEATURE_FIELDS)
+
+
+def is_plain_int(value):
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def is_string_array(value):
+    return isinstance(value, list) and all(isinstance(v, str) for v in value)
+
+
+def check_id(feature, index, errors):
+    value = feature.get("id")
+    if not isinstance(value, str) or not FEATURE_ID_RE.match(value):
+        errors.append(f"features[{index}].id: invalid value {value!r}, expected pattern F###")
+
+
+def check_description(feature, index, errors):
+    value = feature.get("description")
+    if not isinstance(value, str) or not value:
+        errors.append(f"features[{index}].description: must be a non-empty string")
+
+
+def check_priority(feature, index, errors):
+    value = feature.get("priority")
+    if not is_plain_int(value) or value < 1:
+        errors.append(f"features[{index}].priority: must be an integer >= 1, got {value!r}")
+
+
+def check_status(feature, index, errors):
+    value = feature.get("status")
+    if value not in STATUS_VALUES:
+        errors.append(f"features[{index}].status: invalid value {value!r}")
+
+
+def check_scope(feature, index, errors):
+    if not is_string_array(feature.get("scope")):
+        errors.append(f"features[{index}].scope: must be an array of strings")
+
+
+def check_depends_on(feature, index, errors):
+    if not is_string_array(feature.get("depends_on")):
+        errors.append(f"features[{index}].depends_on: must be an array of strings")
+
+
+def make_nullable_string_check(field):
+    def check(feature, index, errors):
+        value = feature.get(field)
+        if value is not None and not isinstance(value, str):
+            errors.append(f"features[{index}].{field}: must be a string or null")
+    return check
+
+
+def check_coverage(feature, index, errors):
+    value = feature.get("coverage")
+    if value is not None and (isinstance(value, bool) or not isinstance(value, (int, float))):
+        errors.append(f"features[{index}].coverage: must be a number or null")
+
+
+def make_optional_int_check(field):
+    def check(feature, index, errors):
+        if field not in feature:
+            return
+        value = feature[field]
+        if not is_plain_int(value) or value < 0:
+            errors.append(f"features[{index}].{field}: must be an integer >= 0, got {value!r}")
+    return check
+
+
+def make_optional_array_check(field):
+    def check(feature, index, errors):
+        if field in feature and not is_string_array(feature[field]):
+            errors.append(f"features[{index}].{field}: must be an array of strings")
+    return check
+
+
+def make_optional_nullable_string_check(field):
+    inner = make_nullable_string_check(field)
+
+    def check(feature, index, errors):
+        if field in feature:
+            inner(feature, index, errors)
+    return check
+
+
+def check_spec(feature, index, errors):
+    if "spec" not in feature or feature["spec"] is None:
+        return
+    value = feature["spec"]
+    if not isinstance(value, dict):
+        errors.append(f"features[{index}].spec: must be an object or null")
+        return
+    if value.get("verdict") not in SPEC_VERDICTS:
+        errors.append(f"features[{index}].spec.verdict: invalid value {value.get('verdict')!r}")
+
+
+REQUIRED_CHECKS = {
+    "id": check_id,
+    "description": check_description,
+    "priority": check_priority,
+    "status": check_status,
+    "scope": check_scope,
+    "depends_on": check_depends_on,
+    "assigned_to": make_nullable_string_check("assigned_to"),
+    "test_file": make_nullable_string_check("test_file"),
+    "notes": make_nullable_string_check("notes"),
+    "coverage": check_coverage,
+}
+
+OPTIONAL_CHECKS = {
+    "correction_cycles": make_optional_int_check("correction_cycles"),
+    "scope_expansions": make_optional_array_check("scope_expansions"),
+    "approaches_tried": make_optional_array_check("approaches_tried"),
+    "failure_reason": make_optional_nullable_string_check("failure_reason"),
+    "discovered_via": make_optional_nullable_string_check("discovered_via"),
+    "spec": check_spec,
+}
+
+
+def check_required_fields(feature, index, errors):
+    for field in REQUIRED_FEATURE_FIELDS:
+        if field not in feature:
+            errors.append(f"features[{index}]: missing required field '{field}'")
+
+
+def check_unknown_fields(feature, index, warnings):
+    for field in feature:
+        if field not in KNOWN_FEATURE_FIELDS:
+            warnings.append(f"features[{index}]: unknown field '{field}' (warning, ignored)")
+
+
+def validate_feature(feature, index, errors, warnings):
+    if not isinstance(feature, dict):
+        errors.append(f"features[{index}]: must be an object")
+        return
+    check_required_fields(feature, index, errors)
+    for field, check in REQUIRED_CHECKS.items():
+        if field in feature:
+            check(feature, index, errors)
+    for check in OPTIONAL_CHECKS.values():
+        check(feature, index, errors)
+    check_unknown_fields(feature, index, warnings)
+
+
+def check_duplicate_ids(features, errors):
+    seen = {}
+    for index, feature in enumerate(features):
+        fid = feature.get("id") if isinstance(feature, dict) else None
+        if not isinstance(fid, str):
+            continue
+        if fid in seen:
+            errors.append(
+                f"features[{index}].id: duplicate id '{fid}' "
+                f"(first seen at features[{seen[fid]}])"
+            )
+        else:
+            seen[fid] = index
+    return set(seen)
+
+
+def check_dangling_depends_on(features, known_ids, errors):
+    for index, feature in enumerate(features):
+        if not isinstance(feature, dict):
+            continue
+        for dep_index, dep in enumerate(feature.get("depends_on") or []):
+            if isinstance(dep, str) and dep not in known_ids:
+                errors.append(
+                    f"features[{index}].depends_on[{dep_index}]: unknown feature id '{dep}'"
+                )
+
+
+def check_envelope(data, errors):
+    if not isinstance(data, dict):
+        errors.append("<root>: must be a JSON object")
+        return False
+    if not isinstance(data.get("features"), list):
+        errors.append("features: must be an array")
+        return False
+    for field in ("project", "created"):
+        if field in data and not isinstance(data[field], str):
+            errors.append(f"{field}: must be a string")
+    for field in ("total_features", "passing"):
+        if field in data and (not is_plain_int(data[field]) or data[field] < 0):
+            errors.append(f"{field}: must be an integer >= 0")
+    return True
+
+
+def validate(data):
+    errors = []
+    warnings = []
+    if not check_envelope(data, errors):
+        return errors, warnings
+    features = data["features"]
+    for index, feature in enumerate(features):
+        validate_feature(feature, index, errors, warnings)
+    known_ids = check_duplicate_ids(features, errors)
+    check_dangling_depends_on(features, known_ids, errors)
+    return errors, warnings
+
+
+def main(argv):
+    path = argv[1] if len(argv) > 1 else ".harness/features.json"
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"{path}: {exc}", file=sys.stderr)
+        return 1
+    errors, warnings = validate(data)
+    for warning in warnings:
+        print(f"WARNING: {warning}", file=sys.stderr)
+    for error in errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/skills/harness-init/SKILL.md
+++ b/skills/harness-init/SKILL.md
@@ -71,37 +71,11 @@ Create `.harness/` with these files:
 }
 ```
 
-Each feature has this shape:
-
-```json
-{
-  "id": "F001",
-  "description": "FEATURE_DESCRIPTION",
-  "priority": 1,
-  "status": "pending",
-  "scope": ["src/feature/", "tests/feature/"],
-  "depends_on": [],
-  "assigned_to": null,
-  "test_file": null,
-  "coverage": null,
-  "notes": null,
-  "correction_cycles": 0,
-  "scope_expansions": [],
-  "approaches_tried": [],
-  "failure_reason": null,
-  "discovered_via": null,
-  "spec": null
-}
-```
-
-**Status values** (exhaustive enum): `pending`, `in-progress`, `blocked`, `passing`, `failed`.
-
-**Operational metrics** (updated automatically or by the lead — used in retrospectives and for dynamic model selection):
-- `correction_cycles`: incremented by the `verify-task-quality.sh` hook each time a TaskCompleted is rejected. High values signal the feature was harder than expected.
-- `scope_expansions`: array of file/directory strings added to scope after initial assignment. Frequent expansions mean the initial scope was too narrow.
-- `approaches_tried`: brief notes on approaches attempted before the passing implementation. Populated by the teammate in the task-complete message to lead.
-- `failure_reason`: why the feature reached `status: "failed"`. Essential for understanding root cause without re-reading conversation history.
-- `discovered_via`: ID of the feature whose implementation revealed the need for this feature (discovery lineage). Different from `depends_on`, which is a technical dependency.
+Each feature's shape (the 16 fields, which are required vs. optional, the status enum) is
+defined once in `${CLAUDE_PLUGIN_ROOT}/schemas/feature.schema.json` and illustrated with the
+one worked example in the Feature Schema section of
+`${CLAUDE_PLUGIN_ROOT}/rules/agent-teams-protocol.md`. `scripts/validate-features.py`
+enforces it in the test suite.
 
 Feature is not done until:
 - `status` is `"passing"`

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -50,6 +50,10 @@ assert_rc2() {
   if [ "$1" -eq 2 ]; then pass "$2"; else fail "$2 -- exit code $1"; fi
 }
 
+assert_rc_nonzero() {
+  if [ "$1" -ne 0 ]; then pass "$2"; else fail "$2 -- expected a nonzero exit code"; fi
+}
+
 # Copies the fixture into $1 and turns it into a committed git repo with a quiet identity.
 make_fixture() {
   mkdir -p "$1"
@@ -552,6 +556,80 @@ else
 fi
 
 echo ""
+echo "== feature schema validator =="
+
+VALIDATE_SCRIPT="$REPO_ROOT/scripts/validate-features.py"
+FEATURE_SCHEMA="$REPO_ROOT/schemas/feature.schema.json"
+
+if python3 -m json.tool "$FEATURE_SCHEMA" >/dev/null 2>&1; then
+  pass "fsv: schemas/feature.schema.json is valid JSON"
+else
+  fail "fsv: schemas/feature.schema.json is not valid JSON"
+fi
+
+SCHEMA_DIALECT=$(python3 -c \
+  'import json, sys; print(json.load(open(sys.argv[1])).get("$schema", ""))' \
+  "$FEATURE_SCHEMA" 2>/dev/null)
+case "$SCHEMA_DIALECT" in
+  *2020-12*) pass "fsv: feature.schema.json declares draft 2020-12" ;;
+  *) fail "fsv: feature.schema.json \$schema is '$SCHEMA_DIALECT', expected draft 2020-12" ;;
+esac
+
+FSV_DIR="$WORK/fsv"
+mkdir -p "$FSV_DIR"
+
+RC=0
+python3 "$VALIDATE_SCRIPT" "$FIXTURE_SRC/.harness/features.json" >/dev/null 2>&1 || RC=$?
+assert_rc0 "$RC" "fsv: validator passes on the shared test fixture (pre-v3.3 fields absent)"
+
+fsv_mutate() {
+  # $1: output filename under $FSV_DIR, $2: python snippet mutating dict `d` in place
+  python3 - "$FIXTURE_SRC/.harness/features.json" "$FSV_DIR/$1" <<PYEOF
+import json, sys
+d = json.load(open(sys.argv[1]))
+$2
+json.dump(d, open(sys.argv[2], "w"))
+PYEOF
+}
+
+fsv_mutate "bad-status.json" 'd["features"][0]["status"] = "done"'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/bad-status.json" 2>&1)
+RC=$?
+assert_rc_nonzero "$RC" "fsv: rejects invalid status enum value"
+assert_contains "$OUT" "features[0].status" "fsv: bad status error names the location"
+
+fsv_mutate "missing-id.json" 'del d["features"][0]["id"]'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/missing-id.json" 2>&1)
+RC=$?
+assert_rc_nonzero "$RC" "fsv: rejects a feature missing 'id'"
+assert_contains "$OUT" "features[0]" "fsv: missing id error names the location"
+
+fsv_mutate "bad-type.json" 'd["features"][0]["correction_cycles"] = "three"'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/bad-type.json" 2>&1)
+RC=$?
+assert_rc_nonzero "$RC" "fsv: rejects wrong type for correction_cycles"
+assert_contains "$OUT" "features[0].correction_cycles" \
+  "fsv: bad correction_cycles error names the location"
+
+fsv_mutate "dup-id.json" 'd["features"][1]["id"] = d["features"][0]["id"]'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/dup-id.json" 2>&1)
+RC=$?
+assert_rc_nonzero "$RC" "fsv: rejects a duplicate feature id"
+assert_contains "$OUT" "features[1].id" "fsv: duplicate id error names the location"
+
+fsv_mutate "dangling-dep.json" 'd["features"][1]["depends_on"] = ["F099"]'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/dangling-dep.json" 2>&1)
+RC=$?
+assert_rc_nonzero "$RC" "fsv: rejects a dangling depends_on reference"
+assert_contains "$OUT" "features[1].depends_on" "fsv: dangling depends_on error names the location"
+
+fsv_mutate "unknown-field.json" 'd["features"][0]["proof"] = "sha256:abc"'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/unknown-field.json" 2>&1)
+RC=$?
+assert_rc0 "$RC" "fsv: an unknown top-level feature field is a warning, not an error"
+assert_contains "$OUT" "proof" "fsv: unknown field warning names the field"
+
+echo ""
 echo "== spec gate artifacts =="
 
 READINESS_STAMP_ERRORS=$(python3 - "$REPO_ROOT" <<'PYEOF'
@@ -686,6 +764,22 @@ if grep -q "treat it as burned" "$REPO_ROOT/templates/CLAUDE.md"; then
 else
   fail "z: transcript-secrets rule missing in templates/CLAUDE.md"
 fi
+
+FULL_EXAMPLE_COUNT=$(grep -r '"correction_cycles": 0' "$REPO_ROOT" --include="*.md" \
+  | wc -l | tr -d ' ')
+if [ "$FULL_EXAMPLE_COUNT" -eq 1 ]; then
+  pass "z: the full 16-field feature JSON example appears exactly once across *.md"
+else
+  fail "z: the full feature JSON example appears $FULL_EXAMPLE_COUNT times across *.md, expected 1"
+fi
+
+for DOC_FILE in rules/agent-teams-protocol.md skills/harness-init/SKILL.md README.md; do
+  if grep -q "schemas/feature.schema.json" "$REPO_ROOT/$DOC_FILE"; then
+    pass "z: $DOC_FILE links to schemas/feature.schema.json"
+  else
+    fail "z: $DOC_FILE does not link to schemas/feature.schema.json"
+  fi
+done
 
 echo ""
 echo "== hook templates =="


### PR DESCRIPTION
## Summary
- Adds `schemas/feature.schema.json` (JSON Schema draft 2020-12) as the single authoritative definition of the `.harness/features.json` envelope and the 16-field feature object.
- Adds `scripts/validate-features.py`, a stdlib-only validator (no `jsonschema` dependency) that hand-implements the schema's checks with location-aware error messages, exit 0/1.
- Dedups the field-by-field prose previously restated in `rules/agent-teams-protocol.md`, `skills/harness-init/SKILL.md`, and `README.md`: the protocol keeps the one worked JSON example and links to the schema; the SKILL and README link instead of restating fields.
- Wires the validator into `test/run-tests.sh`: schema JSON/draft validity, a positive case against the shared fixture, five negative cases (bad status enum, missing id, wrong type, duplicate id, dangling `depends_on`), an unknown-field warning check, and a grep-based check that the 16-field JSON example appears exactly once across `*.md`.
- Only the 10 pre-v3.3 core fields are required in the schema/validator; the 5 operational metrics plus `spec` are optional and type-checked only when present, so the existing pre-v3.3 shared test fixture validates unmodified.
- Filed F022 (`discovered_via: F004`): this repo's own `.harness/features.json` stores a descriptive string in `coverage` (no coverage tooling) rather than the `number|null` the spec types verbatim — flagged rather than silently loosening the schema or the live data.

Linear: OVI-49

## Test plan
- [x] `bash test/run-tests.sh` — 145/145 assertions passing (124 baseline + 21 new)
- [x] `./.harness/init.sh` (smoke + full) green
- [x] TDD red phase confirmed: all new `fsv:`/`z:` assertions failed before the schema/validator/doc links existed