### PR TITLE
P1.2: One state boundary: shared harness_state.py for per-project hooks

### DIFF
--- a/.harness/claude-progress.txt
+++ b/.harness/claude-progress.txt
@@ -61,3 +61,21 @@
 - 2026-07-23 adversarial Opus review APPROVE with 3 non-blocking nits (all captured by
   F022 or cosmetic); CI green (2 checks); merged --merge on approval; Linear OVI-49 Done
 - 2026-07-24 /harness-issue-prep OVI-50 -> F008: SV ASK (4 Qs answered), RV PASS (cycle 1); normalized spec + fresh spec.hash written to features.json; local-only (no stamp/label, Linear untouched)
+
+## Session 6 - 2026-07-24 (single-session)
+- Feature: F008 - [OVI-50] P1.2 one state boundary: shared harness_state.py for per-project hooks
+- Status: implementation complete; PR pending, CI + adversarial review + merge in progress this session
+- Tests: 170/170 passing (145 baseline + 25 new; TDD red phase confirmed 13 new hs: checks
+  failing first, plus the single-writer grep check)
+- Coverage: n/a (shell suite, no coverage tooling; full_test 170/170 is the gate)
+- Decisions: harness_state.py.template writes only the .tmp file (final mv stays in the
+  bash templates, preserving the grep-tested atomic pattern); increment-correction-cycles
+  keeps the original id+status=='in-progress' match gate, exit 3 reserved for a truly
+  missing id; session-start.sh delegates only the next-claimable algorithm, unchanged
+  fallback for pre-v5 projects — details in context_summary.md
+- Prep: /harness-issue-prep OVI-50 -> F008 this session: SV ASK (4 Qs, all answered),
+  RV PASS cycle 1; normalized spec + fresh spec.hash written to features.json
+- Next: /harness-issue-prep the next P2 issue (F009/OVI-51 or F010/OVI-52, both unblocked
+  by P1.1). Also refresh this repo's live .claude/hooks/*.sh from F003's AND F008's fixed
+  templates (still deferred); decide F022
+- Blockers: none

--- a/.harness/context_summary.md
+++ b/.harness/context_summary.md
@@ -4,8 +4,8 @@ Persistent record of architectural decisions, discovered patterns, gotchas, and 
 This file is referenced in CLAUDE.md and loaded every session.
 
 ## Active Context
