### PR TITLE
docs: file F035 (quoted-flag evasion, discovered during F028 review)

### DIFF
--- a/.harness/features.json
+++ b/.harness/features.json
@@ -1,7 +1,7 @@
 {
   "project": "vv-claude-harness",
   "created": "2026-07-22",
-  "total_features": 33,
+  "total_features": 34,
   "passing": 19,
   "features": [
     {
@@ -1035,6 +1035,27 @@
       "approaches_tried": [],
       "failure_reason": null,
       "discovered_via": "F027",
+      "spec": null
+    },
+    {
+      "id": "F035",
+      "description": "skills/harness-init/enforce-scope.sh.template's cp_mv_targets() and sed_inplace_targets() compare flag tokens RAW (e.g. `tok in TARGET_DIRECTORY_FLAGS`, `tok.startswith(\"-t\")`, `tok in SED_SCRIPT_VALUE_FLAGS`), so quoting a flag evades flag recognition entirely: `cp \"-t\" \"src/other/d/\" src/parser/a` and `cp '-t' src/other/d/ src/parser/a` are both wrongly ALLOWED (real bash writes to src/other/d/, an out-of-scope destination named via -t, but the quoted '-t' token never matches TARGET_DIRECTORY_FLAGS so cp_mv_targets() falls through to last_flagless_token() and picks the wrong argument as the destination). Same shape for `cp \"--target-directory=src/other/d/\" src/parser/a` and `sed \"-i\" \"\" -e \"s/a/b/\" src/other/f.txt` (real sed writes src/other/f.txt). Same vulnerability family as F023/F024/F025/F028 -- a shell-level transformation (here, quote removal on a FLAG token, not a target token) that these two extractors don't replicate before comparing against their flag sets.",
+      "priority": 19,
+      "status": "pending",
+      "scope": [
+        "skills/harness-init/enforce-scope.sh.template",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Discovered by adversarial review of PR #51, round 2 (F028's split_tokens() fix). Explicitly filed as a separate, pre-existing bug (identical on main and the F028 branch), not a regression from that PR. Likely fix, per the reviewer: the sibling hook commit-gate.sh.template already solved this (commit-gate.sh.template:389, `tokens = [unquote_token(t) for t in split_tokens(seg)]`, with a comment explicitly stating tokens must be split then unquoted one at a time, never the reverse -- F025). IMPORTANT TRAP flagged by the same reviewer: the obvious one-line port of that fix would be WRONG here, because unquote_token() is not idempotent since F031 added backslash-stripping (e.g. 'src/other/a\\\\b.txt' unquoted once is 'src/other/a\\b.txt', unquoted TWICE becomes 'src/other/ab.txt'). write_targets() already maps unquote_token over its final target list, and redirect_targets() output bypasses split_tokens() entirely -- so unquoting at split time would double-unquote command-token targets while single-unquoting redirect targets, silently undoing F031's traversal defense. Safe shape (per the reviewer): derive an unquoted VIEW of each token for flag detection only (cp_mv_targets()/sed_inplace_targets()' own comparisons), keep the raw quoted tokens for target extraction, and leave the existing single unquote_token map in write_targets() untouched.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": "F028",
       "spec": null
     }
   ]


### PR DESCRIPTION
## Summary
- Discovered by adversarial review of PR #51 (F028), round 2: `cp_mv_targets()` and `sed_inplace_targets()` in `enforce-scope.sh.template` compare flag tokens raw, so a quoted flag (`cp "-t" "src/other/d/" src/parser/a`, `sed "-i" "" -e "s/a/b/" src/other/f.txt`) evades flag recognition and the real out-of-scope destination is never checked.
- Same vulnerability family as F023/F024/F025/F028. Pre-existing on main, not a regression from F028's own fix.
- Filed only (`.harness/features.json`), no code change — the reviewer flagged a real trap in the obvious fix (unquote_token() isn't idempotent since F031), documented in the feature's notes for whoever picks it up.

## Test plan
- [x] `bash test/run-tests.sh` — 692/692 (no new tests, docs-only change)