### PR TITLE
fix: type coverage as number|string|null (F022)

### DIFF
--- a/.harness/claude-progress.txt
+++ b/.harness/claude-progress.txt
@@ -135,3 +135,20 @@
 - 2026-07-24 adversarial Opus review APPROVE with 1 real nit (101-char line, fixed
   before merge) and 1 by-design observation; independently reconfirmed the F022 gap
   without being asked; merged @ e5f1fdf; Linear OVI-52 Done
+
+## Session 9 - 2026-07-24 (single-session)
+- Feature: F022 - coverage field type (discovered_via F004)
+- Status: implementation complete; PR pending, CI + review in progress
+- Tests: 250/250 passing (247 baseline + 3 new; TDD red phase confirmed 1 failing first)
+- Coverage: n/a (shell suite, no coverage tooling; full_test 250/250 is the gate)
+- Decisions: Ovidiu chose "relax the schema" (coverage: number|string|null) over
+  rewriting the live data; live .harness/features.json now validates cleanly for
+  the first time — details in context_summary.md
+- Also: added a durable go-ahead default to global CLAUDE.md (skip the wait when a
+  plan raises no open questions) and a risk/lane self-classification rule to this
+  repo's CLAUDE.md (apply the existing dynamic-override heuristic without asking,
+  per Ovidiu's request to reduce per-session confirmation overhead)
+- Next: /harness-issue-prep the next P2/P3 epic issue (F005/OVI-61 next by priority).
+  Also refresh live .claude/hooks/*.sh from F003's/F008's/F009's/F010's fixed
+  templates (still deferred)
+- Blockers: none

--- a/.harness/context_summary.md
+++ b/.harness/context_summary.md
@@ -4,8 +4,8 @@ Persistent record of architectural decisions, discovered patterns, gotchas, and 
 This file is referenced in CLAUDE.md and loaded every session.
 
 ## Active Context
-- Currently working on: F010 / OVI-52 merged (e5f1fdf), OVI-52 Done in Linear
-- Next up: /harness-issue-prep the next P2/P3 issue (F011-F021 remain, most depend_on the now-passing F001/F002/F003 baseline). Also refresh live .claude/hooks/*.sh from F003's/F008's/F009's/F010's fixed templates (four things deferred now, same reason); F022 (discovered_via F004) still needs a decision on the `coverage` field's type vs. this repo's own descriptive-string values
+- Currently working on: F022 implemented this session (coverage: number|string|null); PR pending, CI + review in progress
+- Next up: /harness-issue-prep the next P2/P3 epic issue (F011-F021 remain, most depend_on the now-passing F001/F002/F003 baseline; F005/OVI-61 is next by priority order). Also refresh live .claude/hooks/*.sh from F003's/F008's/F009's/F010's fixed templates (still deferred)
 
 ## Cross-Cutting Concerns
 - Stack: custom (shell hooks + JSON manifests + markdown skills; no application code)
@@ -19,6 +19,12 @@ This file is referenced in CLAUDE.md and loaded every session.
 ## Domain: Harness Plugin Engineering
 
 ### Decisions
+- F022 resolved: `coverage` is typed `number|string|null` in both
+  schemas/feature.schema.json and scripts/validate-features.py — Ovidiu chose
+  "relax the schema" over rewriting the live data, since this repo (and any other
+  shell-suite-only project) legitimately has no numeric coverage tooling. The live
+  .harness/features.json now validates cleanly for the first time (2026-07-24, per
+  Ovidiu)
 - Claim-matched proof (F010/OVI-52): five new optional feature fields (`qa_binding`,
   `proof`, `coverage_target`, `delivered`, `design_contract`), all backward-compatible
   (absent/null forever valid). The done-definition is now three tiers: passing

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -2,7 +2,7 @@
   "project": "vv-claude-harness",
   "created": "2026-07-22",
   "total_features": 22,
-  "passing": 7,
+  "passing": 8,
   "features": [
     {
       "id": "F001",
@@ -724,7 +724,7 @@
       "id": "F022",
       "description": "[discovered via F004] .harness/features.json's own `coverage` field (F001-F003) holds a descriptive string (\"n/a (shell suite, no coverage tooling; full_test N/N is the gate)\") but schemas/feature.schema.json (F004) types `coverage` as number|null per the OVI-49 spec verbatim. Decide and apply one fix: relax the schema to allow a string, or replace the live features.json coverage strings with null and move the explanation into `notes`.",
       "priority": 4,
-      "status": "pending",
+      "status": "passing",
       "scope": [
         "schemas/feature.schema.json",
         ".harness/features.json"
@@ -733,12 +733,14 @@
         "F004"
       ],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
+      "test_file": "test/run-tests.sh (fsv: coverage-string / coverage-bad-type cases)",
+      "coverage": "n/a (shell suite, no coverage tooling; full_test 250/250 is the gate)",
       "notes": "Discovered while dogfooding scripts/validate-features.py against the live features.json during F004; not fixed there since it's outside F004's scope.",
       "correction_cycles": 0,
       "scope_expansions": [],
-      "approaches_tried": [],
+      "approaches_tried": [
+        "Chose 'relax the schema' (per Ovidiu) over rewriting the live data: coverage now types as number|string|null in both schemas/feature.schema.json and scripts/validate-features.py's check_coverage. A descriptive string is accepted for projects without coverage tooling; bool/other types are still rejected. The live .harness/features.json now validates cleanly for the first time (previously 7 errors, F001-F004/F008-F010's string coverage values)."
+      ],
       "failure_reason": null,
       "discovered_via": "F004",
       "spec": null

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -727,7 +727,8 @@
       "status": "passing",
       "scope": [
         "schemas/feature.schema.json",
-        ".harness/features.json"
+        "scripts/validate-features.py",
+        "test/run-tests.sh"
       ],
       "depends_on": [
         "F004"

--- a/schemas/feature.schema.json
+++ b/schemas/feature.schema.json
@@ -77,8 +77,8 @@
           "description": "Path to the test file proving this feature. Required non-null once status is \"passing\"."
         },
         "coverage": {
-          "type": ["number", "null"],
-          "description": "Coverage percentage on touched code. Required non-null once status is \"passing\"."
+          "type": ["number", "string", "null"],
+          "description": "Coverage percentage on touched code, or a descriptive string for projects without coverage tooling (e.g. \"n/a (shell suite, no coverage tooling; full_test is the gate)\"). Required non-null once status is \"passing\"."
         },
         "notes": {
           "type": ["string", "null"],

--- a/scripts/validate-features.py
+++ b/scripts/validate-features.py
@@ -74,8 +74,10 @@ def make_nullable_string_check(field):
 
 def check_coverage(feature, index, errors):
     value = feature.get("coverage")
-    if value is not None and (isinstance(value, bool) or not isinstance(value, (int, float))):
-        errors.append(f"features[{index}].coverage: must be a number or null")
+    if value is None or isinstance(value, str):
+        return
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        errors.append(f"features[{index}].coverage: must be a number, string, or null")
 
 
 def make_optional_int_check(field):

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -760,6 +760,18 @@ OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/good-design-contract.json" 2>&1)
 RC=$?
 assert_rc0 "$RC" "fsv: accepts a design_contract string"
 
+fsv_mutate "coverage-string.json" \
+  'd["features"][0]["coverage"] = "n/a (shell suite, no coverage tooling)"'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/coverage-string.json" 2>&1)
+RC=$?
+assert_rc0 "$RC" "fsv: accepts a descriptive string for coverage (F022)"
+
+fsv_mutate "coverage-bad-type.json" 'd["features"][0]["coverage"] = True'
+OUT=$(python3 "$VALIDATE_SCRIPT" "$FSV_DIR/coverage-bad-type.json" 2>&1)
+RC=$?
+assert_rc_nonzero "$RC" "fsv: still rejects a boolean coverage value"
+assert_contains "$OUT" "features[0].coverage" "fsv: bad coverage error names the location"
+
 echo ""
 echo "== spec gate artifacts =="
 


### PR DESCRIPTION
## Summary
- `schemas/feature.schema.json` typed `coverage` as `number|null` per OVI-49's spec verbatim, but this repo's own features (no coverage tooling; `full_test` is the gate) store a descriptive string there. The live `.harness/features.json` has never actually validated against its own schema until this fix.
- Per Ovidiu's decision — relax the schema rather than rewrite the live data, since shell-suite-only projects legitimately have no numeric coverage — `coverage` now accepts `number`, `string`, or `null` in both the schema and `scripts/validate-features.py`'s `check_coverage`. Still rejects `bool` and other types.
- The live `.harness/features.json` validates cleanly for the first time.

F022 was discovered during F004/OVI-49 (dogfooding the validator against the live file) and tracked as its own feature since then.

## Test plan
- [x] `bash test/run-tests.sh` — 250/250 (247 baseline + 3 new)
- [x] TDD red phase confirmed first: the new "accepts a descriptive string" case failed before the fix
- [x] `python3 scripts/validate-features.py .harness/features.json` now exits 0 (previously 7 errors)