### PR TITLE
docs: file F046/F047 -- TeammateIdle stdout/stderr bug + stale live hooks

### DIFF
--- a/.harness/features.json
+++ b/.harness/features.json
@@ -1,7 +1,7 @@
 {
   "project": "vv-claude-harness",
   "created": "2026-07-22",
-  "total_features": 45,
+  "total_features": 47,
   "passing": 31,
   "features": [
     {
@@ -1331,6 +1331,53 @@
       "test_file": null,
       "coverage": null,
       "notes": "Discovered by adversarial review of PR #69 (F040), as a sibling-file check for the same command-name-recognition bug class F040 just fixed in enforce-scope.sh. Reviewer explicitly could not confirm end-to-end reachability (the gate itself did not fire on a plain `git commit -m x` in their fixture) -- first task for whoever picks this up is establishing why the gate isn't firing at all before assessing the quoted-name gap's real severity.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": "F040",
+      "spec": null
+    },
+    {
+      "id": "F046",
+      "description": "skills/harness-init/check-remaining-tasks.sh.template (the TeammateIdle blocking hook) exits 2 to keep an idle teammate working, but writes its guidance text (which feature to pick up, or the retrospective/wrap-up instruction) to STDOUT, never stderr. CONFIRMED live: `echo '{}' | bash .claude/hooks/check-remaining-tasks.sh 2>/dev/null` prints the full guidance message; the same command with `2>&1 1>/dev/null` (stderr only) prints nothing at all, rc=2. Every sibling blocking hook writes its guidance to stderr instead (`grep -c '>&2'`: enforce-scope.sh.template=2, verify-task-quality.sh.template=3), and this appears to be the channel the harness actually surfaces back to a blocked teammate -- a teammate held idle by this hook receives an empty message on every re-prompt and has no way to learn what work it's being asked to pick up, and no way to tell whether the loop is expected to keep firing or is stuck. Reachable by any teammate that finishes its assigned work while claimable features remain in features.json (e.g. a reviewer with no further review to do), which is an ordinary, non-adversarial outcome, not an edge case.",
+      "priority": 30,
+      "status": "pending",
+      "scope": [
+        "skills/harness-init/check-remaining-tasks.sh.template",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Reported by teammate review-pr69-f040 (the F040 reviewer), stuck in a TeammateIdle re-prompt loop after its review was delivered and merged, with 7 consecutive re-prompts each carrying \"No stderr output\". Independently confirmed live before filing: the hook's guidance text is genuinely only on stdout, stderr is empty on every invocation. Also flagged by the same reporter: this doesn't fully solve idle teammates with no assignable work (e.g. reviewers) -- the hook has no concept of role and will re-block ANY idle teammate for as long as ANY feature is claimable, which is a separate design question (role-aware idle behavior), not addressed by this fix. Per an existing memory note, the TeammateIdle payload itself carries no teammate identity, so role-aware behavior would have to live in the agent definitions, not this hook.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": "F040",
+      "spec": null
+    },
+    {
+      "id": "F047",
+      "description": "This repo's OWN live `.claude/hooks/*.sh` (the hooks that actually gate work in THIS repo, as opposed to skills/harness-init/*.sh.template which are the distributable source) have drifted badly out of sync with their templates and were never re-synced as the templates were fixed across many sessions of this same OVI-44 sweep. CONFIRMED via `diff` against the current templates: enforce-scope.sh is 1301 diff lines behind (it predates every fix from F023 through F041 -- essentially the entire quoting/escaping/traversal/command-recognition hardening arc this sweep has been doing), verify-task-quality.sh is 122 lines behind, check-remaining-tasks.sh has diverged onto an inline-python implementation the template no longer uses (the template now delegates to harness_state.py's next-claimable), verify-git-identity.sh is a smaller 10-line drift. statusline.sh is effectively in sync (1-line trailing-newline diff only). This means every hook enforcing scope, task quality, and git identity for teammates spawned IN THIS REPO during this entire sweep has been running the OLD, pre-fix logic, not the hardened version this repo has spent dozens of features building -- the fixes exist only in the distributable template, not in the copy actually protecting this project's own teammates.",
+      "priority": 31,
+      "status": "pending",
+      "scope": [
+        ".claude/hooks/enforce-scope.sh",
+        ".claude/hooks/check-remaining-tasks.sh",
+        ".claude/hooks/verify-task-quality.sh",
+        ".claude/hooks/verify-git-identity.sh",
+        ".claude/hooks/statusline.sh"
+      ],
+      "depends_on": [
+        "F046"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Reported by teammate review-pr69-f040 while investigating its own TeammateIdle idle-loop issue (F046): noticed the live hook it was reading didn't match the template's current structure at all. Independently confirmed via `diff skills/harness-init/<name>.sh.template .claude/hooks/<name>` for all 5 hooks before filing -- sizes above are measured, not estimated. depends_on F046 only in the sense that F046's fix should land in the template FIRST, so this resync picks up the corrected version rather than needing a second resync immediately after. This is a resync/copy operation, not new logic -- should be a mechanical diff-and-replace per hook plus a full_test run to confirm nothing in this repo's own workflow depended on the old (buggy) installed behavior, but still needs the standard review cycle since it changes what actually gates every future teammate's actions in this repo.",
       "correction_cycles": 0,
       "scope_expansions": [],
       "approaches_tried": [],


### PR DESCRIPTION
## Summary
- Files two new bugs surfaced by teammate review-pr69-f040 (the F040 reviewer) after it finished its assigned work, no code change.
- **F046**: `check-remaining-tasks.sh.template` (the TeammateIdle blocking hook) exits 2 but writes its guidance to stdout, never stderr, unlike every sibling blocking hook -- confirmed live, this leaves an idle teammate stuck in a loop with an empty message on every re-prompt.
- **F047**: this repo's own live `.claude/hooks/*.sh` have drifted badly out of sync with their templates -- `enforce-scope.sh` is 1301 diff lines behind, predating every fix from F023 through F041. Confirmed via direct `diff` against the current templates for all 5 hooks.

## Test plan
- [x] `python3 -c "import json; json.load(open('.harness/features.json'))"` -- valid JSON
- [x] No code touched, bookkeeping only