### PR TITLE
F031: enforce-scope.sh backslash-escaped traversal bypass

### DIFF
--- a/.harness/features.json
+++ b/.harness/features.json
@@ -1,8 +1,8 @@
 {
   "project": "vv-claude-harness",
   "created": "2026-07-22",
-  "total_features": 22,
-  "passing": 12,
+  "total_features": 31,
+  "passing": 17,
   "features": [
     {
       "id": "F001",
@@ -967,19 +967,22 @@
       "id": "F031",
       "description": "skills/harness-init/enforce-scope.sh.template's unquote_token() strips quote characters ('/\"/$'...') from an already-tokenized word but never removes shell backslash-escapes, so a backslash-escaped traversal segment still reads as a literal directory name rather than a real '..': with scope 'src/parser/', `echo x > src/parser/\\../other/x.txt` writes to src/other/x.txt in real bash (CONFIRMED: `bash -c \"echo content > src/parser/\\\\../other/x.txt\"` creates the file at src/other/x.txt, outside the scope directory) but the hook ALLOWS it -- F026's os.path.normpath() resolution never runs on a genuine '..' token because the literal characters seen by write_targets()/normalize() are 'src/parser/\\..' (backslash included), not 'src/parser/..'. Same vulnerability class as F026 (path-traversal scope escape), different root cause (escape-character handling, not path resolution) -- one character added to a real, already-confirmed bypass.",
       "priority": 12,
-      "status": "pending",
+      "status": "passing",
       "scope": [
         "skills/harness-init/enforce-scope.sh.template",
         "test/run-tests.sh"
       ],
       "depends_on": [],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
+      "test_file": "test/run-tests.sh",
+      "coverage": "n/a (shell suite, no coverage tooling; full_test is the gate)",
       "notes": "Discovered by F026's round-1 reviewer while stress-testing the traversal-resolution fix; explicitly flagged as pre-existing (not introduced by F026) and a different root cause, defensible as a follow-up rather than blocking F026's merge. Independently re-verified against real bash before filing (bash -c, not zsh, to get accurate shell semantics). Likely fix: strip backslash-escapes from a token (or from the whole segment before tokenizing) the same way quote characters are stripped, consistent with commit-gate.sh.template's existing posture on shell metacharacter handling.",
       "correction_cycles": 0,
       "scope_expansions": [],
-      "approaches_tried": [],
+      "approaches_tried": [
+        "Confirmed the fix scope narrowly: the Edit/Write/MultiEdit legacy path receives file_path as a literal JSON string parameter, never shell-parsed, so backslash-escape semantics don't apply there -- only the Bash-command path (which reads shell command strings through segments_of()/unquote_token()) needed the fix. Caught this by tracing an initially-drafted Edit-path test case by hand before implementing, not after.",
+        "Applied backslash-unescaping (\\X -> X) uniformly after quote-stripping in unquote_token(), accepting a documented residual (a real single-quoted literal backslash in a filename gets normalized away too) consistent with this hook's existing pattern-based, evadable-by-construction philosophy -- matches how other residuals in this same file are handled and documented."
+      ],
       "failure_reason": null,
       "discovered_via": "F026",
       "spec": null

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -1,7 +1,7 @@
 {
   "project": "vv-claude-harness",
   "created": "2026-07-22",
-  "total_features": 31,
+  "total_features": 32,
   "passing": 17,
   "features": [
     {
@@ -975,7 +975,7 @@
       "depends_on": [],
       "assigned_to": null,
       "test_file": "test/run-tests.sh",
-      "coverage": "n/a (shell suite, no coverage tooling; full_test is the gate)",
+      "coverage": "n/a (shell suite, no coverage tooling; full_test 656/656 is the gate)",
       "notes": "Discovered by F026's round-1 reviewer while stress-testing the traversal-resolution fix; explicitly flagged as pre-existing (not introduced by F026) and a different root cause, defensible as a follow-up rather than blocking F026's merge. Independently re-verified against real bash before filing (bash -c, not zsh, to get accurate shell semantics). Likely fix: strip backslash-escapes from a token (or from the whole segment before tokenizing) the same way quote characters are stripped, consistent with commit-gate.sh.template's existing posture on shell metacharacter handling.",
       "correction_cycles": 0,
       "scope_expansions": [],
@@ -985,6 +985,27 @@
       ],
       "failure_reason": null,
       "discovered_via": "F026",
+      "spec": null
+    },
+    {
+      "id": "F033",
+      "description": "skills/harness-init/enforce-scope.sh.template's unquote_token() strips the $'...' ANSI-C-quote wrapper (via a regex capturing its inner content) but never decodes the ANSI-C backslash escapes inside it, so a traversal segment spelled with a hex/octal escape survives intact. CONFIRMED against real bash: $'src/parser/\\x2e\\x2e/other/x.txt' really writes to src/other/x.txt (bash decodes \\x2e to the literal character \".\", twice, giving \"..\"), but the hook still sees the literal 8-character string \\x2e\\x2e as one path segment, which normalize() correctly does not recognize as \"..\", so it never resolves the traversal and the write is wrongly ALLOWED. Same vulnerability class and same consequence as F031 (a shell-level string-literal transformation the hook does not replicate, letting a traversal spelling evade normalize()'s exact \"..\" check), but a different mechanism: F031 was escape REMOVAL (\\.. -> ..); this is escape DECODING (\\x2e -> .) inside an already-recognized ANSI-C quote span. Pre-existing on main; NOT introduced or fixed by F031's PR (unquote_token's $' handling and its backslash-unescape pass are applied as two independent steps; the second never re-examines the already-extracted $'...' inner text for its own escape syntax).",
+      "priority": 18,
+      "status": "pending",
+      "scope": [
+        "skills/harness-init/enforce-scope.sh.template",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Discovered by adversarial review of PR #50 (F031), explicitly filed as out-of-scope for that PR (a live bypass, unchanged by F031's fix, not a regression it introduced). Likely fix: after $'...' extraction, decode ANSI-C backslash escapes (\\xHH, \\NNN octal, \\n, \\t, etc. per bash's $'' grammar) before the existing plain-backslash unescape pass runs, or before normalize() sees the token -- scope this carefully, since decoding the wrong set of escapes could itself introduce a new gap.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": "F031",
       "spec": null
     }
   ]

--- a/skills/harness-init/enforce-scope.sh.template
+++ b/skills/harness-init/enforce-scope.sh.template
@@ -45,13 +45,13 @@
 # all_flagless_tokens() the way commit-gate.sh.template handles the same
 # shape -- a pre-existing asymmetry between the two hooks, tracked
 # separately (F029), not introduced by F024.
-# normalize()/FILE_PATH resolve "."/".." path traversal (F026), but two
-# related gaps remain, both documented in full where the relevant code
-# lives (normalize()'s own comment): the resolution is purely lexical, so
-# a symlink inside a scope directory can make the real write land
-# somewhere normpath can't see; and a backslash-escaped traversal segment
-# (`\..`) still bypasses, since unquote_token() only strips quote
-# characters, never shell backslash-escapes (tracked separately, F031).
+# normalize()/FILE_PATH resolve "."/".." path traversal (F026). A backslash-
+# escaped traversal segment (`\..`) is also resolved (F031): unquote_token()
+# strips shell backslash-escapes, not just quote characters, before
+# normalize() ever sees the token. One related gap remains, documented in
+# full where the code lives (normalize()'s own comment): the resolution is
+# purely lexical, so a symlink inside a scope directory can make the real
+# write land somewhere normpath can't see.
 # verified live 2026-07-24 on Claude Code 2.1.218
 
 # Read hook input from stdin
@@ -252,7 +252,17 @@ def unquote_token(token):
     # segment boundaries using mask_quotes(); this function never looks at
     # separators.
     token = re.sub(r"\$'((?:[^'\\]|\\.)*)'", r"\1", token)
-    return token.replace("'", "").replace('"', "")
+    token = token.replace("'", "").replace('"', "")
+    # Outside quotes, real bash strips a backslash and makes the next
+    # character literal -- e.g. "\.." really means "..", letting a traversal
+    # segment hide from normalize()'s os.path.normpath() resolution, which
+    # only recognizes the exact string ".." (F031). Applied uniformly after
+    # quote-stripping since this function no longer tracks which spans were
+    # originally single-quoted (where bash treats backslash as ordinary,
+    # non-special text) -- an accepted, documented residual, same as the
+    # rest of this pattern-based, evadable-by-construction hook: a real
+    # single-quoted literal backslash in a filename is normalized away too.
+    return re.sub(r"\\(.)", r"\1", token)
 
 
 def segments_of(command):

--- a/skills/harness-init/enforce-scope.sh.template
+++ b/skills/harness-init/enforce-scope.sh.template
@@ -258,10 +258,11 @@ def unquote_token(token):
     # segment hide from normalize()'s os.path.normpath() resolution, which
     # only recognizes the exact string ".." (F031). Applied uniformly after
     # quote-stripping since this function no longer tracks which spans were
-    # originally single-quoted (where bash treats backslash as ordinary,
-    # non-special text) -- an accepted, documented residual, same as the
-    # rest of this pattern-based, evadable-by-construction hook: a real
-    # single-quoted literal backslash in a filename is normalized away too.
+    # originally quoted (where bash treats a backslash as ordinary,
+    # non-special text, true of both single- and double-quoted spans) --
+    # an accepted, documented residual, same as the rest of this
+    # pattern-based, evadable-by-construction hook: a real literal
+    # backslash in a quoted filename is normalized away too.
     return re.sub(r"\\(.)", r"\1", token)
 
 
@@ -514,12 +515,7 @@ def normalize(path, project_root):
     # couldn't know what the symlink pointed to WHEN the write actually
     # happens; not a regression versus the pre-F026 behavior, which had no
     # traversal resolution at all (found by adversarial review of PR #48,
-    # round 1). Same for a backslash-escaped traversal segment
-    # (`src/allowed/\../forbidden/x.txt`): unquote_token() strips quote
-    # characters, never shell backslash-escapes, so `\..` still reads as a
-    # literal directory name, not `..` -- pre-existing, tracked separately
-    # (F031), same "not a full shell parser" posture as this hook's other
-    # documented residuals.
+    # round 1).
     if path.startswith(project_root + "/"):
         path = path[len(project_root) + 1:]
     resolved = os.path.normpath(path)

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1642,6 +1642,35 @@ OUT=$(run_hook "$DIR_HS_GLOBROOT" enforce-scope.sh \
 RC=$?
 assert_rc0 "$RC" "hs2: an in-scope edit under a glob-metacharacter project root passes, rc 0"
 
+# F031: unquote_token() strips quote characters from an extracted target but
+# never removes shell backslash-escapes, so a backslash-escaped ".." segment
+# reads as a literal directory name ("\..") rather than a real traversal
+# segment -- normalize()'s os.path.normpath() only collapses the exact
+# string "..", not "\..", so the scope-prefix check is fooled even though
+# real bash strips the backslash and genuinely traverses out. Filed during
+# F026's review.
+OUT=$(run_hook "$DIR_HS" enforce-scope.sh \
+  "$(bash_command_json 'echo x > src/parser/\../other/x.txt')")
+RC=$?
+assert_rc0 "$RC" "hs2: a backslash-escaped '..'-traversal exits 0 (JSON deny)"
+assert_deny_json "$OUT" "hs2: backslash-escaped traversal denial uses JSON deny form"
+assert_contains "$OUT" "src/other/x.txt" \
+  "hs2: backslash-escaped traversal denial names the real, resolved out-of-scope path"
+
+# Not applicable to the Edit/Write/MultiEdit legacy path: file_path arrives as
+# a literal JSON string parameter, never shell-parsed, so a backslash
+# character in it is just part of the filename -- there is no shell to strip
+# it, unlike a Bash tool_input command string.
+
+# A backslash before an ordinary character elsewhere in an in-scope path
+# must not itself trigger a false denial -- only ".." segments matter.
+OUT=$(run_hook "$DIR_HS" enforce-scope.sh \
+  "$(bash_command_json 'echo x > src/parser/\ok.txt')")
+RC=$?
+assert_rc0 "$RC" "hs2: a backslash-escaped ordinary character in an in-scope path passes, rc 0"
+assert_not_contains "$OUT" "permissionDecision" \
+  "hs2: backslash-escaped ordinary character has no deny fields"
+
 for TPL in check-remaining-tasks.sh.template enforce-scope.sh.template \
   verify-git-identity.sh.template verify-task-quality.sh.template; do
   if grep -q '^# Failure posture:' "$TEMPLATES_DIR/$TPL"; then

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1671,6 +1671,19 @@ assert_rc0 "$RC" "hs2: a backslash-escaped ordinary character in an in-scope pat
 assert_not_contains "$OUT" "permissionDecision" \
   "hs2: backslash-escaped ordinary character has no deny fields"
 
+# A more discriminating case than the one above: this must ALLOW under the
+# correct fix (unescaping "\p" -> "p" yields "src/parser/ok.txt", in scope)
+# but DENY under both no-fix (the literal "\parser" segment never matches
+# the "src/parser/" prefix) and an over-broad delete-the-character mutant
+# (which would yield "src/arser/ok.txt", also out of scope) -- so, unlike
+# the case above, this one actually fails without the real fix.
+OUT=$(run_hook "$DIR_HS" enforce-scope.sh \
+  "$(bash_command_json 'echo x > src/\parser/ok.txt')")
+RC=$?
+assert_rc0 "$RC" "hs2: an escaped-but-ordinary path segment resolves to its in-scope form, rc 0"
+assert_not_contains "$OUT" "permissionDecision" \
+  "hs2: escaped-but-ordinary path segment has no deny fields"
+
 for TPL in check-remaining-tasks.sh.template enforce-scope.sh.template \
   verify-git-identity.sh.template verify-task-quality.sh.template; do
   if grep -q '^# Failure posture:' "$TEMPLATES_DIR/$TPL"; then


### PR DESCRIPTION
## Summary
- `unquote_token()` stripped quote characters from an extracted write target but never removed shell backslash-escapes, so `src/parser/\../other/x.txt` read as a literal directory name rather than a real traversal segment — `normalize()`'s `os.path.normpath()` only collapses the exact string `..`, not `\..`.
- Applied backslash-unescaping (`\X` -> `X`) uniformly after quote-stripping, matching real bash's outside-quotes escape rule.
- Not applicable to the Edit/Write/MultiEdit legacy path, which receives `file_path` as a literal JSON string parameter, never shell-parsed — confirmed by tracing an initially-drafted test case for that path by hand before implementing, and removed it once the premise didn't hold.
- Updated the stale header comment in `enforce-scope.sh.template` that documented this as an open, tracked gap.

No Linear issue — internally discovered during F026's review, same precedent as F022-F027.

## Test plan
- [x] `bash test/run-tests.sh` — 654/654 assertions passed (649 baseline + 5 new)
- [x] TDD red phase confirmed: 2 assertions failed for the expected reason before the fix (one drafted test was removed after tracing showed its premise was wrong — Edit's file_path isn't shell-parsed)
- [x] `bash -n` on the template — clean
- [x] Line-length check — clean