### PR TITLE
polish: F034 round-4 nits (wrong test pointer, drifting count)

### DIFF
--- a/.harness/features.json
+++ b/.harness/features.json
@@ -1126,7 +1126,7 @@
       "depends_on": [],
       "assigned_to": null,
       "test_file": "test/run-tests.sh",
-      "coverage": "n/a (shell suite, no coverage tooling; full_test 773/773 is the gate)",
+      "coverage": "n/a (shell suite, no coverage tooling; full_test is the gate -- count omitted here since it drifts on every sibling feature merge; see the header total_features/passing fields for the current count)",
       "notes": "Discovered by adversarial review of PR #53 (F030), which fixed the identical bug in the sibling hook enforce-scope.sh.template and found the same root cause here too, but classified as a real gate bypass rather than a usability false-positive since this hook's whole purpose is to deny compound stage-and-commit commands. Deliberately not fixed inside PR #53 (different file, would have been scope creep on that PR). Given the severity (a live bypass of shipped security infrastructure, same class as F025), prioritized above the other pending internally-discovered features. ROUND 2 CORRECTION: round 1's claim that a leftover redirect token is fully 'inert' to has_staging_flag() was wrong -- it can be silently consumed as a value-taking short flag's value (e.g. -m), shifting the token-position-dependent scan and causing a narrow, NEW false deny (`git commit -m 2>&1 -a`, which real git does not stage-and-commit, since bash's own redirect-stripping makes '-a' the message text, not a flag). Accepted as a documented residual (fail-closed, low severity) rather than building additional machinery to strip redirect fragments from the token stream before flag-scanning runs.",
       "correction_cycles": 0,
       "scope_expansions": [],

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -4177,8 +4177,9 @@ assert_deny_json "$OUT" "cg: mid-command '&>>' does not shadow a real trailing -
 
 # No new false positive on an ordinary clean commit followed by a real
 # background "&" -- the separator property itself (that a real background
-# "&" NOT glued to ">" still splits) is already pinned by an earlier '-am'
-# cluster test in this file, not by this one.
+# "&" NOT glued to ">" still splits) is already pinned by the DIR_CG_AMPERSAND
+# tests earlier in this file ('git status & git commit -m x', etc.) and the
+# Check-0 case ('echo hi & git add . && git commit -m x'), not by this one.
 OUT=$(run_commit_gate "$DIR_CG_MVALUE" 'git commit -m "x" & echo done')
 RC=$?
 assert_rc0 "$RC" "cg: 'git commit -m \"x\" & echo done' passes, rc 0"


### PR DESCRIPTION
## Summary
Two non-blocking nits from PR #58's round-4 review:
- A comment pointed to a nonexistent "-am cluster test" as the place that pins the "real background `&` still splits" property. Corrected to point at the actual tests (the `DIR_CG_AMPERSAND` block and the Check-0 case).
- F034's `coverage` note kept an exact assertion count (773/773, then 774/774) that goes stale on every sibling feature merge — the same drift class flagged twice already. Dropped the exact count entirely per the reviewer's own suggestion; points to the header's `total_features`/`passing` fields instead.

## Test plan
- [x] `bash test/run-tests.sh` — 774/774 (no new tests, comment/docs only)