### PR TITLE
fix: fail closed on unsafe FILE_PATH/COMMAND extraction (F043)

### DIFF
--- a/.harness/features.json
+++ b/.harness/features.json
@@ -2,7 +2,7 @@
   "project": "vv-claude-harness",
   "created": "2026-07-22",
   "total_features": 49,
-  "passing": 33,
+  "passing": 34,
   "features": [
     {
       "id": "F001",
@@ -1284,16 +1284,16 @@
       "id": "F043",
       "description": "skills/harness-init/enforce-scope.sh.template's FILE_PATH/COMMAND extraction (the `FILE_PATH=$(echo \"$INPUT\" | python3 -c \"...\" 2>/dev/null)` block) fails open the same way _decode_ansi_c_escape() did before F038 rounds 2-3, but earlier in the pipeline and via a different entry point: a raw lone UTF-16 surrogate (0xD800-0xDFFF) arriving directly in the hook's OWN input JSON (e.g. `{\"tool_input\":{\"file_path\":\"src/other/\\ud800pwned.txt\"}}` -- no $'...' ANSI-C quoting or bash decoding involved at all, since json.load() itself decodes the JSON \\uD800 escape into a Python str containing a lone surrogate) crashes `print(path)` with the same UnicodeEncodeError. The `2>/dev/null` on that command substitution swallows the traceback, FILE_PATH comes back empty, and `if [ -n \"$FILE_PATH\" ]` skips the ENTIRE Edit/Write scope check block -- silently allowing what should have gone through the AUTHORITATIVE file_path gate (Edit/Write/MultiEdit tool calls are blocked outright, not best-effort like the Bash coverage path F038 itself patches). The identical extraction pattern is used for COMMAND just below it, so the Bash coverage path is affected too.",
       "priority": 27,
-      "status": "pending",
+      "status": "passing",
       "scope": [
         "skills/harness-init/enforce-scope.sh.template",
         "test/run-tests.sh"
       ],
       "depends_on": [],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
-      "notes": "Discovered by adversarial review of PR #67, round 2 (F038's surrogate/multi-char-uppercase fixes for the $'...' ANSI-C decoder). Pre-dates F038 entirely -- this is a structurally different code path (the hook's own top-level JSON input extraction, not the bash-side $'...' decoder F038 touches) with much lower reachability, since a lone surrogate must survive transport from whatever produces the tool_input JSON in the first place (Claude's own model output is valid UTF-8/UTF-16 text and would not normally carry an isolated surrogate this way; some other JSON-producing intermediary would need to construct or forward one). Deliberately not folded into F038's own PRs, which were already at their third round under time pressure from a live regression in a different function -- filed as its own feature per the round-2 reviewer's explicit recommendation.",
+      "test_file": "test/run-tests.sh",
+      "coverage": "n/a (shell suite, no coverage tooling; full_test is the gate -- count omitted here since it drifts on every sibling feature merge; see the header total_features/passing fields for the current count)",
+      "notes": "Discovered by adversarial review of PR #67, round 2 (F038's surrogate/multi-char-uppercase fixes for the $'...' ANSI-C decoder). Pre-dates F038 entirely -- this is a structurally different code path (the hook's own top-level JSON input extraction, not the bash-side $'...' decoder F038 touches) with much lower reachability, since a lone surrogate must survive transport from whatever produces the tool_input JSON in the first place (Claude's own model output is valid UTF-8/UTF-16 text and would not normally carry an isolated surrogate this way; some other JSON-producing intermediary would need to construct or forward one). Deliberately not folded into F038's own PRs, which were already at their third round under time pressure from a live regression in a different function -- filed as its own feature per the round-2 reviewer's explicit recommendation.\n\nFIXED: confirmed the bypass live before touching code (both a raw \\uD800 surrogate in tool_input.file_path AND in tool_input.command produced rc=0 with completely empty stdout -- silent ALLOW -- against a fixture scoped to src/parser/, while the identical non-surrogate command correctly denied). Fixed with a two-stage try/except per extraction script, using TWO DISTINCT exit codes rather than one: exit 2 means json.load() itself failed (genuinely unparseable input, stays fail-open -- this file's own documented environment-failure contract, unchanged), exit 1 means the JSON parsed successfully but something after that (the field extraction, normalize, or the final print()) crashed (fails closed). A single except-and-exit(1) wrapping BOTH stages would have silently reversed the documented fail-open behavior for genuinely malformed JSON, since Python's default uncaught-exception exit code is 1 regardless of which stage raised -- confirmed this exact regression live via a dedicated mutation test (collapsing the two stages into one flipped the 'genuinely unparseable JSON stays fail-open' test from ALLOW to DENY). FILE_PATH's denial uses the plain-text/exit-2 form (matching its existing authoritative-gate convention); COMMAND's uses deny_json() (matching its existing best-effort-gate convention) -- neither introduces a new denial format into a code path that didn't already have one. Mutation-tested the whole fix (revert -> exactly 4 of 7 new assertions fail) and the two-stage design specifically (collapse to one stage -> exactly 1 assertion fails, the malformed-JSON regression test) in isolation.",
       "correction_cycles": 0,
       "scope_expansions": [],
       "approaches_tried": [],

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -1,7 +1,7 @@
 {
   "project": "vv-claude-harness",
   "created": "2026-07-22",
-  "total_features": 49,
+  "total_features": 50,
   "passing": 34,
   "features": [
     {
@@ -1430,6 +1430,31 @@
       "approaches_tried": [],
       "failure_reason": null,
       "discovered_via": "F041",
+      "spec": null
+    },
+    {
+      "id": "F050",
+      "description": "The identical raw-lone-surrogate extraction fail-open F043 fixed in enforce-scope.sh.template's FILE_PATH/COMMAND extraction is ALSO present, unfixed, in commit-gate.sh.template's and verify-git-identity.sh.template's own `COMMAND=$(echo \"$INPUT\" | python3 -c \"...json.load...print(...)\" 2>/dev/null)` blocks -- both are gating hooks (not best-effort), so this is a full bypass, not a coverage gap. CONFIRMED live: `git commit -a -m wip` is correctly DENIED by commit-gate.sh (compound-stage-and-commit reason), but the identical command with a trailing \\uD800 in the message (`git commit -a -m wip\\ud800`) exits rc=0 with completely empty output -- the pre-commit secret-scan gate is silently bypassed by one character. The same pattern (same code, same fix needed) is also present in verify-git-identity.sh.template's own git-identity-mismatch gate (reviewer confirmed this one live too), and, lower priority since these are non-gating/informational hooks, in verify-task-quality.sh.template, check-remaining-tasks.sh.template, and hooks/session-start.sh. The fix is mechanically the same two-stage try/except (exit 2 = JSON unparseable, stays fail-open; exit 1 = parsed fine but unsafe to process further, fails closed) F043 already wrote and ground-truthed for enforce-scope.sh.template.",
+      "priority": 34,
+      "status": "pending",
+      "scope": [
+        "skills/harness-init/commit-gate.sh.template",
+        "skills/harness-init/verify-git-identity.sh.template",
+        "skills/harness-init/verify-task-quality.sh.template",
+        "skills/harness-init/check-remaining-tasks.sh.template",
+        "hooks/session-start.sh",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Discovered by adversarial review of PR #74 (F043), while checking for the same extraction-fail-open pattern in sibling hooks after confirming it in enforce-scope.sh.template. Reviewer explicitly scoped it out of F043's own PR (mechanical fix, but touches unrelated files) and recommended filing separately. Independently confirmed live (by the lead, not just the reviewer) for commit-gate.sh.template before filing: control `git commit -a -m wip` denies with the compound-stage-and-commit reason; the identical command with a trailing surrogate exits rc=0 with empty output. Note this fix does not protect THIS repo's own live .claude/hooks/*.sh until F047 (the live-hooks-out-of-sync resync) also lands -- the two are independent but related.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": "F043",
       "spec": null
     }
   ]

--- a/skills/harness-init/enforce-scope.sh.template
+++ b/skills/harness-init/enforce-scope.sh.template
@@ -115,21 +115,73 @@ PYEOF
 # benefit found in the same round).
 FILE_PATH=$(echo "$INPUT" | python3 -c "
 import json, os, sys
-data = json.load(sys.stdin)
-path = data.get('tool_input', {}).get('file_path', '')
-project_root = sys.argv[1]
-if path:
-    if path.startswith(project_root + '/'):
-        path = path[len(project_root) + 1:]
-    path = os.path.normpath(path)
-print(path)
+# The JSON parse itself is in its OWN try/except, exiting 2 on failure:
+# a genuinely unparseable tool-input document is this file's own
+# documented fail-open contract (see the header), and rc 2 tells the
+# caller to leave that behavior alone. Everything AFTER a successful
+# parse -- extracting the field, normalizing it, and printing it -- is a
+# SEPARATE try/except that exits 1 instead (F043): a raw lone UTF-16
+# surrogate (0xD800-0xDFFF) arriving directly in the input JSON (e.g.
+# {\"tool_input\":{\"file_path\":\"src/other/\ud800pwned.txt\"}}) is
+# perfectly valid JSON -- json.load() decodes its \uD800 escape into a
+# real Python str containing a lone surrogate with no error at all -- but
+# crashes the FINAL print(path) with UnicodeEncodeError once stdout isn't
+# a tty (confirmed live: identical code succeeds interactively, raises
+# under \$(...) capture). The 2>/dev/null on this whole command
+# substitution swallowed that traceback, FILE_PATH came back empty, and
+# the caller's own \"if [ -n \\\"\$FILE_PATH\\\" ]\" then skipped the
+# ENTIRE Edit/Write scope check -- silently allowing what should have
+# gone through this file's own AUTHORITATIVE gate (Edit/Write/MultiEdit
+# calls are blocked outright, not best-effort like the Bash coverage path
+# F038 already patches for its own \$'...' decoder). Two distinct exit
+# codes (not 'any nonzero') are required here: an uncaught exception's
+# default exit code is 1 regardless of which try/except raised it, so a
+# single except-and-exit(1) around BOTH stages would make a genuinely
+# unparseable document fail closed too, silently reversing this file's
+# own documented environment-failure contract -- rc 2 vs rc 1 is what
+# lets the caller (below) tell 'can't parse at all, stay fail-open' apart
+# from 'parsed fine, but unsafe to process further, fail closed'.
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(2)
+try:
+    path = data.get('tool_input', {}).get('file_path', '')
+    project_root = sys.argv[1]
+    if path:
+        if path.startswith(project_root + '/'):
+            path = path[len(project_root) + 1:]
+        path = os.path.normpath(path)
+    print(path)
+except Exception:
+    sys.exit(1)
 " "$PROJECT_ROOT" 2>/dev/null)
+FILE_PATH_RC=$?
+if [ "$FILE_PATH_RC" -eq 1 ]; then
+    echo "Edit blocked: file_path could not be safely extracted from tool input (best-effort check; treating as outside your assigned scope). $ANNOTATION"
+    exit 2
+fi
 
 COMMAND=$(echo "$INPUT" | python3 -c "
 import json, sys
-data = json.load(sys.stdin)
-print(data.get('tool_input', {}).get('command', ''))
+# Same two-stage split as FILE_PATH above, and for the same reason: a
+# crash AFTER a successful JSON parse -- the identical raw-surrogate
+# print() crash, reachable here via tool_input.command instead of
+# file_path -- fails closed (rc 1), while a genuinely unparseable
+# document stays fail-open (rc 2) (F043).
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(2)
+try:
+    print(data.get('tool_input', {}).get('command', ''))
+except Exception:
+    sys.exit(1)
 " 2>/dev/null)
+COMMAND_RC=$?
+if [ "$COMMAND_RC" -eq 1 ]; then
+    deny_json "command could not be safely extracted from tool input (best-effort, pattern-based check; treating as outside your assigned scope). $ANNOTATION"
+fi
 
 if [ -n "$FILE_PATH" ]; then
     case "$FILE_PATH" in

--- a/skills/harness-init/enforce-scope.sh.template
+++ b/skills/harness-init/enforce-scope.sh.template
@@ -17,7 +17,11 @@
 # the goal is stopping accidental drift, not defeating an adversarial teammate.
 # Once a segment's own analysis begins, though, an exception anywhere in it (a
 # decoder crash, or anything else _check_segment() can't handle) denies that
-# segment unconditionally instead -- see main()'s own comment for why.
+# segment unconditionally instead -- see main()'s own comment for why. The same
+# split applies one layer up, at the FILE_PATH/COMMAND extraction near the top of
+# this file (F043): the JSON itself failing to parse stays fail-open, but anything
+# that goes wrong AFTER a successful parse (a raw surrogate crashing the final
+# print(), or any other unexpected shape) fails closed instead.
 # Straightforward single/double/ANSI-C quoting of a separator or a write target is
 # handled (see mask_quotes()/unquote_token()); nested or otherwise unusual quoting
 # is not attempted. Known false-positive residual: redirect-target extraction
@@ -158,7 +162,7 @@ except Exception:
 " "$PROJECT_ROOT" 2>/dev/null)
 FILE_PATH_RC=$?
 if [ "$FILE_PATH_RC" -eq 1 ]; then
-    echo "Edit blocked: file_path could not be safely extracted from tool input (best-effort check; treating as outside your assigned scope). $ANNOTATION"
+    echo "Edit blocked: file_path could not be safely extracted from tool input (treating as outside your assigned scope). $ANNOTATION"
     exit 2
 fi
 

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -3322,6 +3322,46 @@ assert_rc0 "$RC" "hs2 (F042): an ordinary in-scope command with no crash passes,
 assert_not_contains "$OUT" "permissionDecision" \
   "hs2 (F042): ordinary in-scope command has no deny fields"
 
+# F043: the FILE_PATH/COMMAND extraction near the top of this hook fails
+# open the same way _decode_ansi_c_escape() did before F038/F042, but
+# earlier in the pipeline and via a different entry point: a raw lone
+# UTF-16 surrogate (0xD800-0xDFFF) arriving directly in the hook's OWN
+# input JSON is perfectly valid JSON -- json.load() decodes the \uD800
+# escape into a real Python str containing a lone surrogate with no error
+# at all -- but crashes the extraction script's own final print() with
+# UnicodeEncodeError once stdout isn't a tty. The 2>/dev/null on that
+# command substitution swallowed the traceback, FILE_PATH/COMMAND came
+# back empty, and "if [ -n \"\$FILE_PATH\" ]" skipped the ENTIRE scope
+# check -- silently allowing what should have gone through this file's
+# own AUTHORITATIVE file_path gate. Fixed with two distinct python-side
+# exit codes (2 = JSON couldn't be parsed at all, stays fail-open per
+# this file's own documented contract; 1 = parsed fine but unsafe to
+# process further, fails closed) so the fix doesn't accidentally reverse
+# the existing fail-open behavior for genuinely malformed input.
+OUT_SURROGATE_PATH_JSON="{\"tool_input\":{\"file_path\":\"$DIR_HS/src/other/f043a.txt\ud800\"}}"
+OUT=$(run_hook "$DIR_HS" enforce-scope.sh "$OUT_SURROGATE_PATH_JSON")
+RC=$?
+assert_rc2 "$RC" "hs2 (F043): a raw surrogate in file_path exits 2 (blocked), not silently allowed"
+assert_contains "$OUT" "could not be safely extracted" \
+  "hs2 (F043): surrogate-in-file_path denial states extraction failure"
+
+OUT_SURROGATE_CMD_JSON="{\"tool_input\":{\"command\":\"rm src/other/f043b.txt\ud800\"}}"
+OUT=$(run_hook "$DIR_HS" enforce-scope.sh "$OUT_SURROGATE_CMD_JSON")
+RC=$?
+assert_rc0 "$RC" "hs2 (F043): a raw surrogate in command exits 0 (JSON deny), not silently allowed"
+assert_deny_json "$OUT" "hs2 (F043): surrogate-in-command denial uses JSON deny form"
+assert_contains "$OUT" "could not be safely extracted" \
+  "hs2 (F043): surrogate-in-command denial states extraction failure"
+
+# No regression: this file's own documented fail-open contract for a
+# genuinely unparseable tool-input document (as opposed to valid JSON
+# that merely crashes downstream) must be unchanged.
+OUT=$(run_hook "$DIR_HS" enforce-scope.sh '{not valid json at all')
+RC=$?
+assert_rc0 "$RC" "hs2 (F043): genuinely unparseable JSON still exits 0 (stays fail-open)"
+assert_not_contains "$OUT" "permissionDecision" \
+  "hs2 (F043): unparseable JSON has no deny fields (unchanged environment-failure contract)"
+
 for TPL in check-remaining-tasks.sh.template enforce-scope.sh.template \
   verify-git-identity.sh.template verify-task-quality.sh.template; do
   if grep -q '^# Failure posture:' "$TEMPLATES_DIR/$TPL"; then


### PR DESCRIPTION
## Summary
- The FILE_PATH/COMMAND extraction near the top of `enforce-scope.sh` fails open the same way `_decode_ansi_c_escape()` did before F038/F042, but earlier in the pipeline: a raw lone UTF-16 surrogate arriving directly in the hook's own input JSON is perfectly valid JSON (`json.load()` decodes the `\uD800` escape into a real Python `str` with no error), but crashes the extraction script's own `print()` with `UnicodeEncodeError` once stdout isn't a tty. The `2>/dev/null` swallowed the traceback, `FILE_PATH`/`COMMAND` came back empty, and the caller's own `if [ -n "$FILE_PATH" ]` skipped the entire scope check -- silently allowing what should have gone through the authoritative `file_path` gate.
- Fixed with two distinct exit codes per extraction script: 2 means the JSON itself couldn't be parsed (stays fail-open, this file's own documented environment-failure contract, unchanged), 1 means the JSON parsed fine but something after that crashed (fails closed). A single except-and-exit(1) around both stages would have silently reversed the documented fail-open behavior for genuinely malformed input.

## Test plan
- [x] Confirmed the bypass live before fixing (both `file_path` and `command` surrogate cases: rc=0, empty stdout, silent ALLOW)
- [x] Added regression tests: surrogate-in-`file_path` denies, surrogate-in-`command` denies, genuinely unparseable JSON still stays fail-open (no regression)
- [x] Mutation-tested: reverting the whole fix reproduces exactly 4 of 7 new assertion failures; collapsing the two-stage exit codes into one reproduces exactly 1 (the malformed-JSON regression)
- [x] Full suite green: 1083/1083 assertions passing