### PR TITLE
fix: enforce-scope.sh recognizes escaped/quoted command names (F040)

### DIFF
--- a/.harness/features.json
+++ b/.harness/features.json
@@ -2,7 +2,7 @@
   "project": "vv-claude-harness",
   "created": "2026-07-22",
   "total_features": 43,
-  "passing": 30,
+  "passing": 31,
   "features": [
     {
       "id": "F001",
@@ -1214,19 +1214,21 @@
       "id": "F040",
       "description": "skills/harness-init/enforce-scope.sh.template's write_targets() compares the COMMAND NAME token (command_tokens[0]) RAW against (\"cp\",\"mv\")/(\"tee\",\"rm\")/\"sed\", so quoting or backslash-escaping the command name itself evades recognition entirely, not just its flags or targets. CONFIRMED: `\\rm src/other/f.txt`, `\"rm\" src/other/f.txt`, and `'rm' src/other/f.txt` are ALL wrongly ALLOWED (no target extracted at all, since the raw token is '\\\\rm'/'\"rm\"'/\"'rm'\", none of which equals the bare string \"rm\"), even though `\\rm` (backslash-prefixed) is a common, everyday idiom for bypassing a shell alias named rm/cp/mv, not an adversarial evasion technique. Arguably a WIDER hole than F035 itself, since it defeats every command-type extractor (cp_mv_targets(), all_flagless_tokens() for tee/rm, sed_inplace_targets()) in one step, before any of their own (now-fixed) flag/target recognition logic even runs. Likely fix: compare _flag_view(command_tokens[0]) instead of the raw token, mirroring the same pattern used throughout F035 -- this is a command-name recognition check, not a target-value extraction, so no double-unquote risk applies (the command name itself is never returned as a target).",
       "priority": 24,
-      "status": "pending",
+      "status": "passing",
       "scope": [
         "skills/harness-init/enforce-scope.sh.template",
         "test/run-tests.sh"
       ],
       "depends_on": [],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
-      "notes": "Discovered by adversarial review of PR #59 (F035), during a systematic sweep for the same 'raw comparison evadable by quoting' bug class this feature's own fix addresses elsewhere in the same file. Confirmed identical on main and the F035 branch (pre-existing, not a regression). Verified directly: `\\\\rm src/other/f.txt` and `\"rm\" src/other/f.txt` both exit rc 0 with no permissionDecision field at all against a fixture scoped to src/parser/, i.e. a genuine silent bypass, not merely a misnamed denial.",
+      "test_file": "test/run-tests.sh",
+      "coverage": "n/a (shell suite, no coverage tooling; full_test is the gate -- count omitted here since it drifts on every sibling feature merge; see the header total_features/passing fields for the current count)",
+      "notes": "Discovered by adversarial review of PR #59 (F035), during a systematic sweep for the same 'raw comparison evadable by quoting' bug class this feature's own fix addresses elsewhere in the same file. Confirmed identical on main and the F035 branch (pre-existing, not a regression). Verified directly: `\\\\rm src/other/f.txt` and `\"rm\" src/other/f.txt` both exit rc 0 with no permissionDecision field at all against a fixture scoped to src/parser/, i.e. a genuine silent bypass, not merely a misnamed denial.\n\nFIXED: confirmed the bypass live against a src/parser/-scoped fixture before touching code (\\rm, \"rm\", 'rm', \\cp, and \"sed\" -i all exited rc=0 with no permissionDecision field at all). Fixed both call sites that had the raw-comparison bug: write_targets()'s own cp/mv/tee/rm dispatch (introduced a `command_name = _flag_view(command_tokens[0])` local and compared that instead of the raw token), and sed_inplace_targets()'s own internal `tokens[0] != \"sed\"` guard (compared _flag_view(tokens[0]) instead) -- the ticket's own suggested fix named only the write_targets() dispatch, but inspecting sed_inplace_targets() directly (it's called unconditionally from write_targets()'s else branch for any non-cp/mv/tee/rm command) showed the identical bug at its own internal command-name check, a second site the ticket didn't call out. No double-unquote risk: _flag_view() is used here purely for command-NAME recognition, never as a returned target value, matching the established F035 convention. Re-verified live post-fix: all five bypass spellings now correctly deny with the real target named, and an in-scope backslash-escaped rm still allows (no false positive).",
       "correction_cycles": 0,
       "scope_expansions": [],
-      "approaches_tried": [],
+      "approaches_tried": [
+        "Ground-truthed the bypass via direct hook execution against a throwaway fixture (src/parser/ scope) before writing any fix, per session discipline: confirmed rc=0/no-decision for \\rm, \"rm\", 'rm', \\cp, and \"sed\" -i, and rc=0/deny for the unescaped control case, isolating the bug to the raw command-name comparison. Fixed both call sites (write_targets()'s dispatch and sed_inplace_targets()'s own guard) using the existing _flag_view() helper, matching the F035 pattern. Added 6 new regression tests (5 bypass-now-denies cases across rm/cp/sed, plus 1 in-scope no-false-positive case) to test/run-tests.sh. Mutation-tested by reverting the template fix in a working copy via `git stash push -- <file>` while keeping the new tests: confirmed exactly the 10 expected new assertions failed (2 per bypass case: JSON-deny-form and real-target-name) and nothing else regressed, then restored the fix and reconfirmed 1028/1028 green."
+      ],
       "failure_reason": null,
       "discovered_via": "F035",
       "spec": null

--- a/skills/harness-init/enforce-scope.sh.template
+++ b/skills/harness-init/enforce-scope.sh.template
@@ -869,7 +869,15 @@ def sed_inplace_targets(tokens):
     # flags may precede "i" in a cluster and why (a GNU/BSD flavor
     # difference this repo's own platform makes relevant, not an
     # arbitrary choice).
-    if not tokens or tokens[0] != "sed":
+    # Compares _flag_view(tokens[0]), not the raw token, for the same reason
+    # as every other flag/name comparison in this function (F035) -- a
+    # backslash-escaped or quoted "sed" (`\sed -i ...`, `"sed" -i ...`) is
+    # ordinary shell, not adversarial, and real bash still runs sed. The raw
+    # comparison never matched those spellings, so this function returned []
+    # (no targets) and the in-place edit went entirely unchecked, confirmed
+    # live against a src/parser/-scoped fixture (F040, discovered alongside
+    # write_targets()'s identical bug in its own cp/mv/tee/rm dispatch).
+    if not tokens or _flag_view(tokens[0]) != "sed":
         return []
     args = tokens[1:]
     pre_separator_args = args[: _separator_index(args)]
@@ -1063,9 +1071,23 @@ def write_targets(segment):
     targets = redirect_targets(segment)
     command_tokens = split_tokens(strip_redirects(segment))
     if command_tokens:
-        if command_tokens[0] in ("cp", "mv"):
+        # Compares _flag_view(command_tokens[0]), not the raw token, for the
+        # same reason cp_mv_targets()/sed_inplace_targets() compare _flag_view
+        # of their OWN flag tokens (F035): a backslash-escaped or quoted
+        # command name (`\rm src/other/f.txt`, `"rm" src/other/f.txt`, `'rm'
+        # src/other/f.txt`) is ordinary, everyday shell -- a common
+        # alias-bypass idiom, not an adversarial technique -- and real bash
+        # runs it as plain rm regardless of the escaping/quoting. The raw
+        # comparison here never matched any of those spellings, so command
+        # recognition failed entirely and NO target was ever extracted for
+        # cp/mv/tee/rm (confirmed live: rc=0, no denial, against a fixture
+        # scoped to src/parser/). This is a command-NAME recognition check,
+        # not a target-VALUE extraction, so there is no double-unquote risk:
+        # the command name itself is never returned as a target (F040).
+        command_name = _flag_view(command_tokens[0])
+        if command_name in ("cp", "mv"):
             targets = targets + cp_mv_targets(command_tokens[1:])
-        elif command_tokens[0] in ("tee", "rm"):
+        elif command_name in ("tee", "rm"):
             targets = targets + all_flagless_tokens(command_tokens[1:])
         else:
             targets = targets + sed_inplace_targets(command_tokens)

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -2975,6 +2975,65 @@ assert_rc0 "$RC" "hs2 (F039): an in-scope NUL-truncated target passes, rc 0"
 assert_not_contains "$OUT" "permissionDecision" \
   "hs2 (F039): in-scope NUL-truncated target has no deny fields"
 
+# F040: write_targets()'s cp/mv/tee/rm dispatch compared command_tokens[0]
+# RAW against the known command-name tuples, so a backslash-escaped or
+# quoted command name -- an everyday shell idiom, not an adversarial
+# technique -- evaded recognition entirely and no target was extracted at
+# all. Confirmed live against a src/parser/-scoped fixture before fixing:
+# rc=0 with no permissionDecision field whatsoever.
+OUT=$(run_hook "$DIR_HS" enforce-scope.sh \
+  "$(bash_command_json '\rm src/other/f040a.txt')")
+RC=$?
+assert_rc0 "$RC" "hs2 (F040): a backslash-escaped rm exits 0 (JSON deny)"
+assert_deny_json "$OUT" "hs2 (F040): backslash-escaped rm denial uses JSON deny form"
+assert_contains "$OUT" "src/other/f040a.txt" \
+  "hs2 (F040): backslash-escaped rm denial names the real target"
+
+OUT=$(run_hook "$DIR_HS" enforce-scope.sh \
+  "$(bash_command_json '"rm" src/other/f040b.txt')")
+RC=$?
+assert_rc0 "$RC" "hs2 (F040): a double-quoted rm exits 0 (JSON deny)"
+assert_deny_json "$OUT" "hs2 (F040): double-quoted rm denial uses JSON deny form"
+assert_contains "$OUT" "src/other/f040b.txt" \
+  "hs2 (F040): double-quoted rm denial names the real target"
+
+OUT=$(run_hook "$DIR_HS" enforce-scope.sh \
+  "$(bash_command_json "'rm' src/other/f040c.txt")")
+RC=$?
+assert_rc0 "$RC" "hs2 (F040): a single-quoted rm exits 0 (JSON deny)"
+assert_deny_json "$OUT" "hs2 (F040): single-quoted rm denial uses JSON deny form"
+assert_contains "$OUT" "src/other/f040c.txt" \
+  "hs2 (F040): single-quoted rm denial names the real target"
+
+OUT=$(run_hook "$DIR_HS" enforce-scope.sh \
+  "$(bash_command_json '\cp src/parser/a.txt src/other/f040d.txt')")
+RC=$?
+assert_rc0 "$RC" "hs2 (F040): a backslash-escaped cp exits 0 (JSON deny)"
+assert_deny_json "$OUT" "hs2 (F040): backslash-escaped cp denial uses JSON deny form"
+assert_contains "$OUT" "src/other/f040d.txt" \
+  "hs2 (F040): backslash-escaped cp denial names the real target"
+
+# sed_inplace_targets() has the identical bug in its OWN internal command-
+# name guard (tokens[0] != "sed"), a separate call site from write_targets()'s
+# dispatch -- both need the fix, confirmed by inspecting sed_inplace_targets()
+# directly (F040).
+OUT=$(run_hook "$DIR_HS" enforce-scope.sh \
+  "$(bash_command_json '"sed" -i "s/a/b/" src/other/f040e.txt')")
+RC=$?
+assert_rc0 "$RC" "hs2 (F040): a double-quoted sed -i exits 0 (JSON deny)"
+assert_deny_json "$OUT" "hs2 (F040): double-quoted sed -i denial uses JSON deny form"
+assert_contains "$OUT" "src/other/f040e.txt" \
+  "hs2 (F040): double-quoted sed -i denial names the real target"
+
+# No new false positive: a backslash-escaped rm on an IN-SCOPE target must
+# still be allowed.
+OUT=$(run_hook "$DIR_HS" enforce-scope.sh \
+  "$(bash_command_json '\rm src/parser/f040f.txt')")
+RC=$?
+assert_rc0 "$RC" "hs2 (F040): a backslash-escaped rm on an in-scope target passes, rc 0"
+assert_not_contains "$OUT" "permissionDecision" \
+  "hs2 (F040): in-scope backslash-escaped rm has no deny fields"
+
 for TPL in check-remaining-tasks.sh.template enforce-scope.sh.template \
   verify-git-identity.sh.template verify-task-quality.sh.template; do
   if grep -q '^# Failure posture:' "$TEMPLATES_DIR/$TPL"; then


### PR DESCRIPTION
## Summary
- `write_targets()`'s cp/mv/tee/rm dispatch and `sed_inplace_targets()`'s own internal sed-name guard both compared `command_tokens[0]` raw against the known command-name strings, so `\rm`, `"rm"`, `'rm'`, or `"sed"` (ordinary shell idioms, not adversarial techniques) evaded command recognition entirely -- no target was extracted at all, a silent bypass.
- Both sites now compare `_flag_view(token)` instead, matching the existing F035 convention. This is command-name recognition, not target-value extraction, so no double-unquote risk applies.
- Discovered during F035's own review; filed as F040.

## Test plan
- [x] Confirmed the bypass live against a `src/parser/`-scoped fixture before fixing (`\rm`, `"rm"`, `'rm'`, `\cp`, `"sed" -i` all exited rc=0 with no `permissionDecision` field)
- [x] Added 6 regression tests to `test/run-tests.sh` (5 bypass-now-denies cases, 1 in-scope no-false-positive case)
- [x] Mutation-tested: reverted the template fix via `git stash`, confirmed exactly the 10 expected new assertions failed and nothing else regressed, restored the fix
- [x] Full suite green: 1028/1028 assertions passing