### PR TITLE
P2.2: Claim-matched proof, per-feature coverage target, delivery closure

### DIFF
--- a/.harness/claude-progress.txt
+++ b/.harness/claude-progress.txt
@@ -112,3 +112,23 @@
   regression test, 207/207; re-review APPROVE end-to-end against the real hook; merged
   @ 8ec5df5; Linear OVI-51 Done
 - 2026-07-24 /harness-issue-prep OVI-52 -> F010: SV ASK (6 Qs) -> RV ASK (1 new gap: qa_binding field, cycle 1) -> RV PASS (cycle 2); remote mode, Linear description updated + spec_hash written to features.json; UNSTAMPED (same Keychain/Bash-sandbox block as OVI-51, confirmed persistent; Ovidiu declined the sandbox override again) -- no label applied
+
+## Session 8 - 2026-07-24 (single-session)
+- Feature: F010 - [OVI-52] P2.2 claim-matched proof, per-feature coverage target, delivery closure
+- Status: implementation complete; PR pending, CI + adversarial review + merge in progress this session
+- Tests: 247/247 passing (207 baseline + 40 new; TDD red phase confirmed 21 new
+  fsv:/ht:/pf:/z:/w: checks failing first)
+- Coverage: n/a (shell suite, no coverage tooling; full_test 247/247 is the gate)
+- Decisions: 5 new optional feature fields (qa_binding, proof, coverage_target,
+  delivered, design_contract), all backward-compatible; done-definition is now three
+  tiers (passing -> done -> shipped); verify-task-quality.sh reads coverage_target and
+  proof/qa_binding straight off the targeted feature at accept-time, no status check;
+  session-end.sh's proof discipline note is informational only, not a
+  SESSION_INCOMPLETE trigger — details in context_summary.md
+- Found and fixed: two pre-existing test fixtures collided with new fields/behavior
+  (F004's "unknown field" example used `proof`; session-end's "clean" fixture had
+  F001 already passing with no proof) — both fixed, not worked around
+- Next: /harness-issue-prep the next P2/P3 issue (F011-F021 remain). Also refresh live
+  .claude/hooks/*.sh from F003's/F008's/F009's/F010's fixed templates (still deferred);
+  decide F022
+- Blockers: none

--- a/.harness/context_summary.md
+++ b/.harness/context_summary.md
@@ -4,8 +4,8 @@ Persistent record of architectural decisions, discovered patterns, gotchas, and 
 This file is referenced in CLAUDE.md and loaded every session.
 
 ## Active Context
-- Currently working on: F010 / OVI-52 prepped this session (SV ASK -> 6 Qs -> RV ASK, 1 new gap -> RV PASS cycle 2); normalized, remote write-back to Linear done, UNSTAMPED (Keychain still blocked by Bash sandbox); not yet implemented
-- Next up: implement F010/OVI-52 (lane=code, risk=standard). Also refresh live .claude/hooks/*.sh from F003's/F008's/F009's fixed templates (still deferred); F022 (discovered_via F004) still needs a decision on the `coverage` field's type vs. this repo's own descriptive-string values
+- Currently working on: F010 / OVI-52 implemented this session (qa_binding/proof/coverage_target/delivered/design_contract); PR pending, CI + review in progress
+- Next up: /harness-issue-prep the next P2/P3 issue (F011-F021 remain, most depend_on the now-passing F001/F002/F003 baseline). Also refresh live .claude/hooks/*.sh from F003's/F008's/F009's/F010's fixed templates (four things deferred now, same reason); F022 (discovered_via F004) still needs a decision on the `coverage` field's type vs. this repo's own descriptive-string values
 
 ## Cross-Cutting Concerns
 - Stack: custom (shell hooks + JSON manifests + markdown skills; no application code)
@@ -19,6 +19,18 @@ This file is referenced in CLAUDE.md and loaded every session.
 ## Domain: Harness Plugin Engineering
 
 ### Decisions
+- Claim-matched proof (F010/OVI-52): five new optional feature fields (`qa_binding`,
+  `proof`, `coverage_target`, `delivered`, `design_contract`), all backward-compatible
+  (absent/null forever valid). The done-definition is now three tiers: passing
+  (mechanical: tests + coverage_target) -> done (passing + proof) -> shipped (done +
+  delivered). `verify-task-quality.sh`'s coverage_target gate and proof/qa_binding WARN
+  both read straight off the TARGETED feature's own object at accept-time — no external
+  lookup, no status-field check (the hook itself never sets status="passing", so
+  "accepted" is the operative event, not a status transition) (2026-07-24, F010)
+- `harness-issue-prep`'s Step 5 template gained a mandatory "QA binding" line, and
+  `spec-verification`'s SV-01 check now flags a spec missing one — naturally prospective
+  since it's new text in a static agent definition file: only future invocations see it,
+  no grandfather-clause logic needed (2026-07-24, F010)
 - enforce-scope.sh.template now handles both Edit/Write/MultiEdit and Bash matchers.
   The pre-existing out-of-scope Edit/Write check is untouched (exit 2, "legacy path
   until touched" per Amendment 5). Two new denial paths — lead-owned state files
@@ -51,6 +63,18 @@ This file is referenced in CLAUDE.md and loaded every session.
 - A portable way to simulate an atomic-write interrupt without OS-specific mocking: chmod the containing directory to remove write permission (555), attempt the write, assert the original file untouched and no tmp file was created, then chmod back — works on macOS and Linux CI without root (2026-07-24, F008)
 
 ### Gotchas
+- Two existing test fixtures broke silently when F010 added new known feature fields
+  and new session-end.sh behavior: (1) F004's "unknown field" test used `proof` as its
+  example of a not-yet-existing field name — became a real, validated field this
+  session, so the test needed a genuinely-still-unused field name (`custom_metadata`)
+  instead. (2) session-end.sh's "clean session prints nothing" fixture had F001
+  already `passing` with no `proof` in the BASE shared fixture (unrelated to what the
+  test itself mutates) — the new proof-discipline-note logic correctly flagged it,
+  breaking the "prints nothing" assertion; fixed by giving F001 a proof object too.
+  Both are the same lesson: when a new field/behavior becomes real, grep the whole
+  test suite for anything that used its name/shape as a "doesn't exist yet" example or
+  relied on a shared fixture's OTHER entries being unaffected by new logic
+  (2026-07-24, F010)
 - F008's single-writer grep test (`grep -l "json.dump" ...`) false-positived on F009's
   legitimate new `json.dumps(...)` calls (serializing a JSON string for hook stdout,
   not writing features.json at all) — "json.dump" is a substring of "json.dumps".
@@ -251,3 +275,31 @@ This file is referenced in CLAUDE.md and loaded every session.
   one-line change (take the LAST match, not the first) plus a regression test; re-review
   confirmed APPROVE end-to-end against the real hook, not just re-reading the diff.
   Merged clean @ 8ec5df5; Linear OVI-51 Done.
+
+## Meta-Session 2026-07-24 (session 8, F010/OVI-52)
+- Scope accuracy: initial scope (6 entries) expanded to 9 mid-implementation once the
+  schema-split-ownership pattern (F004) and the doc-consolidation requirements
+  (Amendment item 5) were followed through to their actual file targets
+  (scripts/validate-features.py, skills/harness-init/SKILL.md, agents/spec-verification.md).
+  Same lesson as F009's session: read acceptance criteria for "every X" claims and check
+  the feature's scope array actually covers every X before starting, not after.
+- Model calibration: single-session, 4 correction_cycles — all the known TDD-red-phase
+  false-rejection pattern (now six sessions running: F002, F003, F004, F008, F009,
+  F010). This has never once been a real correction. Worth a harder look at whether the
+  procedural fix (mark red-phase tasks complete only after green) needs to become
+  mechanical instead of relying on memory, since six sessions of "don't do this" hasn't
+  stopped it recurring.
+- Prep quality: this spec needed 2 RV cycles, not 1 — cycle 1 surfaced a genuine new
+  gap (qa_binding had no machine-readable home) that neither the original SV report nor
+  the human's first round of answers had caught. Lesson reinforced from F009: RV isn't
+  just re-checking the human's answers, it's re-deriving testability from scratch, and
+  that can find things nobody asked about yet.
+- Discovery lineage: no new features filed. Found and fixed two pre-existing test
+  fragility issues (see Gotchas) — both were "a new field/behavior collided with an
+  existing test's fixture assumptions," not the same bug twice, but the same category.
+- Approach patterns: designing the coverage_target/proof mechanism required accepting
+  that THIS repo's own coverage field (a descriptive string) means the new gate stays
+  dormant here — rather than forcing a decision on F022 to make the new feature
+  "fully exercised" in this repo, the gate was built to degrade gracefully (skip when
+  coverage isn't numeric) so it's correct and testable via fixture for any project,
+  including this one whenever F022 is eventually resolved.

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -2,7 +2,7 @@
   "project": "vv-claude-harness",
   "created": "2026-07-22",
   "total_features": 22,
-  "passing": 5,
+  "passing": 7,
   "features": [
     {
       "id": "F001",
@@ -328,25 +328,35 @@
       "id": "F010",
       "description": "## Problem\n\nvv-harness today defines \"done\" uniformly for every feature: `passing` + `test_file` + coverage >= 95%. Nothing represents review, merge, or user-visible verification, and for UI-heavy work, unit coverage proves the wrong boundary \u2014 a green check doesn't say what it actually established, or what it didn't.\n\nIntroduce a claim-matched proof mechanism: each feature can declare a `qa_binding` (the kind of evidence it promises) at prep time, and record a `proof` object (claim, evidence type, artifact, and \u2014 critically \u2014 what the evidence did NOT establish) at completion time. `verify-task-quality.sh` warns (never blocks) when a feature passes without proof, or with proof that doesn't match its declared binding. A `coverage_target` lets non-unit-test-shaped features declare a different bar than the 95% default, and an optional `delivered` record closes the loop through PR merge.\n\nThe \"Feature is not done until\" sentence becomes the single, one-time-only owner of the done-definition (passing = mechanical gate; done = passing + proof recorded; shipped = done + delivered) \u2014 consolidating the two copies that exist today (`rules/agent-teams-protocol.md` and `skills/harness-init/SKILL.md`) down to one.\n\n## Acceptance criteria\n\n1. Validator accepts features with/without the four new fields (`qa_binding`, `proof`, `coverage_target`, `delivered`). When `proof` is present, it rejects a proof object missing any of `claim`, `evidence_type`, `artifact`, or `not_established`, or where any of those four is an empty string. It rejects a bad `evidence_type` or `qa_binding` value (not in the shared enum) and an out-of-range `coverage_target` (outside 1-100).\n2. Fixture test: feature with `coverage_target: 80` and 85% coverage -> TaskCompleted accepts; without the field and 85% -> rejects (95% default applies).\n3. Fixture tests, all reading `qa_binding`/`proof` directly off the feature object:\n   a. Passing feature with no `proof` -> hook output contains the no-proof warning.\n   b. Passing feature with `proof` present, `qa_binding` present, `proof.evidence_type` == `qa_binding` -> no warning.\n   c. Passing feature with `proof` present, `qa_binding` present, `proof.evidence_type` != `qa_binding` -> hook output contains the mismatch warning naming both values.\n   d. Passing feature with `proof` present, `qa_binding` absent (legacy) -> no warning.\n4. The literal string \"Feature is not done until\" appears exactly once across all `*.md` files (grep test), in `rules/agent-teams-protocol.md`; `skills/harness-init/SKILL.md`'s prior copy is converted to a link. `bash test/run-tests.sh` green.\n5. The prep template (harness-issue-prep Step 5's canonical spec template) contains a \"QA binding\" line; the spec-verification checklist's SV-01 check treats a missing binding as a flag, prospectively (not retroactive to pre-existing specs including <issue id=\"184b13fc-e119-46aa-82a8-627cdd95c3e5\" href=\"https://linear.app/eftimie/issue/OVI-52/p22-claim-matched-proof-per-feature-coverage-target-delivery-closure\">OVI-52</issue>).\n6. Schema accepts an optional `design_contract: string|null` field.\n7. Schema accepts `evidence_type` and `qa_binding` value `\"conformance\"`.\n\n## Edge and error cases\n\n* Old projects: absent fields (`qa_binding`, `proof`, `coverage_target`, `delivered`, `design_contract`) remain valid forever.\n* `delivered.merged_at`, when present, must be valid ISO8601 \u2014 rejected otherwise.\n* `coverage_target` override justification in `notes` is advisory only, never machine-checked.\n* `qa_binding` absent means the mismatch-warning case (3c) never fires for that feature \u2014 only the no-proof case (3a) or no-warning case (3d/legacy) apply.\n* No new dependencies.\n\n## Non-functional requirements\n\n* No new blocking gates: warn first, promote to blocking only if the warning proves insufficient in practice (promotion criterion to be recorded when/if that happens).\n* `verify-task-quality.sh` reads `qa_binding` and `proof` directly off the feature object \u2014 no external lookup, no re-parsing of prose.\n\n## Dependencies\n\nBlocked by P1.1 (schema owner). Complements P0.3/P1.2 (hook write path). The QA-binding SV-01 rule (acceptance criterion 5) modifies the harness-issue-prep skill and the spec-verification agent's own checklist \u2014 both of which are actively used to prep and verify THIS spec. This circularity is resolved by making the rule prospective: <issue id=\"184b13fc-e119-46aa-82a8-627cdd95c3e5\" href=\"https://linear.app/eftimie/issue/OVI-52/p22-claim-matched-proof-per-feature-coverage-target-delivery-closure\">OVI-52</issue>'s own prep is not required to retroactively satisfy a rule this same ticket introduces.\n\n## Assumptions ledger\n\n* `proof` object: all four subfields (`claim`, `evidence_type`, `artifact`, `not_established`) required non-empty when `proof` is present (2026-07-24, per Ovidiu \u2014 lead's recommendation, approved).\n* Done-definition grep target: literal string \"Feature is not done until\", exactly once across `*.md`; consolidating the two existing occurrences down to one (2026-07-24, per Ovidiu; occurrence count corrected during re-verification).\n* `coverage_target` override justification in `notes` is advisory only, never machine-enforced (2026-07-24, per Ovidiu).\n* `delivered.merged_at`: validator rejects non-ISO8601 values (2026-07-24, per Ovidiu).\n* `proof`/`qa_binding` mismatch: hook emits a warning naming both values and prompting a fix (2026-07-24, per Ovidiu).\n* QA-binding-missing SV-01 flag rule is prospective; <issue id=\"184b13fc-e119-46aa-82a8-627cdd95c3e5\" href=\"https://linear.app/eftimie/issue/OVI-52/p22-claim-matched-proof-per-feature-coverage-target-delivery-closure\">OVI-52</issue> itself is exempt (2026-07-24, per Ovidiu).\n* `qa_binding` is a new persisted feature-object field (schema + `features.json`), sharing `proof.evidence_type`'s enum, set at prep time and read directly by `verify-task-quality.sh` \u2014 no external lookup (2026-07-24, per Ovidiu, resolving a gap found during re-verification).\n\n## Out of scope\n\nAutomated journey-test runners; blocking on proof (explicitly deferred with a promotion criterion to be recorded later); further design-surface machinery beyond the `design_contract` pointer field.",
       "priority": 10,
-      "status": "pending",
+      "status": "passing",
       "scope": [
         "schemas/feature.schema.json",
+        "scripts/validate-features.py",
         "rules/agent-teams-protocol.md",
+        "skills/harness-init/SKILL.md",
         "skills/harness-init/verify-task-quality.sh.template",
         "hooks/session-end.sh",
         "skills/harness-issue-prep/SKILL.md",
+        "agents/spec-verification.md",
         "test/run-tests.sh"
       ],
       "depends_on": [
         "F004"
       ],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
+      "test_file": "test/run-tests.sh (fsv:/ht:/pf:/z:/w: prefixes, coverage_target + proof/qa_binding cases)",
+      "coverage": "n/a (shell suite, no coverage tooling; full_test 247/247 is the gate)",
       "notes": "Linear: OVI-52. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation. SV ASK (6 Qs) -> RV ASK (1 new gap surfaced: qa_binding field) -> RV PASS cycle 2. lane=code, risk=standard (additive/backward-compatible schema+hook changes, no existing enforcement semantics altered). Unstamped: same Keychain/Bash-sandbox block as F009/OVI-51 (confirmed persistent, not a fluke); Ovidiu declined the sandbox override again. Remote write-back to Linear done (description normalized); harness-ready label withheld since stamping is gated on it.",
-      "correction_cycles": 0,
-      "scope_expansions": [],
-      "approaches_tried": [],
+      "correction_cycles": 4,
+      "scope_expansions": [
+        "scripts/validate-features.py, skills/harness-init/SKILL.md, agents/spec-verification.md -- the schema extension needs its hand-rolled validator counterpart (per F004's split-ownership design), and the done-definition dedup + QA-binding-as-SV-01-flag requirements (spec item 2, Amendment item 5) directly named these two files."
+      ],
+      "approaches_tried": [
+        "coverage_target gate compares the TARGETED feature's own already-recorded `coverage` number against `coverage_target` (falls back to 95); skipped entirely when coverage isn't numeric yet (this repo's own descriptive strings), so it's dormant here but fully functional/tested via fixture for projects with real coverage tooling.",
+        "proof/qa_binding WARN logic reads both fields directly off the feature object at TaskCompleted-accept time (not at a later status='passing' transition, since the hook itself never sets that status) -- 'accepted' is the operative event, not a status-field check.",
+        "session-end.sh's proof discipline note is a separate stdout emission, deliberately NOT routed through add_gap()/SESSION_INCOMPLETE, matching the spec's explicit 'informational, not a trigger' requirement.",
+        "Fixed a second real pre-existing test dependency along the way: the 'clean session prints nothing' fixture had F001 already passing with no proof in the base fixture; gave it a proof object too so the test stays genuinely clean under the new done-definition."
+      ],
       "failure_reason": null,
       "discovered_via": null,
       "spec": {

--- a/agents/spec-verification.md
+++ b/agents/spec-verification.md
@@ -41,7 +41,9 @@ INPUTS
 
 CHECKS (emit a verdict and rule ID for each; for a feature set, emit per-feature findings)
 [SV-01] Testability. Every acceptance criterion maps to at least one concrete, verifiable
-assertion. Prose that cannot become a test is FLAG.
+assertion. Prose that cannot become a test is FLAG. A spec missing a "QA binding" line
+(declaring which evidence_type — unit, integration, journey, manual, corpus, or
+conformance — it will eventually be proven with) is also FLAG.
 [SV-02] Ambiguity. Flag every vague quantifier or undefined term ('fast', 'robust',
 'many', 'soon', 'securely') and demand a concrete threshold, unit, or definition.
 [SV-03] Edge and error coverage. Boundary values, empty and maximal inputs, and the

--- a/hooks/session-end.sh
+++ b/hooks/session-end.sh
@@ -69,6 +69,7 @@ except Exception:
     pass
 PYEOF
 )
-[ -n "$PROOF_NOTES" ] && printf 'Discipline note (informational, not blocking):\n%s\n' "$PROOF_NOTES"
+[ -n "$PROOF_NOTES" ] && \
+  printf 'Discipline note (informational, not blocking):\n%s\n' "$PROOF_NOTES"
 
 exit 0

--- a/hooks/session-end.sh
+++ b/hooks/session-end.sh
@@ -54,4 +54,21 @@ if [ -n "$GAPS" ]; then
 else
   rm -f "$H/SESSION_INCOMPLETE" 2>/dev/null
 fi
+
+# Proof discipline note: informational only, never written to SESSION_INCOMPLETE
+# (not a gap) -- a passing feature with no proof recorded is worth surfacing, not
+# blocking the next session over.
+PROOF_NOTES=$(python3 - "$H/features.json" <<'PYEOF' 2>/dev/null || true
+import json, sys
+try:
+    feats = json.load(open(sys.argv[1])).get("features", [])
+    for f in feats:
+        if f.get("status") == "passing" and not f.get("proof"):
+            print(f"{f.get('id', '?')} is passing with no proof recorded.")
+except Exception:
+    pass
+PYEOF
+)
+[ -n "$PROOF_NOTES" ] && printf 'Discipline note (informational, not blocking):\n%s\n' "$PROOF_NOTES"
+
 exit 0

--- a/rules/agent-teams-protocol.md
+++ b/rules/agent-teams-protocol.md
@@ -109,7 +109,23 @@ that drift. Absent or `null` means unverified. Hooks and the lead must tolerate 
 states. A stamp-sourced `risk: "elevated"` maps to `require_plan_approval: true` plus an
 Opus implementer (see the dynamic-override table).
 
-Feature is not done until: `status` is `"passing"`, `test_file` points to a test, and `coverage` >= 95% on touched code.
+Feature is not done until: `status` is `"passing"`, `test_file` points to a test, and
+`coverage` >= `coverage_target` (or 95% on touched code when `coverage_target` is
+absent). That is the mechanical gate — **passing**. **Done** is passing plus a `proof`
+object recorded (claim, evidence type, artifact, and what the evidence did NOT
+establish). **Shipped** is done plus `delivered` (PR merged and verified), when the
+project ships through PRs. All other prose restatements of this definition — including
+in `skills/harness-init/SKILL.md` — link here instead of repeating it.
+
+**Claim-matched proof** (optional, for backward compatibility): a feature may declare a
+`qa_binding` at prep time (`/harness-issue-prep` Step 5's mandatory "QA binding" line) —
+the `evidence_type` it promises to be proven with. At completion time the lead records
+a `proof` object; `verify-task-quality.sh` warns (never blocks) when a feature accepts
+with no `proof`, or with `proof.evidence_type` not matching its declared `qa_binding`.
+`coverage_target` (integer 1-100) overrides the 95% default; overrides should be
+justified in `notes`, advisory only, never machine-enforced. `delivered.merged_at` must
+be valid ISO8601. `design_contract` optionally points at a locked design artifact
+(mock, redline, screenshot set) that journey/manual proof is compared against.
 
 ## Model Selection
 

--- a/schemas/feature.schema.json
+++ b/schemas/feature.schema.json
@@ -117,6 +117,45 @@
             "verified_at": { "type": "string" },
             "source": { "type": "string" }
           }
+        },
+        "qa_binding": {
+          "type": ["string", "null"],
+          "enum": ["unit", "integration", "journey", "manual", "corpus", "conformance", null],
+          "description": "Optional, for backward compatibility. Declared at prep time (harness-issue-prep Step 5's mandatory 'QA binding' line): the evidence_type this feature promises to be proven with. verify-task-quality.sh compares it against proof.evidence_type to warn on a mismatch. Absent/null for legacy features."
+        },
+        "proof": {
+          "type": ["object", "null"],
+          "description": "Optional, for backward compatibility. Claim-matched evidence recorded at completion time. Absent or null means no proof recorded. When present, all four subfields are required and must be non-empty.",
+          "required": ["claim", "evidence_type", "artifact", "not_established"],
+          "properties": {
+            "claim": { "type": "string", "minLength": 1, "description": "The assertion this evidence supports." },
+            "evidence_type": {
+              "type": "string",
+              "enum": ["unit", "integration", "journey", "manual", "corpus", "conformance"],
+              "description": "What kind of evidence this is; compared against qa_binding."
+            },
+            "artifact": { "type": "string", "minLength": 1, "description": "Path or URL: test file, screenshot dir, recording, CI run." },
+            "not_established": { "type": "string", "minLength": 1, "description": "HE's honesty field: what the evidence did NOT establish. Explicit content required (e.g. \"none\" is valid, but the key must be present and non-empty)." }
+          }
+        },
+        "coverage_target": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 100,
+          "description": "Optional, for backward compatibility. Overrides the 95% default coverage gate; integer 1-100. Overrides should be justified in notes -- advisory only, never machine-enforced."
+        },
+        "delivered": {
+          "type": ["object", "null"],
+          "description": "Optional, for backward compatibility. Delivery closure for projects that ship via PRs. Absent or null means not yet delivered or not applicable.",
+          "properties": {
+            "pr": { "type": "string" },
+            "merged_at": { "type": "string", "description": "ISO8601 timestamp; the validator rejects a malformed value." },
+            "verified": { "type": "string" }
+          }
+        },
+        "design_contract": {
+          "type": ["string", "null"],
+          "description": "Optional, for backward compatibility. Pointer to a locked design artifact (mock, redline, screenshot set) that journey or manual proof is compared against."
         }
       }
     }

--- a/scripts/validate-features.py
+++ b/scripts/validate-features.py
@@ -2,10 +2,13 @@
 import json
 import re
 import sys
+from datetime import datetime
 
 FEATURE_ID_RE = re.compile(r"^F[0-9]{3}$")
 STATUS_VALUES = {"pending", "in-progress", "blocked", "passing", "failed"}
 SPEC_VERDICTS = (None, "PASS", "ASK", "BLOCK")
+EVIDENCE_TYPES = ("unit", "integration", "journey", "manual", "corpus", "conformance")
+PROOF_SUBFIELDS = ("claim", "artifact", "not_established")
 
 REQUIRED_FEATURE_FIELDS = (
     "id", "description", "priority", "status", "scope",
@@ -14,6 +17,7 @@ REQUIRED_FEATURE_FIELDS = (
 OPTIONAL_FEATURE_FIELDS = (
     "correction_cycles", "scope_expansions", "approaches_tried",
     "failure_reason", "discovered_via", "spec",
+    "qa_binding", "proof", "coverage_target", "delivered", "design_contract",
 )
 KNOWN_FEATURE_FIELDS = set(REQUIRED_FEATURE_FIELDS) | set(OPTIONAL_FEATURE_FIELDS)
 
@@ -111,6 +115,69 @@ def check_spec(feature, index, errors):
         errors.append(f"features[{index}].spec.verdict: invalid value {value.get('verdict')!r}")
 
 
+def check_qa_binding(feature, index, errors):
+    if "qa_binding" not in feature or feature["qa_binding"] is None:
+        return
+    value = feature["qa_binding"]
+    if value not in EVIDENCE_TYPES:
+        errors.append(f"features[{index}].qa_binding: invalid value {value!r}")
+
+
+def check_proof(feature, index, errors):
+    if "proof" not in feature or feature["proof"] is None:
+        return
+    value = feature["proof"]
+    if not isinstance(value, dict):
+        errors.append(f"features[{index}].proof: must be an object or null")
+        return
+    for key in PROOF_SUBFIELDS:
+        sub = value.get(key)
+        if not isinstance(sub, str) or not sub:
+            errors.append(f"features[{index}].proof.{key}: must be a non-empty string")
+    evidence_type = value.get("evidence_type")
+    if evidence_type not in EVIDENCE_TYPES:
+        errors.append(f"features[{index}].proof.evidence_type: invalid value {evidence_type!r}")
+
+
+def check_coverage_target(feature, index, errors):
+    if "coverage_target" not in feature or feature["coverage_target"] is None:
+        return
+    value = feature["coverage_target"]
+    if not is_plain_int(value) or value < 1 or value > 100:
+        errors.append(f"features[{index}].coverage_target: must be an integer 1-100, got {value!r}")
+
+
+def is_iso8601(value):
+    if not isinstance(value, str):
+        return False
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return True
+
+
+def check_delivered(feature, index, errors):
+    if "delivered" not in feature or feature["delivered"] is None:
+        return
+    value = feature["delivered"]
+    if not isinstance(value, dict):
+        errors.append(f"features[{index}].delivered: must be an object or null")
+        return
+    if "merged_at" in value and not is_iso8601(value["merged_at"]):
+        errors.append(
+            f"features[{index}].delivered.merged_at: invalid ISO8601 value "
+            f"{value.get('merged_at')!r}"
+        )
+
+
+def check_design_contract(feature, index, errors):
+    if "design_contract" not in feature or feature["design_contract"] is None:
+        return
+    if not isinstance(feature["design_contract"], str):
+        errors.append(f"features[{index}].design_contract: must be a string or null")
+
+
 REQUIRED_CHECKS = {
     "id": check_id,
     "description": check_description,
@@ -131,6 +198,11 @@ OPTIONAL_CHECKS = {
     "failure_reason": make_optional_nullable_string_check("failure_reason"),
     "discovered_via": make_optional_nullable_string_check("discovered_via"),
     "spec": check_spec,
+    "qa_binding": check_qa_binding,
+    "proof": check_proof,
+    "coverage_target": check_coverage_target,
+    "delivered": check_delivered,
+    "design_contract": check_design_contract,
 }
 
 

--- a/skills/harness-init/SKILL.md
+++ b/skills/harness-init/SKILL.md
@@ -77,10 +77,11 @@ one worked example in the Feature Schema section of
 `${CLAUDE_PLUGIN_ROOT}/rules/agent-teams-protocol.md`. `scripts/validate-features.py`
 enforces it in the test suite.
 
-Feature is not done until:
-- `status` is `"passing"`
-- `test_file` points to a test
-- `coverage` >= 95% on touched code
+The done-definition (passing / done / shipped) and the optional claim-matched-proof
+fields (`qa_binding`, `proof`, `coverage_target`, `delivered`, `design_contract`) are
+defined once, in the Feature Schema section of
+`${CLAUDE_PLUGIN_ROOT}/rules/agent-teams-protocol.md` — see that section rather than
+this one for the current definition.
 
 A feature may also carry a `spec` verification object; see the Feature Schema section of the Agent Teams protocol.
 

--- a/skills/harness-init/verify-task-quality.sh.template
+++ b/skills/harness-init/verify-task-quality.sh.template
@@ -92,6 +92,70 @@ FULL_OUTPUT=$(bash .harness/init.sh full_test 2>&1) || {
     exit 2
 }
 
+# Coverage target gate: compare the targeted feature's own recorded `coverage`
+# number against its `coverage_target` (falls back to 95). Skipped entirely when
+# coverage isn't a number yet (e.g. this repo's own descriptive strings) --
+# proportional: don't punish projects without numeric coverage tooling.
+if [ -n "$FEATURE_ID" ] && [ -f ".harness/features.json" ]; then
+    COVERAGE_RESULT=$(python3 - ".harness/features.json" "$FEATURE_ID" <<'PYEOF'
+import json
+import sys
+
+path, feature_id = sys.argv[1], sys.argv[2]
+with open(path) as fh:
+    data = json.load(fh)
+match = next((f for f in data.get("features", []) if f.get("id") == feature_id), None)
+if match is None:
+    sys.exit(0)
+coverage = match.get("coverage")
+if not isinstance(coverage, (int, float)) or isinstance(coverage, bool):
+    sys.exit(0)
+target = match.get("coverage_target")
+if not isinstance(target, int) or isinstance(target, bool):
+    target = 95
+if coverage < target:
+    print(f"{coverage}|{target}")
+PYEOF
+)
+    if [ -n "$COVERAGE_RESULT" ]; then
+        ACHIEVED="${COVERAGE_RESULT%%|*}"
+        TARGET="${COVERAGE_RESULT##*|}"
+        echo "Task rejected: coverage $ACHIEVED% is below the target $TARGET%."
+        increment_correction_cycles
+        exit 2
+    fi
+fi
+
+# Claim-matched proof: warn (never block) when this feature accepts with no
+# proof recorded, or with proof whose evidence_type doesn't match its declared
+# qa_binding. Reads both fields directly off the feature object -- no external
+# lookup, no re-parsing of prose.
+if [ -n "$FEATURE_ID" ] && [ -f ".harness/features.json" ]; then
+    PROOF_WARNING=$(python3 - ".harness/features.json" "$FEATURE_ID" <<'PYEOF'
+import json
+import sys
+
+path, feature_id = sys.argv[1], sys.argv[2]
+with open(path) as fh:
+    data = json.load(fh)
+match = next((f for f in data.get("features", []) if f.get("id") == feature_id), None)
+if match is None:
+    sys.exit(0)
+proof = match.get("proof")
+qa_binding = match.get("qa_binding")
+if not proof:
+    print(f"WARN: {feature_id} accepted with no proof recorded.")
+elif qa_binding and proof.get("evidence_type") != qa_binding:
+    print(
+        f"WARN: {feature_id}'s proof.evidence_type "
+        f"'{proof.get('evidence_type')}' does not match its declared "
+        f"qa_binding '{qa_binding}'. Fix the proof or the binding."
+    )
+PYEOF
+)
+    [ -n "$PROOF_WARNING" ] && echo "$PROOF_WARNING"
+fi
+
 # Remind about stale in-progress features
 if [ -f ".harness/features.json" ]; then
     IN_PROGRESS=$(python3 -c "

--- a/skills/harness-issue-prep/SKILL.md
+++ b/skills/harness-issue-prep/SKILL.md
@@ -115,6 +115,8 @@ On `PASS` (from SV directly, or from RV after the human loop), rewrite the spec 
 canonical template:
 
 ```markdown
+QA binding: <unit|integration|journey|manual|corpus|conformance>
+
 ## Problem
 ## Acceptance criteria   (numbered; each one testable as written)
 ## Edge and error cases
@@ -123,6 +125,12 @@ canonical template:
 ## Assumptions ledger    (decisions made during prep, dated)
 ## Out of scope
 ```
+
+The `QA binding` line is mandatory: it declares, up front, which kind of evidence
+(`proof.evidence_type` in `schemas/feature.schema.json`) this spec will eventually be
+proven with, so Pass 1 is never improvised at close time. It is written into the
+feature's `qa_binding` field at write-back time (Step 6); `verify-task-quality.sh`
+compares it against the recorded `proof.evidence_type` and warns on a mismatch.
 
 Fill each section from the verified spec content and the human loop's answers; do not
 invent requirements that were not established during verification. Populate the

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -438,9 +438,24 @@ path = sys.argv[1]
 with open(path) as fh:
     data = json.load(fh)
 for feature in data["features"]:
+    if feature["id"] == "F001":
+        # Already passing in the base fixture with no proof; give it one too so
+        # this stays a genuinely clean, no-discipline-note scenario.
+        feature["proof"] = {
+            "claim": "pipeline parsing works",
+            "evidence_type": "unit",
+            "artifact": "tests/parser/test_parser.py",
+            "not_established": "none",
+        }
     if feature["id"] == "F002":
         feature["status"] = "passing"
         feature["coverage"] = 96
+        feature["proof"] = {
+            "claim": "hook coverage reporting works",
+            "evidence_type": "unit",
+            "artifact": "tests/hooks/test_hooks.py",
+            "not_established": "none",
+        }
 with open(path, "w") as fh:
     json.dump(data, fh, indent=2)
     fh.write("\n")
@@ -455,7 +470,7 @@ if [ -f "$DIR_G/.harness/SESSION_INCOMPLETE" ]; then
 else
   pass "g: SESSION_INCOMPLETE absent after a clean session"
 fi
-assert_empty "$OUT" "g: clean session-end prints nothing"
+assert_empty "$OUT" "g: clean session-end prints nothing (proof recorded, no discipline note)"
 
 printf 'stale gap from previous run\n' > "$DIR_G/.harness/SESSION_INCOMPLETE"
 OUT=$(run_session_end "$DIR_G")
@@ -474,6 +489,38 @@ assert_rc0 "$RC" "h: session-start after gaps exits 0"
 assert_contains "$OUT" "unresolved discipline gaps" "h: warns about the incomplete session"
 assert_contains "$OUT" "F002 is in-progress but missing test_file or coverage." \
   "h: surfaces the SESSION_INCOMPLETE contents"
+
+DIR_PROOF="$WORK/session-end-proof-note"
+make_fixture "$DIR_PROOF"
+python3 - "$DIR_PROOF/.harness/features.json" <<'PYEOF'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path) as fh:
+    data = json.load(fh)
+for feature in data["features"]:
+    if feature["id"] == "F002":
+        feature["status"] = "passing"
+        feature["coverage"] = 96
+with open(path, "w") as fh:
+    json.dump(data, fh, indent=2)
+    fh.write("\n")
+PYEOF
+TODAY=$(date -u +%Y-%m-%d)
+printf '\n## Meta-Session %s\n- clean\n' "$TODAY" >> "$DIR_PROOF/.harness/context_summary.md"
+git -C "$DIR_PROOF" add -A
+git -C "$DIR_PROOF" commit -q -m "session work committed, F002 passing, no proof"
+OUT=$(run_session_end "$DIR_PROOF")
+RC=$?
+assert_rc0 "$RC" "pf: session-end exits 0 with a passing-no-proof feature"
+assert_contains "$OUT" "F002" "pf: proof discipline note names the feature"
+assert_contains "$OUT" "no proof" "pf: proof discipline note mentions no proof"
+if [ -f "$DIR_PROOF/.harness/SESSION_INCOMPLETE" ]; then
+  fail "pf: a missing-proof note must not write SESSION_INCOMPLETE"
+else
+  pass "pf: a missing-proof note does not trigger SESSION_INCOMPLETE"
+fi
 
 echo ""
 echo "== statusline.sh =="
@@ -626,11 +673,92 @@ RC=$?
 assert_rc_nonzero "$RC" "fsv: rejects a dangling depends_on reference"
 assert_contains "$OUT" "features[1].depends_on" "fsv: dangling depends_on error names the location"
 
-fsv_mutate "unknown-field.json" 'd["features"][0]["proof"] = "sha256:abc"'
+fsv_mutate "unknown-field.json" 'd["features"][0]["custom_metadata"] = "not a real field"'
 OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/unknown-field.json" 2>&1)
 RC=$?
 assert_rc0 "$RC" "fsv: an unknown top-level feature field is a warning, not an error"
-assert_contains "$OUT" "proof" "fsv: unknown field warning names the field"
+assert_contains "$OUT" "custom_metadata" "fsv: unknown field warning names the field"
+
+fsv_mutate "bad-qa-binding.json" 'd["features"][0]["qa_binding"] = "vibes"'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/bad-qa-binding.json" 2>&1)
+RC=$?
+assert_rc_nonzero "$RC" "fsv: rejects an invalid qa_binding value"
+assert_contains "$OUT" "features[0].qa_binding" "fsv: bad qa_binding error names the location"
+
+fsv_mutate "good-qa-binding.json" 'd["features"][0]["qa_binding"] = "unit"'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/good-qa-binding.json" 2>&1)
+RC=$?
+assert_rc0 "$RC" "fsv: accepts a valid qa_binding value"
+
+fsv_mutate "conformance-qa-binding.json" 'd["features"][0]["qa_binding"] = "conformance"'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/conformance-qa-binding.json" 2>&1)
+RC=$?
+assert_rc0 "$RC" "fsv: accepts qa_binding value 'conformance'"
+
+fsv_mutate "bad-proof-missing-subfield.json" \
+  'd["features"][0]["proof"] = {"claim": "x", "evidence_type": "unit", "artifact": "y"}'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/bad-proof-missing-subfield.json" 2>&1)
+RC=$?
+assert_rc_nonzero "$RC" "fsv: rejects a proof object missing not_established"
+assert_contains "$OUT" "features[0].proof.not_established" \
+  "fsv: missing proof subfield error names the location"
+
+fsv_mutate "bad-proof-empty-subfield.json" \
+  'd["features"][0]["proof"] = {"claim": "", "evidence_type": "unit",\
+  "artifact": "y", "not_established": "z"}'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/bad-proof-empty-subfield.json" 2>&1)
+RC=$?
+assert_rc_nonzero "$RC" "fsv: rejects a proof object with an empty subfield"
+assert_contains "$OUT" "features[0].proof.claim" \
+  "fsv: empty proof subfield error names the location"
+
+fsv_mutate "bad-proof-evidence-type.json" \
+  'd["features"][0]["proof"] = {"claim": "x", "evidence_type": "vibes",\
+  "artifact": "y", "not_established": "z"}'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/bad-proof-evidence-type.json" 2>&1)
+RC=$?
+assert_rc_nonzero "$RC" "fsv: rejects a proof object with a bad evidence_type"
+assert_contains "$OUT" "features[0].proof.evidence_type" \
+  "fsv: bad proof evidence_type error names the location"
+
+fsv_mutate "good-proof.json" \
+  'd["features"][0]["proof"] = {"claim": "x", "evidence_type": "unit",\
+  "artifact": "y", "not_established": "z"}'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/good-proof.json" 2>&1)
+RC=$?
+assert_rc0 "$RC" "fsv: accepts a complete proof object"
+
+fsv_mutate "bad-coverage-target-range.json" 'd["features"][0]["coverage_target"] = 150'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/bad-coverage-target-range.json" 2>&1)
+RC=$?
+assert_rc_nonzero "$RC" "fsv: rejects an out-of-range coverage_target"
+assert_contains "$OUT" "features[0].coverage_target" \
+  "fsv: bad coverage_target error names the location"
+
+fsv_mutate "good-coverage-target.json" 'd["features"][0]["coverage_target"] = 80'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/good-coverage-target.json" 2>&1)
+RC=$?
+assert_rc0 "$RC" "fsv: accepts a valid coverage_target"
+
+fsv_mutate "bad-delivered-merged-at.json" \
+  'd["features"][0]["delivered"] = {"pr": "#1", "merged_at": "not-a-date", "verified": "x"}'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/bad-delivered-merged-at.json" 2>&1)
+RC=$?
+assert_rc_nonzero "$RC" "fsv: rejects a non-ISO8601 delivered.merged_at"
+assert_contains "$OUT" "features[0].delivered.merged_at" \
+  "fsv: bad delivered.merged_at error names the location"
+
+fsv_mutate "good-delivered.json" \
+  'd["features"][0]["delivered"] = {"pr": "#1",\
+  "merged_at": "2026-07-24T12:00:00Z", "verified": "x"}'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/good-delivered.json" 2>&1)
+RC=$?
+assert_rc0 "$RC" "fsv: accepts a valid delivered object with ISO8601 merged_at"
+
+fsv_mutate "good-design-contract.json" 'd["features"][0]["design_contract"] = "docs/mock.png"'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/good-design-contract.json" 2>&1)
+RC=$?
+assert_rc0 "$RC" "fsv: accepts a design_contract string"
 
 echo ""
 echo "== spec gate artifacts =="
@@ -696,6 +824,18 @@ if [ -z "$SKILL_ERRORS" ]; then
   pass "w: harness-issue-prep and harness-issue-debug SKILL.md files have sane frontmatter"
 else
   fail "w: skill frontmatter -- $SKILL_ERRORS"
+fi
+
+if grep -q "QA binding" "$REPO_ROOT/skills/harness-issue-prep/SKILL.md"; then
+  pass "w: harness-issue-prep's Step 5 template carries a QA binding line"
+else
+  fail "w: harness-issue-prep's Step 5 template is missing the QA binding line"
+fi
+
+if grep -q "QA binding" "$REPO_ROOT/agents/spec-verification.md"; then
+  pass "w: spec-verification's SV-01 checklist references the QA binding requirement"
+else
+  fail "w: spec-verification's SV-01 checklist is missing the QA binding requirement"
 fi
 
 DIR_X="$WORK/x"
@@ -774,6 +914,14 @@ if [ "$FULL_EXAMPLE_COUNT" -eq 1 ]; then
   pass "z: the full 16-field feature JSON example appears exactly once across *.md"
 else
   fail "z: the full feature JSON example appears $FULL_EXAMPLE_COUNT times across *.md, expected 1"
+fi
+
+DONE_DEF_COUNT=$(grep -r "Feature is not done until" "$REPO_ROOT" --include="*.md" \
+  | wc -l | tr -d ' ')
+if [ "$DONE_DEF_COUNT" -eq 1 ]; then
+  pass "z: the done-definition sentence appears exactly once across *.md"
+else
+  fail "z: the done-definition sentence appears $DONE_DEF_COUNT times across *.md, expected 1"
 fi
 
 for DOC_FILE in rules/agent-teams-protocol.md skills/harness-init/SKILL.md README.md; do
@@ -1126,6 +1274,94 @@ if [ -f "$DIR_HQ4/.harness/features.json.tmp" ]; then
 else
   pass "ht: the stale tmp is cleared"
 fi
+
+set_f003_fields() {
+  # $1: fixture dir, $2: python snippet setting fields on the F003 dict named `feature`
+  python3 - "$1/.harness/features.json" <<PYEOF
+import json
+path = "$1/.harness/features.json"
+with open(path) as fh:
+    data = json.load(fh)
+for feature in data["features"]:
+    if feature["id"] == "F003":
+        feature["status"] = "in-progress"
+        $2
+with open(path, "w") as fh:
+    json.dump(data, fh, indent=2)
+    fh.write("\n")
+PYEOF
+}
+
+DIR_HQ5="$WORK/ht-quality-coverage-target-accept"
+make_fixture "$DIR_HQ5"
+install_hooks "$DIR_HQ5"
+printf '#!/bin/bash\nexit 0\n' > "$DIR_HQ5/.harness/init.sh"
+set_f003_fields "$DIR_HQ5" 'feature["coverage_target"] = 80
+        feature["coverage"] = 85'
+OUT=$(run_hook "$DIR_HQ5" verify-task-quality.sh '{"task":{"metadata":{"feature_id":"F003"}}}' 2>&1)
+RC=$?
+assert_rc0 "$RC" "ht: coverage_target 80 with 85% coverage accepts"
+
+DIR_HQ6="$WORK/ht-quality-coverage-target-reject"
+make_fixture "$DIR_HQ6"
+install_hooks "$DIR_HQ6"
+printf '#!/bin/bash\nexit 0\n' > "$DIR_HQ6/.harness/init.sh"
+set_f003_fields "$DIR_HQ6" 'feature["coverage"] = 85'
+OUT=$(run_hook "$DIR_HQ6" verify-task-quality.sh '{"task":{"metadata":{"feature_id":"F003"}}}' 2>&1)
+RC=$?
+assert_rc2 "$RC" "ht: no coverage_target with 85% coverage rejects (95% default)"
+assert_contains "$OUT" "coverage" "ht: coverage rejection message mentions coverage"
+
+DIR_HQ7="$WORK/ht-quality-no-proof-warn"
+make_fixture "$DIR_HQ7"
+install_hooks "$DIR_HQ7"
+printf '#!/bin/bash\nexit 0\n' > "$DIR_HQ7/.harness/init.sh"
+set_f003_fields "$DIR_HQ7" 'pass'
+OUT=$(run_hook "$DIR_HQ7" verify-task-quality.sh '{"task":{"metadata":{"feature_id":"F003"}}}' 2>&1)
+RC=$?
+assert_rc0 "$RC" "ht: acceptance with no proof still exits 0"
+assert_contains "$OUT" "no proof recorded" "ht: no-proof acceptance warns on stdout"
+assert_contains "$OUT" "F003" "ht: no-proof warning names the feature"
+
+DIR_HQ8="$WORK/ht-quality-qa-binding-match"
+make_fixture "$DIR_HQ8"
+install_hooks "$DIR_HQ8"
+printf '#!/bin/bash\nexit 0\n' > "$DIR_HQ8/.harness/init.sh"
+set_f003_fields "$DIR_HQ8" 'feature["qa_binding"] = "unit"
+        feature["proof"] = {"claim": "x", "evidence_type": "unit",
+        "artifact": "y", "not_established": "z"}'
+OUT=$(run_hook "$DIR_HQ8" verify-task-quality.sh '{"task":{"metadata":{"feature_id":"F003"}}}' 2>&1)
+RC=$?
+assert_rc0 "$RC" "ht: acceptance with matching proof/qa_binding exits 0"
+assert_not_contains "$OUT" "no proof recorded" "ht: matching proof has no no-proof warning"
+assert_not_contains "$OUT" "does not match" "ht: matching proof has no mismatch warning"
+
+DIR_HQ9="$WORK/ht-quality-qa-binding-mismatch"
+make_fixture "$DIR_HQ9"
+install_hooks "$DIR_HQ9"
+printf '#!/bin/bash\nexit 0\n' > "$DIR_HQ9/.harness/init.sh"
+set_f003_fields "$DIR_HQ9" 'feature["qa_binding"] = "unit"
+        feature["proof"] = {"claim": "x", "evidence_type": "journey",
+        "artifact": "y", "not_established": "z"}'
+OUT=$(run_hook "$DIR_HQ9" verify-task-quality.sh '{"task":{"metadata":{"feature_id":"F003"}}}' 2>&1)
+RC=$?
+assert_rc0 "$RC" "ht: acceptance with mismatched proof/qa_binding still exits 0"
+assert_contains "$OUT" "unit" "ht: mismatch warning names the declared qa_binding"
+assert_contains "$OUT" "journey" "ht: mismatch warning names the actual evidence_type"
+
+DIR_HQ10="$WORK/ht-quality-legacy-no-binding"
+make_fixture "$DIR_HQ10"
+install_hooks "$DIR_HQ10"
+printf '#!/bin/bash\nexit 0\n' > "$DIR_HQ10/.harness/init.sh"
+set_f003_fields "$DIR_HQ10" \
+  'feature["proof"] = {"claim": "x", "evidence_type": "unit",
+  "artifact": "y", "not_established": "z"}'
+OUT=$(run_hook "$DIR_HQ10" verify-task-quality.sh \
+  '{"task":{"metadata":{"feature_id":"F003"}}}' 2>&1)
+RC=$?
+assert_rc0 "$RC" "ht: acceptance with proof but no declared qa_binding exits 0"
+assert_not_contains "$OUT" "no proof recorded" "ht: legacy no-binding case has no no-proof warning"
+assert_not_contains "$OUT" "does not match" "ht: legacy no-binding case has no mismatch warning"
 
 SETTINGS_BLOCK_ERRORS=$(python3 - "$REPO_ROOT" <<'PYEOF'
 import os


### PR DESCRIPTION
## Summary
- Five new optional feature fields (`schemas/feature.schema.json` + `scripts/validate-features.py`), all backward-compatible: `qa_binding`, `proof` (claim/evidence_type/artifact/not_established, all four required non-empty when present), `coverage_target` (1-100), `delivered` (merged_at must be valid ISO8601), `design_contract`.
- Done-definition is now three tiers, owned by one sentence in `rules/agent-teams-protocol.md` (consolidated from two copies): passing (mechanical gate) -> done (passing + proof) -> shipped (done + delivered). `skills/harness-init/SKILL.md`'s prior copy is now a link.
- `verify-task-quality.sh` gains a `coverage_target` gate and a proof/qa_binding mismatch WARN, both reading straight off the targeted feature's own object at accept-time (no external lookup, no status-field check).
- `session-end.sh` gains an informational proof-discipline note (not a `SESSION_INCOMPLETE` trigger).
- `harness-issue-prep`'s Step 5 template gains a mandatory "QA binding" line; `spec-verification`'s SV-01 checklist flags a spec missing one (naturally prospective).
- Fixes two pre-existing test fixtures that collided with the new fields/behavior (F004's "unknown field" example used `proof`; session-end's "clean" fixture had F001 already passing with no proof).

Spec-verification returned ASK (6 questions); re-verification surfaced one additional gap (where does "declared QA binding" live as machine-readable data?) resolved by adding the persisted `qa_binding` field — RV PASS on cycle 2. Full detail in the normalized spec (`.harness/features.json`, F010).

Linear: OVI-52 (lane: code, risk: standard)

## Test plan
- [x] `bash test/run-tests.sh` — 247/247 (207 baseline + 40 new)
- [x] TDD red phase confirmed first: 21 new `fsv:`/`ht:`/`pf:`/`z:`/`w:` checks all failed before the schema/hook/doc changes existed
- [x] All existing tests pass unchanged except two fixtures deliberately updated (with justification) to stay consistent with the new fields/behavior