-- Currently working on: F004 / OVI-49 merged (5b15018), OVI-49 Done in Linear
-- Next up: /harness-issue-prep the next P0/P1 issue, then implement; also refresh live .claude/hooks/*.sh from F003's fixed templates; F022 (discovered_via F004) needs a decision on the `coverage` field's type vs. this repo's own descriptive-string values
+- Currently working on: F008 / OVI-50 implemented this session (shared harness_state.py); PR pending, CI + review in progress
+- Next up: /harness-issue-prep the next P2 issue (P2.1/F009 or P2.2/F010, both unblocked by P1.1); also refresh live .claude/hooks/*.sh from F003's fixed templates AND from F008's new harness_state.py (now two things deferred, same reason); F022 (discovered_via F004) still needs a decision on the `coverage` field's type vs. this repo's own descriptive-string values
 
 ## Cross-Cutting Concerns
 - Stack: custom (shell hooks + JSON manifests + markdown skills; no application code)
@@ -27,10 +27,15 @@ This file is referenced in CLAUDE.md and loaded every session.
 - verify-task-quality is the only features.json writer besides the lead: targeted feature only, indent=2, trailing newline, atomic .tmp + mv (2026-07-22, OVI-48)
 - schemas/feature.schema.json (JSON Schema draft 2020-12) is now the single owner of the features.json envelope + 16-field feature object; scripts/validate-features.py hand-implements the same checks in stdlib Python (no jsonschema dependency, per spec) rather than loading the schema at runtime — the schema documents intent for humans/external tools, the script enforces it (2026-07-23, F004/OVI-49)
 - Only the 10 pre-v3.3 core fields are required in the schema/validator; the 5 operational metrics + `spec` are optional and type-checked only when present, so the existing shared test fixture (test/fixtures/harness-project/.harness/features.json, which predates v3.3 and has no envelope fields either) validates unmodified — kept envelope fields (project/created/total_features/passing) optional too for the same backward-compat reason (2026-07-23, F004)
+- harness_state.py.template's increment-correction-cycles writes only the `.tmp` file; the final `mv` promotion stays in the bash templates (verify-task-quality.sh.template), preserving the existing grep-tested atomic-write pattern (`grep -q 'mv '`) rather than moving the whole atomic write into Python (2026-07-24, F008/OVI-50)
+- increment-correction-cycles preserves the original id-AND-status=='in-progress' match gate exactly (silent no-op, exit 0, no write, if the id exists but status differs); the NEW exit-3 code is reserved strictly for "no feature with that id at all" — these are two different conditions the OVI-50 spec only fully specified for the latter (2026-07-24, F008)
+- session-start.sh (plugin-shipped, must support pre-v5 projects) delegates ONLY the next-claimable algorithm to harness_state.py when `.claude/hooks/harness_state.py` exists; the "Features: N/M passing" line and the fallback inline logic are untouched — per the OVI-50 spec's explicit scoping of point 4, not a full rewrite of session-start.sh's read path (2026-07-24, F008)
 
 ### Patterns
 - Tests must pin env vars the hooks read: run_session_start forces CLAUDE_PLUGIN_ROOT unset (env -u), run_session_start_with_root sets it — never inherit the test shell's env for hook behavior assertions (2026-07-22)
 - Fixture tests install templates via install_hooks and invoke them exactly the way settings.json does (`CLAUDE_PROJECT_DIR=<fixture> <fixture>/.claude/hooks/<name>.sh`) — testing through the real invocation form caught the cwd bugs the old `bash relative/path` form hid (2026-07-22)
+- To prove a delegated code path produces byte-identical output to the inline path it replaces, install the real module into one fixture and not the other, run the SAME hook against both, and diff the specific output line — don't just assert the delegated path "looks right" in isolation (2026-07-24, F008)
+- A portable way to simulate an atomic-write interrupt without OS-specific mocking: chmod the containing directory to remove write permission (555), attempt the write, assert the original file untouched and no tmp file was created, then chmod back — works on macOS and Linux CI without root (2026-07-24, F008)
 
 ### Gotchas
 - Baseline before any change: 66/66 assertions passing on main @ d3661ff (2026-07-22)
@@ -39,6 +44,7 @@ This file is referenced in CLAUDE.md and loaded every session.
 - session-start.sh's own warning blocks are the reference pattern for new orientation checks: wrap the whole python heredoc body in try/except pass AND pipe stderr to /dev/null with `|| true` at the shell level — belt-and-suspenders against a malformed features.json ever leaking a traceback into model context (2026-07-23, F002)
 - This repo's live .claude/hooks/*.sh lag the fixed templates: the old verify-task-quality corrupted correction_cycles (F003 +1, no trailing newline) when the gate rejected a TDD red-phase task completion; reset to 0 as a false positive. Refresh live hooks from templates after OVI-48 merges (2026-07-22)
 - Dogfooding scripts/validate-features.py against this repo's own live .harness/features.json (not required by F004's acceptance criteria, just a sanity check) found F001-F004's `coverage` field holds a descriptive string ("n/a (shell suite, no coverage tooling; full_test N/N is the gate)"), not the number|null the OVI-49 spec types verbatim. Did not loosen the schema or rewrite the live data to make this pass — filed as F022 (discovered_via F004) instead, since silently relaxing a just-verified spec to match existing non-conformant data would be gaming the check, not fixing it (2026-07-23, F004)
+- Marking a TDD sub-task "completed" while the suite is intentionally red still trips the TaskCompleted gate and bumps correction_cycles — this is now the FOURTH session in a row (F002, F003, F004, F008) hitting the identical false positive. The procedural fix (mark red-phase tasks complete only after green) keeps slipping under real work pressure; worth tightening harness-continue's task-template wording or the gate itself rather than continuing to just log it (2026-07-24, F008)
 
 ## Meta-Patterns
 <!-- Coordination insights that apply across features — NOT domain-specific.
@@ -155,3 +161,27 @@ This file is referenced in CLAUDE.md and loaded every session.
   check rather than duplicating the schema's `^F[0-9]{3}$` pattern check — acceptable
   drift given the no-jsonschema constraint, but noted for anyone touching this again).
   Merged on green CI (2 checks) + APPROVE @ 5b15018; Linear OVI-49 Done.
+
+## Meta-Session 2026-07-24 (session 6, F008/OVI-50)
+- Scope accuracy: F008's scope (harness_state.py.template + the two per-project hook
+  templates + session-start.sh + SKILL.md/INSTALL.md + test/run-tests.sh) matched the
+  work exactly; the one addition (updating install_hooks() test helper) was implied by
+  the refactor itself, not a scope expansion.
+- Model calibration: single-session, 2 correction_cycles — both the known TDD-red-phase
+  false-rejection (marking a sub-task complete mid-red), not real correction cycles.
+- Prep quality: this feature's spec went through SV ASK (4 questions) -> RV PASS in one
+  cycle. All 4 questions resolved genuine ambiguities that would have caused rework if
+  guessed at implementation time (especially the criterion-1-vs-point-3 contradiction on
+  the write-surface test, and the two unspecified edge cases for next-claimable/increment).
+  The prep investment paid for itself directly in this session.
+- Discovery lineage: none this session (no new features filed).
+- Approach patterns: preserving an EXISTING grep-tested pattern (the literal `mv ` string
+  in verify-task-quality.sh.template) shaped the module's design — increment-correction-cycles
+  writes only the .tmp file rather than doing a complete atomic write internally, keeping
+  the real promotion step in bash. Worth checking existing grep-based tests for what they
+  actually assert BEFORE consolidating logic into a new shared module, not after.
+- Approach patterns: writing a manual before/after comparison (install harness_state.py
+  into one fixture, not the other, diff the specific output line) caught that the
+  delegation-parity test would otherwise pass vacuously until session-start.sh's actual
+  delegation logic existed — a good habit for any "output must be identical" acceptance
+  criterion, not just a shell-test assertion.

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -2,7 +2,7 @@
   "project": "vv-claude-harness",
   "created": "2026-07-22",
   "total_features": 22,
-  "passing": 4,
+  "passing": 5,
   "features": [
     {
       "id": "F001",
@@ -249,7 +249,7 @@
       "id": "F008",
       "description": "## Problem\n\nEvery vv-harness hook re-implements `.harness/features.json` parsing and mutation\nindependently: session-start.sh has several separate inline python3 heredocs;\nstatusline.sh, session-end.sh, and every per-project hook template each duplicate this\nlogic. The divergence already produced one real inconsistency (P0.3: `.get()` vs. hard\nsubscripts). The sharper risk is multiple independent writers: `verify-task-quality.sh`\nand the lead both mutate the same file with no single owner.\n\nIntroduce `skills/harness-init/harness_state.py.template` \u2014 a stdlib-only Python module\ninstalled by `/harness-init` to `.claude/hooks/harness_state.py` \u2014 as the one place that\nwrites `features.json`, and migrate `check-remaining-tasks.sh`, `verify-task-quality.sh`,\nand (for the next-claimable algorithm only) `session-start.sh` to consume it via a small\nCLI: `load`, `next-claimable`, `counts`, `increment-correction-cycles <FID>`.\n\nPlugin hooks (session-start/end/statusline) stay self-contained with their own read-only\ndefensive parsing, since they must keep working against pre-v5 projects that lack\n`harness_state.py`; only the write path and the next-claimable *algorithm* are\nconsolidated \u2014 session-start.sh delegates to `harness_state.py` when present and falls\nback to its inline logic when it is not.\n\n## Acceptance criteria\n\n1. `grep -rl \"json.dump\" skills/harness-init/*.template | grep -v harness_state.py.template` returns no results \u2014 zero `json.dump` call sites outside `harness_state.py.template`. Any number of `json.dump` call sites inside `harness_state.py.template` is permitted.\n2. All P0.3 fixture tests pass unchanged against the refactored templates.\n3. `harness_state.py load`: a malformed JSON file exits 0, with a stderr note and an empty result (fail-soft for read paths).\n4. `harness_state.py increment-correction-cycles <FID>`: a missing feature id performs no write and exits 3.\n5. `harness_state.py increment-correction-cycles <FID>`: an existing feature id whose `correction_cycles` field is absent or null is initialized to 0, then incremented to 1, and the write succeeds with exit 0.\n6. `harness_state.py next-claimable`: when nothing is claimable (empty features list, all features passing, or every pending feature blocked by an unmet `depends_on`), it exits 0 and prints exactly `no claimable feature` to stdout, with no JSON payload.\n7. `harness_state.py`'s atomic write leaves either the old or the new content on a simulated interrupt; the tmp file is cleaned up (asserted by test).\n8. `session-start.sh`: with `.claude/hooks/harness_state.py` present in the fixture, `next-claimable` output is identical to the existing inline-computation path (test compares both).\n9. `bash test/run-tests.sh` is green.\n\n## Edge and error cases\n\n- `next-claimable` with nothing claimable \u2014 see criterion 6.\n- `increment-correction-cycles` with a missing FID \u2014 see criterion 4 (no write, exit 3).\n- `increment-correction-cycles` with an existing FID but absent/null `correction_cycles` \u2014 see criterion 5 (initialize to 0, increment to 1, write).\n- Malformed `features.json` on `load` \u2014 see criterion 3 (fail-soft, exit 0, stderr note, empty result).\n- An interrupted atomic write \u2014 see criterion 7 (old-or-new content guarantee, no orphaned tmp file).\n\n## Non-functional requirements\n\n- python3 stdlib only; no third-party dependencies.\n- bash 3.2+ compatibility (macOS system bash).\n- Single-writer invariant is code consolidation, not runtime write-serialization: all\n  `features.json`-writing code lives in `harness_state.py.template`; each invocation\n  (lead, `verify-task-quality.sh`, etc.) still performs its own independent atomic\n  tmp+mv write. No file lock, advisory lock, or IPC coordination between concurrent\n  invocations is required.\n- Plugin hooks (session-start/end/statusline) remain self-contained with their own\n  read-only defensive parsing for backward compatibility with pre-v5 projects.\n\n## Dependencies\n\nBlocked by P0.3 / F003 (green base, already passing) and P1.1 / F004 (schema semantics\nthe library implements, already passing).\n\n## Assumptions ledger\n\n- Single-writer invariant means code consolidation only (all write logic in one\n  module), not runtime lock-based serialization; concurrent invocations remain\n  independent atomic tmp+mv writers (2026-07-24, per Ovidiu).\n- The write-surface acceptance criterion is \"zero `json.dump` outside\n  `harness_state.py.template`,\" not an exact total count of 1; the template may\n  contain multiple `json.dump` call sites internally (2026-07-24, per Ovidiu).\n- `next-claimable` with nothing claimable: exit 0, stdout is the literal string\n  `no claimable feature`, no JSON payload (2026-07-24, per Ovidiu).\n- `increment-correction-cycles` on a feature with absent/null `correction_cycles`:\n  initialize to 0, then increment to 1, and write \u2014 not an error path; only a missing\n  FID triggers exit 3 (2026-07-24, per Ovidiu).\n\n## Out of scope\n\nRewriting the three plugin hooks' read paths beyond the next-claimable delegation; any\nnew state files; runtime write-serialization or file locking across concurrent\ninvocations (each invocation's own atomic tmp+mv write is sufficient).",
       "priority": 8,
-      "status": "pending",
+      "status": "passing",
       "scope": [
         "skills/harness-init/harness_state.py.template",
         "skills/harness-init/check-remaining-tasks.sh.template",
@@ -264,12 +264,15 @@
         "F004"
       ],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
+      "test_file": "test/run-tests.sh (== harness_state.py == section, hs: prefix)",
+      "coverage": "n/a (shell suite, no coverage tooling; full_test 170/170 is the gate)",
       "notes": "Linear: OVI-50. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
-      "correction_cycles": 0,
+      "correction_cycles": 2,
       "scope_expansions": [],
-      "approaches_tried": [],
+      "approaches_tried": [
+        "Extracted skills/harness-init/harness_state.py.template as a stdlib-only module (load/next-claimable/counts/increment-correction-cycles); the two per-project hook templates call it instead of their own inline python3 heredocs. Session-start.sh (plugin-shipped) delegates the next-claimable ALGORITHM only when .claude/hooks/harness_state.py exists, falling back to its untouched inline logic for pre-v5 projects.",
+        "Kept the final tmp->real 'mv' promotion in the bash templates (not inside the python module) specifically to preserve the existing grep-tested atomic-write pattern in verify-task-quality.sh.template; the module only writes the .tmp file, matching the original architecture."
+      ],
       "failure_reason": null,
       "discovered_via": null,
       "spec": {

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -132,6 +132,10 @@ manual steps, run in a Claude Code session inside the project, are the upgrade:
 3. Add the `statusLine`, `env`, and `permissions` wiring to `.claude/settings.json` per
    harness-init Step 3.6.
 4. Append `.harness/SESSION_INCOMPLETE` to `.gitignore`.
+5. Copy the shared state module: `cp "${CLAUDE_PLUGIN_ROOT}/skills/harness-init/harness_state.py.template"
+   .claude/hooks/harness_state.py && chmod +x .claude/hooks/harness_state.py` — `verify-task-quality.sh`
+   and `check-remaining-tasks.sh` consume it if present; re-copy the two templates from the
+   current plugin version too, since older per-project copies still have the old inline logic.
 
 ## Personalize your CLAUDE.md
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -39,6 +39,36 @@ try:
     feats = json.load(open(sys.argv[1])).get("features", [])
     passing = sum(1 for f in feats if f.get("status") == "passing")
     print(f"Features: {passing}/{len(feats)} passing")
+except Exception:
+    pass
+PYEOF
+
+# next-claimable: delegate the algorithm to harness_state.py when a per-project
+# copy exists (v5+ projects); fall back to the inline computation otherwise
+# (older projects initialized before this module existed).
+STATE_MODULE="$ROOT/.claude/hooks/harness_state.py"
+if [ -f "$STATE_MODULE" ] && [ -f "$H/features.json" ]; then
+  RESULT=$(python3 "$STATE_MODULE" next-claimable "$H/features.json" 2>/dev/null || true)
+  if [ "$RESULT" = "no claimable feature" ]; then
+    echo "Next claimable: none (no pending or failed features)"
+  elif [ -n "$RESULT" ]; then
+    python3 - "$RESULT" <<'PYEOF' 2>/dev/null || true
+import json, sys
+try:
+    data = json.loads(sys.argv[1])
+    f = data["next"]
+    scope = ", ".join(f.get("scope") or [])
+    desc = f.get("description", "")
+    print(f"Next claimable: {f.get('id', '?')} - {desc} (scope: {scope})")
+except Exception:
+    pass
+PYEOF
+  fi
+else
+  python3 - "$H/features.json" <<'PYEOF' 2>/dev/null || true
+import json, sys
+try:
+    feats = json.load(open(sys.argv[1])).get("features", [])
     status = {f.get("id"): f.get("status") for f in feats}
     claimable = [f for f in feats if f.get("status") in ("pending", "failed")
                  and all(status.get(d) == "passing" for d in (f.get("depends_on") or []))]
@@ -53,6 +83,7 @@ try:
 except Exception:
     pass
 PYEOF
+fi
 
 python3 - "$H/features.json" <<'PYEOF' 2>/dev/null || true
 import hashlib, json, sys

--- a/skills/harness-init/SKILL.md
+++ b/skills/harness-init/SKILL.md
@@ -254,17 +254,21 @@ Present the hook to the user and wait for confirmation before creating or modify
 Set up Agent Teams quality enforcement hooks. Read the `.sh.template` files in this skill's directory and install them:
 
 1. Create `.claude/hooks/` directory: `mkdir -p .claude/hooks`
-2. Copy `verify-task-quality.sh.template` to `.claude/hooks/verify-task-quality.sh`
-3. Copy `check-remaining-tasks.sh.template` to `.claude/hooks/check-remaining-tasks.sh`
-4. Copy `enforce-scope.sh.template` to `.claude/hooks/enforce-scope.sh`
-5. Copy `verify-git-identity.sh.template` to `.claude/hooks/verify-git-identity.sh`
-6. Copy the plugin's status line script into the project:
+2. Copy `harness_state.py.template` to `.claude/hooks/harness_state.py` — the shared,
+   stdlib-only `features.json` read/write module that `verify-task-quality.sh` and
+   `check-remaining-tasks.sh` consume (schema in
+   `${CLAUDE_PLUGIN_ROOT}/schemas/feature.schema.json`).
+3. Copy `verify-task-quality.sh.template` to `.claude/hooks/verify-task-quality.sh`
+4. Copy `check-remaining-tasks.sh.template` to `.claude/hooks/check-remaining-tasks.sh`
+5. Copy `enforce-scope.sh.template` to `.claude/hooks/enforce-scope.sh`
+6. Copy `verify-git-identity.sh.template` to `.claude/hooks/verify-git-identity.sh`
+7. Copy the plugin's status line script into the project:
    `cp "${CLAUDE_PLUGIN_ROOT}/hooks/statusline.sh" .claude/hooks/statusline.sh`
    — the plugin cache path changes on every plugin update, so the project keeps its own copy.
-7. Make all executable: `chmod +x .claude/hooks/*.sh`
-8. Append `.harness/SESSION_INCOMPLETE` to the project's `.gitignore` (create it if missing).
+8. Make all executable: `chmod +x .claude/hooks/*.sh .claude/hooks/harness_state.py`
+9. Append `.harness/SESSION_INCOMPLETE` to the project's `.gitignore` (create it if missing).
    It is transient session state written by the plugin's SessionEnd hook.
-9. Add to `.claude/settings.json` (merge with the PostToolUse hooks from Step 3.5):
+10. Add to `.claude/settings.json` (merge with the PostToolUse hooks from Step 3.5):
 
 ```json
 {

--- a/skills/harness-init/check-remaining-tasks.sh.template
+++ b/skills/harness-init/check-remaining-tasks.sh.template
@@ -18,56 +18,29 @@ if [ ! -f ".harness/features.json" ]; then
     exit 0
 fi
 
-# Check features.json for remaining work.
+# Check features.json for remaining work via the shared state module.
 # Status enum: pending, in-progress, blocked, passing, failed
 # Claimable statuses: pending (ready for work), failed (needs re-attempt)
-NEXT=$(python3 - <<'PYEOF' || true
+STATE_MODULE=".claude/hooks/harness_state.py"
+RESULT=$(python3 "$STATE_MODULE" next-claimable .harness/features.json || true)
+
+if [ -z "$RESULT" ] || [ "$RESULT" = "no claimable feature" ]; then
+    exit 0
+fi
+
+NEXT=$(printf '%s' "$RESULT" | python3 -c "
 import json
 import sys
 
-try:
-    with open('.harness/features.json') as fh:
-        data = json.load(fh)
-except Exception as exc:
-    print(f"check-remaining-tasks: cannot parse features.json: {exc}", file=sys.stderr)
-    sys.exit(0)
+data = json.load(sys.stdin)
+f = data['next']
+status_note = ' (retry)' if f.get('status') == 'failed' else ''
+scope = ', '.join(f.get('scope') or []) or 'no scope defined'
+print(f\"{data['count']} claimable feature(s). Next: {f.get('id')}: \"
+      f\"{f.get('description')} (priority {f.get('priority', 'unset')})\"
+      f\"{status_note} [scope: {scope}]\")
+")
 
-features = data.get('features', []) if isinstance(data, dict) else []
-valid = []
-for entry in features:
-    try:
-        entry.get('status')
-        valid.append(entry)
-    except Exception:
-        print(f"check-remaining-tasks: skipping malformed feature entry: {entry!r}",
-              file=sys.stderr)
-
-passing_ids = {f.get('id') for f in valid if f.get('status') == 'passing'}
-claimable = []
-for f in valid:
-    try:
-        if f.get('status') in ('pending', 'failed') \
-                and all(dep in passing_ids for dep in f.get('depends_on') or []):
-            claimable.append(f)
-    except Exception as exc:
-        print(f"check-remaining-tasks: skipping malformed feature entry "
-              f"{f.get('id')!r}: {exc}", file=sys.stderr)
-if claimable:
-    claimable.sort(key=lambda f: f.get('priority') or 999)
-    f = claimable[0]
-    status_note = ' (retry)' if f.get('status') == 'failed' else ''
-    scope = ', '.join(f.get('scope') or []) or 'no scope defined'
-    print(f"{len(claimable)} claimable feature(s). Next: {f.get('id')}: "
-          f"{f.get('description')} (priority {f.get('priority', 'unset')})"
-          f"{status_note} [scope: {scope}]")
-PYEOF
-)
-
-if [ -n "$NEXT" ]; then
-    echo "$NEXT"
-    echo "Read .harness/features.json for full details, then claim it via TaskUpdate."
-    exit 2
-fi
-
-# No remaining work
-exit 0
+echo "$NEXT"
+echo "Read .harness/features.json for full details, then claim it via TaskUpdate."
+exit 2

--- a/skills/harness-init/harness_state.py.template
+++ b/skills/harness-init/harness_state.py.template
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+
+CLAIMABLE_STATUSES = ("pending", "failed")
+
+
+def load_valid_features(path):
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except (OSError, ValueError) as exc:
+        print(f"harness_state: cannot parse {path}: {exc}", file=sys.stderr)
+        return []
+    features = data.get("features", []) if isinstance(data, dict) else []
+    valid = []
+    for entry in features:
+        try:
+            entry.get("status")
+        except AttributeError:
+            print(f"harness_state: skipping malformed feature entry: {entry!r}", file=sys.stderr)
+            continue
+        valid.append(entry)
+    return valid
+
+
+def compute_claimable(valid):
+    passing_ids = {f.get("id") for f in valid if f.get("status") == "passing"}
+    claimable = []
+    for f in valid:
+        try:
+            deps_ok = all(dep in passing_ids for dep in f.get("depends_on") or [])
+        except TypeError as exc:
+            print(
+                f"harness_state: skipping malformed feature entry {f.get('id')!r}: {exc}",
+                file=sys.stderr,
+            )
+            continue
+        if f.get("status") in CLAIMABLE_STATUSES and deps_ok:
+            claimable.append(f)
+    return claimable
+
+
+def write_atomic_tmp(path, data):
+    tmp_path = path + ".tmp"
+    try:
+        os.remove(tmp_path)
+    except OSError:
+        pass
+    try:
+        with open(tmp_path, "w") as fh:
+            json.dump(data, fh, indent=2)
+            fh.write("\n")
+    except OSError as exc:
+        print(f"harness_state: could not write {tmp_path}: {exc}", file=sys.stderr)
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+        return False
+    return True
+
+
+def cmd_load(path):
+    print(json.dumps(load_valid_features(path)))
+    return 0
+
+
+def cmd_next_claimable(path):
+    claimable = compute_claimable(load_valid_features(path))
+    if not claimable:
+        print("no claimable feature")
+        return 0
+    claimable.sort(key=lambda f: f.get("priority", 999))
+    print(json.dumps({"count": len(claimable), "next": claimable[0]}))
+    return 0
+
+
+def cmd_counts(path):
+    valid = load_valid_features(path)
+    passing = sum(1 for f in valid if f.get("status") == "passing")
+    in_progress = [f.get("id") for f in valid if f.get("status") == "in-progress"]
+    print(json.dumps({"passing": passing, "total": len(valid), "in_progress": in_progress}))
+    return 0
+
+
+def cmd_increment_correction_cycles(path, feature_id):
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except (OSError, ValueError) as exc:
+        print(f"harness_state: cannot parse {path}: {exc}", file=sys.stderr)
+        return 1
+    features = data.get("features", []) if isinstance(data, dict) else []
+    match = next(
+        (f for f in features if isinstance(f, dict) and f.get("id") == feature_id), None
+    )
+    if match is None:
+        print(f"harness_state: no feature with id {feature_id!r}", file=sys.stderr)
+        return 3
+    if match.get("status") != "in-progress":
+        return 0
+    current = match.get("correction_cycles")
+    match["correction_cycles"] = (current if current is not None else 0) + 1
+    return 0 if write_atomic_tmp(path, data) else 1
+
+
+USAGE = (
+    "usage: harness_state.py <load|next-claimable|counts|increment-correction-cycles> "
+    "<features.json> [feature_id]"
+)
+
+
+def main(argv):
+    if len(argv) < 3:
+        print(USAGE, file=sys.stderr)
+        return 2
+    verb, path = argv[1], argv[2]
+    if verb == "load":
+        return cmd_load(path)
+    if verb == "next-claimable":
+        return cmd_next_claimable(path)
+    if verb == "counts":
+        return cmd_counts(path)
+    if verb == "increment-correction-cycles":
+        if len(argv) < 4:
+            print(USAGE, file=sys.stderr)
+            return 2
+        return cmd_increment_correction_cycles(path, argv[3])
+    print(f"harness_state: unknown verb {verb!r}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/skills/harness-init/verify-task-quality.sh.template
+++ b/skills/harness-init/verify-task-quality.sh.template
@@ -43,9 +43,10 @@ if [ ! -f ".harness/init.sh" ]; then
     exit 2
 fi
 
-# Increment correction_cycles for the targeted in-progress feature.
-# This tracks how many times the quality gate rejected completion —
-# useful for retrospectives and dynamic model selection.
+# Increment correction_cycles for the targeted in-progress feature via the
+# shared state module. This tracks how many times the quality gate rejected
+# completion — useful for retrospectives and dynamic model selection.
+STATE_MODULE=".claude/hooks/harness_state.py"
 increment_correction_cycles() {
     if [ -z "$FEATURE_ID" ]; then
         echo "verify-task-quality: no feature_id in task metadata or subject;" \
@@ -56,31 +57,10 @@ increment_correction_cycles() {
         return 0
     fi
     # Clear any tmp orphaned by an earlier killed run: the guarded mv below
-    # must only ever promote a tmp that THIS python invocation wrote.
+    # must only ever promote a tmp that THIS invocation wrote.
     rm -f .harness/features.json.tmp
-    python3 - "$FEATURE_ID" <<'PYEOF'
-import json, sys
-target_id = sys.argv[1]
-try:
-    with open('.harness/features.json', 'r') as f:
-        data = json.load(f)
-    changed = False
-    for feature in data.get('features', []):
-        if feature.get('id') == target_id and feature.get('status') == 'in-progress':
-            feature['correction_cycles'] = feature.get('correction_cycles', 0) + 1
-            changed = True
-    if changed:
-        with open('.harness/features.json.tmp', 'w') as f:
-            json.dump(data, f, indent=2)
-            f.write('\n')
-except Exception as e:
-    print(f"verify-task-quality: could not update correction_cycles: {e}", file=sys.stderr)
-    import os
-    try:
-        os.remove('.harness/features.json.tmp')
-    except OSError:
-        pass
-PYEOF
+    python3 "$STATE_MODULE" increment-correction-cycles .harness/features.json "$FEATURE_ID" \
+        2>&1 || true
     if [ -f ".harness/features.json.tmp" ]; then
         mv .harness/features.json.tmp .harness/features.json
     fi

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -84,7 +84,8 @@ run_statusline() {
 
 TEMPLATES_DIR="$REPO_ROOT/skills/harness-init"
 
-# Installs the hook templates into $1/.claude/hooks/ as executable .sh files.
+# Installs the hook templates into $1/.claude/hooks/ as executable .sh files,
+# plus harness_state.py which check-remaining-tasks.sh and verify-task-quality.sh consume.
 install_hooks() {
   mkdir -p "$1/.claude/hooks"
   for TPL in "$TEMPLATES_DIR"/*.sh.template; do
@@ -92,6 +93,8 @@ install_hooks() {
     cp "$TPL" "$1/.claude/hooks/$BASE"
     chmod +x "$1/.claude/hooks/$BASE"
   done
+  cp "$TEMPLATES_DIR/harness_state.py.template" "$1/.claude/hooks/harness_state.py"
+  chmod +x "$1/.claude/hooks/harness_state.py"
 }
 
 # Invokes a hook the way settings.json does: "$CLAUDE_PROJECT_DIR"/.claude/hooks/<name>.sh
@@ -1020,6 +1023,188 @@ if [ -z "$SETTINGS_BLOCK_ERRORS" ]; then
   pass "ht: SKILL.md settings block invokes hooks via \$CLAUDE_PROJECT_DIR"
 else
   fail "ht: SKILL.md settings block -- $SETTINGS_BLOCK_ERRORS"
+fi
+
+echo ""
+echo "== harness_state.py =="
+
+STATE_MODULE_TEMPLATE="$TEMPLATES_DIR/harness_state.py.template"
+
+hs_increment() {
+  python3 "$STATE_MODULE_TEMPLATE" increment-correction-cycles "$1" "$2"
+}
+
+hs_read_correction_cycles() {
+  python3 -c "
+import json
+data = json.load(open('$1'))
+print(data['features'][0]['correction_cycles'])
+"
+}
+
+DUMP_HITS=$(grep -l "json.dump" "$TEMPLATES_DIR"/*.template 2>/dev/null \
+  | grep -v "harness_state.py.template" || true)
+if [ -z "$DUMP_HITS" ]; then
+  pass "hs: zero json.dump call sites outside harness_state.py.template"
+else
+  fail "hs: json.dump found outside harness_state.py.template in: $DUMP_HITS"
+fi
+
+HS_LOAD="$WORK/hs-load"
+mkdir -p "$HS_LOAD"
+printf '{ not json' > "$HS_LOAD/features.json"
+OUT=$(python3 "$STATE_MODULE_TEMPLATE" load "$HS_LOAD/features.json" 2>"$HS_LOAD/stderr.log")
+RC=$?
+assert_rc0 "$RC" "hs: load exits 0 on malformed JSON"
+assert_contains "$OUT" "[]" "hs: load prints an empty result on malformed JSON"
+HS_LOAD_STDERR=$(cat "$HS_LOAD/stderr.log")
+assert_contains "$HS_LOAD_STDERR" "cannot parse" "hs: load notes the parse failure on stderr"
+
+HS_MISSING="$WORK/hs-missing-fid"
+mkdir -p "$HS_MISSING"
+printf '{"features": [{"id": "F001", "status": "in-progress", "correction_cycles": 2}]}' \
+  > "$HS_MISSING/features.json"
+SUM_BEFORE=$(cksum < "$HS_MISSING/features.json")
+OUT=$(hs_increment "$HS_MISSING/features.json" F099 2>&1)
+RC=$?
+if [ "$RC" -eq 3 ]; then
+  pass "hs: increment on a missing feature id exits 3"
+else
+  fail "hs: increment on a missing feature id exited $RC, expected 3"
+fi
+SUM_AFTER=$(cksum < "$HS_MISSING/features.json")
+if [ "$SUM_BEFORE" = "$SUM_AFTER" ]; then
+  pass "hs: increment on a missing feature id performs no write"
+else
+  fail "hs: increment on a missing feature id modified features.json"
+fi
+if [ -f "$HS_MISSING/features.json.tmp" ]; then
+  fail "hs: increment on a missing feature id left a tmp file"
+else
+  pass "hs: increment on a missing feature id leaves no tmp file"
+fi
+
+HS_INIT="$WORK/hs-init-cc"
+mkdir -p "$HS_INIT"
+printf '{"features": [{"id": "F001", "status": "in-progress"}]}' > "$HS_INIT/features.json"
+OUT=$(hs_increment "$HS_INIT/features.json" F001 2>&1)
+RC=$?
+assert_rc0 "$RC" "hs: increment on an absent correction_cycles field exits 0"
+if [ -f "$HS_INIT/features.json.tmp" ]; then
+  CC=$(hs_read_correction_cycles "$HS_INIT/features.json.tmp")
+  if [ "$CC" = "1" ]; then
+    pass "hs: absent correction_cycles is initialized to 1"
+  else
+    fail "hs: correction_cycles was $CC, expected 1"
+  fi
+else
+  fail "hs: expected increment to write a .tmp file"
+fi
+
+HS_INIT_NULL="$WORK/hs-init-cc-null"
+mkdir -p "$HS_INIT_NULL"
+printf '{"features": [{"id": "F001", "status": "in-progress", "correction_cycles": null}]}' \
+  > "$HS_INIT_NULL/features.json"
+OUT=$(hs_increment "$HS_INIT_NULL/features.json" F001 2>&1)
+RC=$?
+assert_rc0 "$RC" "hs: increment on a null correction_cycles field exits 0"
+CC=$(hs_read_correction_cycles "$HS_INIT_NULL/features.json.tmp")
+if [ "$CC" = "1" ]; then
+  pass "hs: null correction_cycles is initialized to 1"
+else
+  fail "hs: correction_cycles was $CC, expected 1"
+fi
+
+HS_GATE="$WORK/hs-status-gate"
+mkdir -p "$HS_GATE"
+printf '{"features": [{"id": "F001", "status": "pending", "correction_cycles": 0}]}' \
+  > "$HS_GATE/features.json"
+OUT=$(hs_increment "$HS_GATE/features.json" F001 2>&1)
+RC=$?
+assert_rc0 "$RC" "hs: increment on a non-in-progress feature exits 0 (silent no-op)"
+if [ -f "$HS_GATE/features.json.tmp" ]; then
+  fail "hs: a non-in-progress feature should not produce a tmp write"
+else
+  pass "hs: a non-in-progress feature produces no tmp write"
+fi
+
+HS_NONE="$WORK/hs-none-claimable"
+mkdir -p "$HS_NONE"
+cat > "$HS_NONE/features.json" <<'JSON'
+{"features": [{"id": "F001", "status": "passing", "priority": 1, "scope": [], "depends_on": []}]}
+JSON
+OUT=$(python3 "$STATE_MODULE_TEMPLATE" next-claimable "$HS_NONE/features.json" 2>&1)
+RC=$?
+assert_rc0 "$RC" "hs: next-claimable exits 0 when nothing is claimable"
+if [ "$OUT" = "no claimable feature" ]; then
+  pass "hs: next-claimable prints the exact literal string when empty"
+else
+  fail "hs: next-claimable printed '$OUT', expected 'no claimable feature'"
+fi
+
+HS_SOME="$WORK/hs-claimable"
+mkdir -p "$HS_SOME"
+cat > "$HS_SOME/features.json" <<'JSON'
+{"features": [
+  {"id": "F001", "status": "passing", "priority": 1, "scope": [], "depends_on": []},
+  {"id": "F002", "status": "pending", "priority": 2, "scope": ["src/x/"], "depends_on": ["F001"]}
+]}
+JSON
+OUT=$(python3 "$STATE_MODULE_TEMPLATE" next-claimable "$HS_SOME/features.json" 2>&1)
+RC=$?
+assert_rc0 "$RC" "hs: next-claimable exits 0 when a feature is claimable"
+assert_contains "$OUT" '"id": "F002"' "hs: next-claimable JSON names the claimable feature"
+
+HS_COUNTS="$WORK/hs-counts"
+mkdir -p "$HS_COUNTS"
+cat > "$HS_COUNTS/features.json" <<'JSON'
+{"features": [
+  {"id": "F001", "status": "passing"},
+  {"id": "F002", "status": "in-progress"},
+  {"id": "F003", "status": "pending"}
+]}
+JSON
+OUT=$(python3 "$STATE_MODULE_TEMPLATE" counts "$HS_COUNTS/features.json" 2>&1)
+RC=$?
+assert_rc0 "$RC" "hs: counts exits 0"
+assert_contains "$OUT" '"passing": 1' "hs: counts reports the passing count"
+assert_contains "$OUT" '"total": 3' "hs: counts reports the total count"
+assert_contains "$OUT" '"F002"' "hs: counts lists in-progress ids"
+
+HS_INTERRUPT="$WORK/hs-interrupt"
+mkdir -p "$HS_INTERRUPT"
+printf '{"features": [{"id": "F001", "status": "in-progress", "correction_cycles": 0}]}' \
+  > "$HS_INTERRUPT/features.json"
+chmod 555 "$HS_INTERRUPT"
+OUT=$(hs_increment "$HS_INTERRUPT/features.json" F001 2>&1)
+RC=$?
+chmod 755 "$HS_INTERRUPT"
+assert_rc_nonzero "$RC" "hs: a write failure (permission-denied dir) exits non-zero"
+assert_contains "$(cat "$HS_INTERRUPT/features.json")" '"correction_cycles": 0' \
+  "hs: original features.json is unchanged after a write failure"
+if [ -f "$HS_INTERRUPT/features.json.tmp" ]; then
+  fail "hs: a failed write left an orphaned tmp file"
+else
+  pass "hs: a failed write leaves no orphaned tmp file"
+fi
+
+DIR_HS_PLAIN="$WORK/hs-delegate-plain"
+make_fixture "$DIR_HS_PLAIN"
+OUT_PLAIN=$(run_session_start "$DIR_HS_PLAIN" '{"source":"startup"}')
+NEXT_PLAIN=$(printf '%s\n' "$OUT_PLAIN" | grep "^Next claimable:")
+
+DIR_HS_MODULE="$WORK/hs-delegate-module"
+make_fixture "$DIR_HS_MODULE"
+mkdir -p "$DIR_HS_MODULE/.claude/hooks"
+cp "$STATE_MODULE_TEMPLATE" "$DIR_HS_MODULE/.claude/hooks/harness_state.py"
+chmod +x "$DIR_HS_MODULE/.claude/hooks/harness_state.py"
+OUT_MODULE=$(run_session_start "$DIR_HS_MODULE" '{"source":"startup"}')
+NEXT_MODULE=$(printf '%s\n' "$OUT_MODULE" | grep "^Next claimable:")
+
+if [ -n "$NEXT_PLAIN" ] && [ "$NEXT_PLAIN" = "$NEXT_MODULE" ]; then
+  pass "hs: next-claimable output is identical whether harness_state.py is present or not"
+else
+  fail "hs: next-claimable output differs -- plain: '$NEXT_PLAIN' module: '$NEXT_MODULE'"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- New `skills/harness-init/harness_state.py.template`: stdlib-only module (no third-party deps), small CLI: `load`, `next-claimable`, `counts`, `increment-correction-cycles`. Becomes the one code path that writes `.harness/features.json`.
- `check-remaining-tasks.sh.template` and `verify-task-quality.sh.template` now call the CLI instead of duplicating inline python3 heredocs. The final `.tmp` → real `mv` promotion stays in the bash template (preserves the existing grep-tested atomic-write pattern).
- `session-start.sh` (plugin-shipped, must keep working on pre-v5 projects) delegates only the `next-claimable` algorithm to `harness_state.py` when a per-project copy exists; falls back to its untouched inline logic otherwise. Verified byte-identical output both ways.
- `increment-correction-cycles` preserves the original id+status=='in-progress' match gate exactly; exit code 3 is new and reserved specifically for "no feature with that id at all." A present-but-absent/null `correction_cycles` field is initialized to 0 before incrementing (not an error).
- `skills/harness-init/SKILL.md` Step 3.6 and `INSTALL.md`'s upgrade section updated with the install + chmod step.

Spec was ambiguous on 4 points (single-writer scope, write-surface acceptance-criterion wording, next-claimable empty-result contract, increment-correction-cycles missing-field behavior) — all resolved via `/harness-issue-prep` before implementation (SV ASK → 4 answers → RV PASS), see the normalized spec in `.harness/features.json` (F008).

Linear: OVI-50

## Test plan
- [x] `bash test/run-tests.sh` — 170/170 (145 baseline + 25 new)
- [x] TDD red phase confirmed first: 13 new `hs:` checks + the single-writer grep check all failed before the module/refactor existed
- [x] All existing P0.3 `ht:` fixture tests pass unchanged against the refactored templates
- [x] Manually diffed session-start.sh output with and without `harness_state.py` installed — byte-identical `Next claimable:` line