### PR TITLE
F005/OVI-61 S1: hostile-gate tests

### DIFF
--- a/.harness/features.json
+++ b/.harness/features.json
@@ -2,7 +2,7 @@
   "project": "vv-claude-harness",
   "created": "2026-07-22",
   "total_features": 22,
-  "passing": 8,
+  "passing": 9,
   "features": [
     {
       "id": "F001",
@@ -150,7 +150,7 @@
       "id": "F005",
       "description": "## Problem\n\nNothing in the test suite currently proves that an attack against a mechanical gate actually fails, with the specific violated invariant named. <issue id=\"4ca10113-4d20-4cef-b975-690851c67c4d\" href=\"https://linear.app/eftimie/issue/OVI-48/p03-hook-robustness-test-coverage-for-the-5-per-project-hook-templates\">OVI-48</issue>/F003 proves the hooks fire correctly on well-formed and malformed fixtures; nothing proves they correctly DENY a hostile input, and nothing checks that a denial message actually teaches the invariant it enforces rather than failing silently.\n\nAdd an adversarial section to `test/run-tests.sh`: per gate, attack cases that must be denied, each asserting both the deny mechanics (exit code) and that the denial message names the violated invariant and the repair. A gate that blocks without teaching is half a gate.\n\n(This issue originally also specified a cold-start dogfood release gate. That half will NOT be implemented \u2014 see the Linear comment on <issue id=\"e3b71020-1b75-4519-8dc0-ee15ae0ad35b\" href=\"https://linear.app/eftimie/issue/OVI-61/s1-hostile-gate-tests-cold-start-dogfood-release-gate\">OVI-61</issue> dated 2026-07-24 for the full reasoning: a recommended-but-unenforced checklist item drifts into ceremony, and there's no evidence in this project's history that skipped dogfooding caused a real incident. This is not a deferral to a later pass of this issue; it is dropped.)\n\n## Acceptance criteria\n\n1. At least 8 new adversarial assertions; suite green on ubuntu CI.\n2. Every adversarial case checks the denial message content, not just the exit code.\n3. Attack cases cover:\n   a. enforce-scope: out-of-scope Edit; Edit to `.harness/features.json` in teammate context (F009/<issue id=\"600268cd-4a6d-470d-a618-6d7aa64de47d\" href=\"https://linear.app/eftimie/issue/OVI-51/p21-mechanize-lead-only-state-ownership-best-effort-bash-write\">OVI-51</issue>'s lead-owned-file denial); Bash `>>` redirect outside scope (F009/<issue id=\"600268cd-4a6d-470d-a618-6d7aa64de47d\" href=\"https://linear.app/eftimie/issue/OVI-51/p21-mechanize-lead-only-state-ownership-best-effort-bash-write\">OVI-51</issue>'s Bash-write-boundary denial).\n   b. verify-git-identity: `git push` under mismatched name; mismatched email.\n   c. verify-task-quality: TaskCompleted with a failing smoke test; missing `init.sh`.\n   d. check-remaining-tasks: no attack case (prompt-tier hook, never blocks) \u2014 assert only the existing rc 0/2 contract, no new adversarial case needed here.\n4. The two commit-content-gate attack cases (compound `git add && git commit`; secret-shaped staged addition) are marked skip-until-S4: F011/<issue id=\"cc065d0e-47a0-461d-a0cb-ec1f784694da\" href=\"https://linear.app/eftimie/issue/OVI-64/s4-commit-content-gate-secret-scan-compound-stage-and-commit-denial\">OVI-64</issue> (the commit-content gate itself) is still `pending`, so these cases cannot exist yet.\n\n## Edge and error cases\n\nAttacks run against fixtures in temp dirs, never the repo's own tree \u2014 matching the existing `make_fixture()`/`WORK` temp-dir pattern already used throughout `test/run-tests.sh`.\n\n## Non-functional requirements\n\nbash 3.2+, python3 + git only. No new dependencies.\n\n## Dependencies\n\nBlocked by <issue id=\"4ca10113-4d20-4cef-b975-690851c67c4d\" href=\"https://linear.app/eftimie/issue/OVI-48/p03-hook-robustness-test-coverage-for-the-5-per-project-hook-templates\">OVI-48</issue> (F003, already passing). Two cases dependent on S4 (F011/<issue id=\"cc065d0e-47a0-461d-a0cb-ec1f784694da\" href=\"https://linear.app/eftimie/issue/OVI-64/s4-commit-content-gate-secret-scan-compound-stage-and-commit-denial\">OVI-64</issue>, still pending) \u2014 marked skip-until-S4, not blocking this issue's completion.\n\n## Assumptions ledger\n\n* Scope narrowed to hostile-gate tests only; the cold-start dogfood gate (`docs/release-checklist.md`, `MAINTENANCE_LOG.md`, a sample-app seed, and a version-bump-blocking rule) is dropped from this issue entirely, not deferred \u2014 documented via Linear comment rather than in the acceptance criteria themselves (2026-07-24, per Ovidiu).\n\n## Out of scope\n\nCold-start dogfood release gate \u2014 will NOT be implemented (see the Problem section and the 2026-07-24 Linear comment). If mechanical dogfood enforcement is ever wanted, it requires its own future ticket designed from scratch; no such ticket exists today and none is implied by this one. Also out of scope: commit-content gate attack cases (deferred to when F011/<issue id=\"cc065d0e-47a0-461d-a0cb-ec1f784694da\" href=\"https://linear.app/eftimie/issue/OVI-64/s4-commit-content-gate-secret-scan-compound-stage-and-commit-denial\">OVI-64</issue> lands); CI-automating anything beyond the existing `bash test/run-tests.sh` run; fuzzing.",
       "priority": 5,
-      "status": "pending",
+      "status": "passing",
       "scope": [
         "test/run-tests.sh"
       ],
@@ -158,12 +158,15 @@
         "F003"
       ],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
+      "test_file": "test/run-tests.sh",
+      "coverage": "n/a (shell suite, no coverage tooling; full_test is the gate)",
       "notes": "Linear: OVI-61. Full spec re-verified per-issue by /harness-issue-prep before implementation. SV ASK (1 Q: dogfood substrate contradiction) -> lead recommendation approved -> RV PASS cycle 1 (flagged the combined substrate+scope-narrowing approval as worth separate confirmation) -> Ovidiu explicitly rejected the soft 'recommended, not blocking' middle ground -> chose to drop the cold-start dogfood gate entirely (not deferred). Scope reduced to hostile-gate tests only (test/run-tests.sh). Reasoning recorded as a Linear comment on OVI-61 (2026-07-24). lane=code, risk=standard (self-classified: single file, no new enforcement mechanism, testing existing hooks only). Unstamped: same Keychain/Bash-sandbox block confirmed a third time; not re-asked about the override since already declined twice.",
       "correction_cycles": 0,
       "scope_expansions": [],
-      "approaches_tried": [],
+      "approaches_tried": [
+        "Audited all 4 gates for existing message-content assertions before writing new ones; found enforce-scope's out-of-scope Edit and verify-git-identity's name-mismatch cases already checked content, avoiding duplicate coverage.",
+        "Added 15 new assertions (7 over the 8-minimum acceptance criterion) across email-mismatch (verify-git-identity), missing-init.sh + failing-smoke-test (verify-task-quality), and lead-owned-Edit/tee/rm/new->>-redirect (enforce-scope). check-remaining-tasks needed no new case per the narrowed spec (prompt-tier, never blocks)."
+      ],
       "failure_reason": null,
       "discovered_via": null,
       "spec": {

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1019,6 +1019,10 @@ assert_deny_json "$OUT" "hs2: lead-owned Edit denial uses the JSON deny form"
 assert_contains "$OUT" "permissionDecisionReason" "hs2: lead-owned Edit denial includes a reason"
 assert_contains "$OUT" "verified live" "hs2: denial reason carries a verified-live annotation"
 assert_contains "$OUT" "on Claude Code" "hs2: annotation names the Claude Code version"
+assert_contains "$OUT" "lead-owned" \
+  "hg: lead-owned Edit denial names the violated invariant (F005/OVI-61)"
+assert_contains "$OUT" "SendMessage" \
+  "hg: lead-owned Edit denial names the repair (F005/OVI-61)"
 
 OUT=$(run_hook "$DIR_HS" enforce-scope.sh "$(bash_command_json 'echo x >> .harness/features.json')")
 RC=$?
@@ -1029,6 +1033,8 @@ OUT=$(run_hook "$DIR_HS" enforce-scope.sh "$(bash_command_json 'tee src/other/es
 RC=$?
 assert_rc0 "$RC" "hs2: Bash tee to an out-of-scope target exits 0 (JSON deny)"
 assert_deny_json "$OUT" "hs2: out-of-scope tee denial uses JSON deny form"
+assert_contains "$OUT" "outside your assigned scope" \
+  "hg: out-of-scope tee denial names the invariant (F005/OVI-61)"
 
 HEREDOC_CMD=$'cat <<\'EOF\' > src/other/escaped.txt\ncontent\nEOF'
 OUT=$(run_hook "$DIR_HS" enforce-scope.sh "$(bash_command_json "$HEREDOC_CMD")")
@@ -1045,6 +1051,25 @@ OUT=$(run_hook "$DIR_HS" enforce-scope.sh "$(bash_command_json 'rm .harness/feat
 RC=$?
 assert_rc0 "$RC" "hs2: Bash rm on a lead-owned state file exits 0 (JSON deny)"
 assert_deny_json "$OUT" "hs2: lead-owned rm denial uses JSON deny form"
+assert_contains "$OUT" "lead-owned" \
+  "hg: lead-owned rm denial names the violated invariant (F005/OVI-61)"
+assert_contains "$OUT" "SendMessage" \
+  "hg: lead-owned rm denial names the repair (F005/OVI-61)"
+
+# Hostile case (F005/OVI-61): Bash '>>' redirect specifically out of scope, distinct
+# from the lead-owned '>>' case above (which targets .harness/features.json).
+OUT=$(run_hook "$DIR_HS" enforce-scope.sh "$(bash_command_json 'echo x >> src/other/out.txt')")
+RC=$?
+assert_rc0 "$RC" "hg: Bash >> redirect outside scope exits 0 (JSON deny)"
+assert_deny_json "$OUT" "hg: out-of-scope >> redirect denial uses JSON deny form"
+assert_contains "$OUT" "outside your assigned scope" \
+  "hg: out-of-scope >> redirect denial names the invariant"
+
+# F005/OVI-61 scope note: the commit-content gate (compound `git add && git commit`,
+# secret-shaped staged addition) has no hook yet -- F011/OVI-64 is still pending.
+# Those two attack cases are skip-until-S4, not part of this issue's acceptance criteria.
+# check-remaining-tasks needs no new attack case either: it is a prompt-tier hook that
+# never blocks, and its existing rc 0/2 contract (below) already covers it.
 
 OUT=$(run_hook "$DIR_HS" enforce-scope.sh "$(bash_command_json 'git status')")
 RC=$?
@@ -1131,6 +1156,17 @@ RC=$?
 assert_rc2 "$RC" "ht: verify-git-identity blocks git push on identity mismatch"
 assert_contains "$OUT" "Fix with: git config user.name" "ht: mismatch message includes the fix command"
 
+# Hostile case (F005/OVI-61): mismatched EMAIL specifically, name restored to match.
+git -C "$DIR_HG" config user.name "Fixture User"
+git -C "$DIR_HG" config user.email "impostor@example.com"
+OUT=$(run_hook "$DIR_HG" verify-git-identity.sh "$PUSH_JSON")
+RC=$?
+assert_rc2 "$RC" "hg: verify-git-identity blocks git push on email mismatch alone"
+assert_contains "$OUT" "Fix with: git config user.name" \
+  "hg: email-mismatch message includes the fix command"
+assert_contains "$OUT" "impostor@example.com" \
+  "hg: email-mismatch message names the current (wrong) email"
+
 DIR_HR="$WORK/ht-remaining"
 make_fixture "$DIR_HR"
 install_hooks "$DIR_HR"
@@ -1206,6 +1242,10 @@ install_hooks "$DIR_HQ"
 OUT=$(run_hook "$DIR_HQ" verify-task-quality.sh '{}')
 RC=$?
 assert_rc2 "$RC" "ht: verify-task-quality rejects when .harness/init.sh is missing"
+assert_contains "$OUT" "init.sh not found" \
+  "hg: missing-init.sh message names the violated invariant (F005/OVI-61)"
+assert_contains "$OUT" "Run /harness-init" \
+  "hg: missing-init.sh message names the repair (F005/OVI-61)"
 
 DIR_HQ2="$WORK/ht-quality-targeted"
 make_fixture "$DIR_HQ2"
@@ -1229,6 +1269,10 @@ OUT=$(run_hook "$DIR_HQ2" verify-task-quality.sh \
   '{"task":{"metadata":{"feature_id":"F002"}}}' 2>&1)
 RC=$?
 assert_rc2 "$RC" "ht: smoke failure rejects the targeted completion"
+assert_contains "$OUT" "smoke test failed" \
+  "hg: smoke-failure message names the violated invariant (F005/OVI-61)"
+assert_contains "$OUT" "Fix compilation errors before marking complete" \
+  "hg: smoke-failure message names the repair (F005/OVI-61)"
 METRICS=$(python3 - "$DIR_HQ2/.harness/features.json" <<'PYEOF'
 import json
 import sys


### PR DESCRIPTION
## Summary
- Adds hostile-gate adversarial assertions to `test/run-tests.sh` covering enforce-scope (lead-owned Edit/rm/tee, new out-of-scope Bash `>>` redirect), verify-git-identity (email mismatch), and verify-task-quality (missing init.sh, failing smoke test) — 15 new assertions, each checking denial message content (violated invariant + repair), not just exit code.
- check-remaining-tasks needs no new case (prompt-tier hook, never blocks) — existing rc 0/2 contract already covers it.
- Commit-content-gate attack cases (compound `git add && git commit`, secret-shaped staged addition) are skip-until-S4 — F011/OVI-64 (the gate itself) is still pending.
- Scope narrowed per OVI-61: the cold-start dogfood release gate half of the original issue will NOT be implemented (documented via Linear comment on OVI-61, 2026-07-24) — dropped entirely, not deferred.
- Harness metadata: F005 marked passing (8 -> 9 passing features).

## Test plan
- [x] `bash test/run-tests.sh` — 265/265 assertions passed
- [x] `bash -n test/run-tests.sh` — syntax OK
- [x] `python3 scripts/validate-features.py` — clean
- [x] Line-length check on changed lines (3 pre-existing >100-char lines found, none touched this PR)