### PR TITLE
fix: re-sync this repo's own live .claude/hooks/*.sh from their templates (F047)

### DIFF
--- a/.claude/hooks/check-remaining-tasks.sh
+++ b/.claude/hooks/check-remaining-tasks.sh
@@ -3,59 +3,57 @@
 # Runs when a teammate is about to go idle.
 # Exit code 0 = allow idle (no more work)
 # Exit code 2 = send feedback, keep teammate working
+# Degraded behavior: a malformed feature entry is skipped with a stderr note;
+# the remaining features are still evaluated for claimable work.
+# Failure posture: fail-open. A missing or malformed features.json, or an unexpected
+# harness_state.py output, results in exit 0 (idle allowed) rather than blocking.
+# Residual: the reformatting step assumes harness_state.py's documented contract (the
+# literal string "no claimable feature" or valid JSON) and is not independently
+# validated -- an out-of-contract module output would raise rather than fall back.
+# Guidance text (which feature to pick up next) goes to stderr, not stdout: Claude
+# Code discards a hook's stdout entirely on exit 2 and feeds only stderr back to the
+# blocked agent as its error message (code.claude.com/docs/en/hooks). A stdout-only
+# message left an idle teammate with no visible guidance at all (F046, reported by a
+# teammate stuck in a re-prompt loop with "No stderr output"). This was the first
+# hook in this repo to get the channel right -- enforce-scope.sh.template's two
+# legacy `exit 2` sites and verify-task-quality.sh.template's four all still write
+# their blocking message to stdout, the same defect, not yet fixed (see F046 notes).
 
 set -euo pipefail
 
-PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 cd "$PROJECT_ROOT"
 
 # Read hook input from stdin
 INPUT=$(cat)
 
-# Check features.json for remaining work
-# Status enum: pending, in-progress, blocked, passing, failed
-# Claimable statuses: pending (ready for work), failed (needs re-attempt)
-if [ -f ".harness/features.json" ]; then
-    CLAIMABLE=$(cat .harness/features.json | python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-features = data.get('features', [])
-passing_ids = {f['id'] for f in features if f['status'] == 'passing'}
-claimable = [
-    f for f in features
-    if f['status'] in ('pending', 'failed')
-    and all(dep in passing_ids for dep in f.get('depends_on', []))
-]
-print(len(claimable))
-" 2>/dev/null || echo "0")
-
-    if [ "$CLAIMABLE" -gt 0 ]; then
-        # Find the highest priority claimable feature whose dependencies are met
-        NEXT=$(cat .harness/features.json | python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-features = data.get('features', [])
-passing_ids = {f['id'] for f in features if f['status'] == 'passing'}
-claimable = [
-    f for f in features
-    if f['status'] in ('pending', 'failed')
-    and all(dep in passing_ids for dep in f.get('depends_on', []))
-]
-if claimable:
-    claimable.sort(key=lambda f: f.get('priority', 999))
-    f = claimable[0]
-    status_note = ' (retry)' if f['status'] == 'failed' else ''
-    scope = ', '.join(f.get('scope', [])) if f.get('scope') else 'no scope defined'
-    print(f'{f[\"id\"]}: {f[\"description\"]} (priority {f.get(\"priority\", \"unset\")}){status_note} [scope: {scope}]')
-" 2>/dev/null || echo "")
-
-        if [ -n "$NEXT" ]; then
-            echo "There are $CLAIMABLE claimable feature(s). Pick up the next one: $NEXT"
-            echo "Read .harness/features.json for full details, then claim it via TaskUpdate."
-            exit 2
-        fi
-    fi
+if [ ! -f ".harness/features.json" ]; then
+    exit 0
 fi
 
-# No remaining work
-exit 0
+# Check features.json for remaining work via the shared state module.
+# Status enum: pending, in-progress, blocked, passing, failed
+# Claimable statuses: pending (ready for work), failed (needs re-attempt)
+STATE_MODULE=".claude/hooks/harness_state.py"
+RESULT=$(python3 "$STATE_MODULE" next-claimable .harness/features.json || true)
+
+if [ -z "$RESULT" ] || [ "$RESULT" = "no claimable feature" ]; then
+    exit 0
+fi
+
+NEXT=$(printf '%s' "$RESULT" | python3 -c "
+import json
+import sys
+
+data = json.load(sys.stdin)
+f = data['next']
+status_note = ' (retry)' if f.get('status') == 'failed' else ''
+scope = ', '.join(f.get('scope') or []) or 'no scope defined'
+print(f\"{data['count']} claimable feature(s). Next: {f.get('id')}: \"
+      f\"{f.get('description')} (priority {f.get('priority', 'unset')})\"
+      f\"{status_note} [scope: {scope}]\")
+")
+
+echo "$NEXT" >&2
+echo "Read .harness/features.json for full details, then claim it via TaskUpdate." >&2
+exit 2

--- a/.claude/hooks/commit-gate.sh
+++ b/.claude/hooks/commit-gate.sh
@@ -1,0 +1,927 @@
+#!/bin/bash
+# VV Claude Code Harness - PreToolUse commit-content gate
+# Runs before Bash tool calls; no-ops unless the command tokenizes to a
+# segment starting with "git" whose subcommand is "commit" (see
+# segment_subcommand below). Three earlier revisions used progressively wider
+# regexes for this decision (bash substring match -> \bgit\s+commit\b ->
+# \bgit\b.*\bcommit\b -> \bgit\b[^|;&]*(?:^|\s)commit(?:\s|$)), each fixing
+# one adversarial-review finding while introducing another (a filename or
+# branch name containing "commit"/"add" as a substring; a newline inside the
+# command letting an unrelated later line match; a separator with no
+# surrounding whitespace bypassing the boundary check entirely). Real
+# tokenization replaces all four of those regexes: it compares whole tokens,
+# so a substring occurrence inside a longer word is never a match, and
+# segmenting on the control operators command_segments recognizes (see its
+# own comment) up front means a token from one logical command can't pair
+# with a token from another -- for those operators specifically. This is
+# still pattern-based tokenization, not a real shell parser: an operator
+# command_segments doesn't split on, or a leading token segment_subcommand
+# doesn't know to skip, can still glue two logical commands into one
+# unrecognized segment (see Residual holes below for the ones found so far).
+# Adapted from Setlist's commit-gate.sh (Alex Ciortan, CC BY 4.0).
+#
+# Checks (each names a closed finding class in its denial):
+#   0. compound-stage-and-commit -- denies a command that stages AND commits in one
+#      step (`git add|stage ... && git commit`, or
+#      `git commit -a`/`-i`/`--all`/`--include`, including combined short-flag
+#      clusters like `-am`). A pre-commit hook can only scan an index that already
+#      holds the content; newly staged content in the SAME command is invisible to
+#      Check 1's scan. Quoted spans (single, double, ANSI-C $'...') are masked (not
+#      deleted -- see mask_quotes) when finding segment boundaries, so a commit
+#      message like `git commit -m "run git add later"` does not false-trip on the
+#      words "git"/"add" inside it, while the real tokens of a quoted invocation
+#      like `git "commit" -m x` still tokenize correctly (F025).
+#   1. secret-assignment / url-credential -- scans staged additions
+#      (`git diff --cached -U0`, `+` lines) for key/secret/password/token
+#      assignments >= 16 chars (keyword may appear as part of a larger identifier,
+#      e.g. AWS_SECRET_ACCESS_KEY or a quoted JSON key, not just a bare word --
+#      this trades some false positives for fewer false negatives, acceptable
+#      since the pattern set is the project's own tuning surface) and
+#      URL-embedded credentials (any scheme, not just http/https). Any staged
+#      path whose basename matches `*.env.example` is exempt. Denial names the
+#      finding class, file, and line number -- NEVER the matched value or line
+#      content, to avoid writing a candidate secret into the transcript or hook
+#      logs. Pattern set is tuned by editing this copied-then-project-owned file
+#      directly; no separate runtime override mechanism exists. The pattern is
+#      still worst-case polynomial in a single line's length on adversarially
+#      repeated keyword-shaped text with no valid terminator (removing its
+#      leading wildcard prefix cut the constant factor by roughly two orders of
+#      magnitude but did not change its complexity class) -- SECRET_SCAN_MAX_LEN
+#      bounds any one line's scan time regardless, and SCAN_TIME_BUDGET_SECONDS
+#      bounds the total across every line, so neither the pattern's exact
+#      complexity nor the number of staged lines can make this hook hang.
+#   2. style-violation -- opt-in via harness.json's `style_gate` key (shape
+#      `{"enabled": false}`; absent, false, or any non-object value means off).
+#      Example shipped: an em-dash ban, built from an escape sequence so this
+#      file never contains the character.
+#
+# Fail-open for: parse errors, not a git repo, `git diff --cached` exiting non-zero
+# or timing out (COMMIT_GATE_DIFF_TIMEOUT env var, default 5 seconds -- overridable
+# only for testing; production installs should not set it), the scan-time budget
+# being exceeded, python3 unavailable, or any unexpected scanning exception
+# (logged to stderr as the exception TYPE NAME only, never its message/args,
+# since exception text can itself carry matched line content).
+#
+# Residual holes: `git commit <pathspec>` commits the working tree without
+# staging, which this hook cannot distinguish from a normal commit of
+# already-staged content. A single staged line longer than SECRET_SCAN_MAX_LEN
+# is only scanned up to that length -- a secret past that point on the same
+# line is silently missed (accepted: scanning overlapping windows to close
+# this adds real complexity for a line length no ordinary commit approaches).
+# No automated latency test exists for any hook in this repo; design target
+# (undocumented elsewhere) is under 1 second for a typical commit's staged diff,
+# since this hook blocks an interactive PreToolUse Bash call synchronously.
+# Check 0's quote handling (mask_quotes/unquote_token) covers single/double/
+# ANSI-C quoting only; recursive or nested quoting is out of scope, consistent
+# with this repo's existing pattern-based-and-evadable-by-construction posture
+# for Bash-command hooks. A quoted span containing a heredoc body is not
+# masked correctly (the quote-matching regex doesn't cross heredoc syntax) --
+# if the heredoc body's literal text happens to read like a staging command,
+# this can produce a false denial (fail-closed, over-blocking); accepted,
+# same evadable-by-construction posture.
+# parse_command joins backslash-newline shell continuations (outside quotes)
+# into a single space before segmenting, so `git \` + newline + `commit -m x`
+# is recognized as one git-commit invocation rather than being split into two
+# segments that neither alone tokenize as one -- an earlier version of this
+# hook didn't join continuations, which no-op'ed the entire gate for a
+# continued command (fail-open bypass, not merely a missed check: the secret
+# scan itself was skipped). join_continuations runs on the whole raw command
+# regardless of quote boundaries (it has no quote awareness of its own), so a
+# continuation that happens to fall inside a quoted commit message is joined
+# to a space there too -- a minor content change inside the message text, not
+# a detection gap, since quoted content is preserved (not erased) through
+# segmentation either way (see mask_quotes). Not attempted:
+# joining a continuation that falls inside a heredoc body (see above) --
+# that would require tracking heredoc state across the whole command, not a
+# one-line fix like the unquoted case was.
+# segment_subcommand recognizes "git" invoked directly, via a path
+# (/usr/bin/git, ./git), backslash-prefixed (\git, the standard alias-bypass
+# idiom), or paren-wrapped ("(git ..."); it also skips a closed set of shell
+# reserved words that can lead a simple command inside a control structure
+# (SHELL_LEADING_KEYWORDS: "then", "do", "else", "elif" -- e.g. "if true;
+# then git commit -m x; fi"). A brace-grouped invocation ("{ git commit -m
+# x; }") is not recognized, and neither is an invocation wrapped in another
+# command (`sudo git commit`, `env FOO=1 git commit`) -- accepted rather
+# than maintaining an open-ended wrapper/grouping-command allowlist (sudo,
+# doas, env, nice, timeout, brace groups, ...) in a way the closed
+# keyword/flag classification isn't. A `case ... in PATTERN) git commit
+# ...` segment is also not recognized: the token immediately before "git"
+# is an arbitrary case pattern, not a fixed word to skip, so closing this
+# would need real shell parsing rather than one more set entry -- accepted,
+# same class as the wrapper-command gap. GIT_FLAGS_WITH_VALUE enumerates
+# the global flags that consume a following space-separated argument,
+# probed mechanically against git 2.52 (see its own comment above); it is
+# not a full git CLI parser and does not claim to track every future git
+# release -- for example, `--super-prefix` consumed an argument through at
+# least git 2.38 but is absent from handle_options() by 2.43 (removed
+# somewhere in that range; not pinned closer), so it was dropped from the
+# set per the 2.52 probe; this is a narrow regression on git older than
+# roughly 2.42, not a general bypass on any currently supported git.
+# GIT_COMMIT_LONG_OPTIONS/VALUE_TAKING_LONG_FLAGS (F032) is a second
+# git-version-pinned table with the identical drift exposure: last
+# verified against git 2.52.0, mechanically re-derived from git's own
+# option-parsing errors (not assembled from memory). If a future git
+# version adds, removes, or renames a `git commit` long option -- changing
+# which prefixes are ambiguous with which -- this table needs
+# re-verification against that version; a stale table's failure mode is a
+# missed abbreviation (an over-cautious deny of a real command, never a
+# bypass, since _resolve_long_flag() only ever narrows what it recognizes,
+# it does not invent new matches).
+
+INPUT=$(cat)
+
+PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+cd "$PROJECT_ROOT" 2>/dev/null || exit 0
+
+COMMAND=$(echo "$INPUT" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(data.get('tool_input', {}).get('command', ''))
+" 2>/dev/null)
+
+deny_json() {
+    python3 - "$1" <<'PYEOF'
+import json
+import sys
+
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": sys.argv[1],
+    }
+}))
+PYEOF
+    exit 0
+}
+
+DENY_REASON=$(python3 - "$COMMAND" "$PROJECT_ROOT" <<'PYEOF'
+import fnmatch
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+DENY_COMPOUND = (
+    "compound-stage-and-commit: this command stages and commits in one step, but "
+    "a pre-commit hook can only scan an index that already holds the content -- "
+    "newly staged content in the same command is invisible to the secret scan. "
+    "Repair: split into a separate 'git add <files>' followed by 'git commit' "
+    "with no staging flags (avoid -a/-i/--all/--include)."
+)
+REPAIR_STAGED = (
+    "remove or redact the flagged value from the staged diff, or move it to an "
+    "untracked file (e.g. .env, already gitignored)"
+)
+REPAIR_STYLE = "replace the em dash with a comma, period, or parentheses"
+
+STAGING_FLAGS = {"-a", "-i", "--all", "--include"}
+
+# The set of long options `git commit` recognizes, used as the
+# disambiguation universe for _resolve_long_flag(): real git accepts any
+# UNAMBIGUOUS prefix of a long option (`git commit --mess ...` resolves to
+# `--message`), so a fixed VALUE_TAKING_LONG_FLAGS exact-string set alone,
+# however complete, is still bypassable via abbreviation (confirmed
+# against real git 2.52.0: `--mess`, `--messa`, `--trail` etc. all resolve
+# and genuinely stage a dirty file via a trailing `-- -a`, found by
+# adversarial review of PR #56, round 1). Built from TWO sources, not
+# memory or `-h` output alone: `git commit --git-completion-helper` (the
+# baseline), THEN a systematic probe of every 2- and 3-letter `--xx`/`--xyz`
+# prefix against real git, collecting every option name mentioned in the
+# resulting "ambiguous option: ... (could be A or B)" error messages --
+# this second pass is what surfaced --allow-empty/--allow-empty-message
+# and their --no- forms, which --git-completion-helper's own suggestion
+# list omits entirely (confirmed: `git commit --al` genuinely errors
+# "ambiguous option: al (could be --allow-empty or --allow-empty-message)"
+# in real git, a 3-way ambiguity with --all that neither source alone
+# would have revealed). NOT included: git's further "--no-no-X" double-
+# negation forms (e.g. --no-no-verify, git's auto-negation of its own
+# --no-verify) -- confirmed real but not resolved by this function, an
+# accepted, narrow residual (this deep a double-negation abbreviation is
+# not a realistic attack shape). The `--no-`-prefixed entries are real,
+# independently abbreviation-eligible strings in git's own resolver even
+# though none of them are in VALUE_TAKING_LONG_FLAGS below.
+GIT_COMMIT_LONG_OPTIONS = (
+    "--quiet", "--verbose", "--file", "--author", "--date", "--message",
+    "--reedit-message", "--reuse-message", "--fixup", "--squash",
+    "--reset-author", "--trailer", "--signoff", "--template", "--edit",
+    "--cleanup", "--status", "--gpg-sign", "--all", "--include",
+    "--interactive", "--patch", "--unified", "--inter-hunk-context",
+    "--only", "--no-verify", "--dry-run", "--short", "--branch",
+    "--ahead-behind", "--porcelain", "--long", "--null", "--amend",
+    "--no-post-rewrite", "--untracked-files", "--pathspec-from-file",
+    "--pathspec-file-nul", "--verify", "--post-rewrite",
+    "--allow-empty", "--allow-empty-message",
+    "--no-allow-empty", "--no-allow-empty-message",
+)
+
+# Long `git commit` flags that take a bare (space-separated) value, e.g.
+# `git commit --message foo`. Unlike VALUE_TAKING_SHORT_FLAGS/
+# REQUIRED_VALUE_SHORT_FLAGS (F027), no split into an "attached-only" vs
+# "required" subset is needed here: verified against `git commit -h` that
+# all 14 are genuinely required-value (shown as `<value>`, never the
+# bracketed `[=<mode>]` optarg syntax `-u[<mode>]`/`-S[<keyid>]` use), so
+# every bare occurrence unconditionally consumes the next token as its
+# value. The attached "--message=foo" form is a single token that never
+# equals any string in this set, so it's never mistaken for the bare form
+# and needs no special handling. Before this, has_staging_flag() only
+# recognized this space-separated-value pattern for SHORT flags (F027),
+# then only 8 of these 14 long flags (round 1 of F032, missing --trailer,
+# --reedit-message, --cleanup, --unified, --inter-hunk-context, and
+# --pathspec-from-file -- found by the same PR #56 round-1 review that
+# caught the abbreviation gap).
+VALUE_TAKING_LONG_FLAGS = {
+    "--message", "--file", "--author", "--date", "--template",
+    "--fixup", "--squash", "--reuse-message", "--trailer",
+    "--reedit-message", "--cleanup", "--unified", "--inter-hunk-context",
+    "--pathspec-from-file",
+}
+
+
+def _resolve_long_flag(view):
+    # Real git accepts any prefix of a long option that uniquely identifies
+    # it among ALL options the subcommand recognizes -- not just among the
+    # value-taking ones -- so resolution must check against the FULL
+    # GIT_COMMIT_LONG_OPTIONS universe, not just VALUE_TAKING_LONG_FLAGS,
+    # to correctly mirror real git's own ambiguity rule. Returns the
+    # resolved full flag name, or None if `view` doesn't uniquely resolve
+    # (no match, or an ambiguous prefix of 2+ options) -- in the ambiguous
+    # case, real git itself errors out and nothing runs, so treating it as
+    # "not a recognized flag" here is always safe, never a bypass.
+    if view in GIT_COMMIT_LONG_OPTIONS:
+        return view
+    matches = [o for o in GIT_COMMIT_LONG_OPTIONS if o.startswith(view)]
+    return matches[0] if len(matches) == 1 else None
+
+# Global git flags that consume a following argument in their space-separated
+# form (the "=value" form, e.g. --git-dir=.git, is already handled -- it's a
+# single token with no following argument to skip). This set was probed
+# mechanically against git 2.52, not assembled from memory: every long-option-
+# shaped string in the git binary was tried as `git <flag> ARG1VAL ZZBOGUS`
+# and classified by whether git reports ZZBOGUS (consumes an arg) or the flag
+# itself (doesn't); all 52 single-letter short flags were swept the same way.
+# An earlier version had only -C/-c, then a second pass added --git-dir/
+# --work-tree/--namespace/--exec-path/--super-prefix/--attr-source from
+# memory rather than probing -- that pass both missed two real ones
+# (--config-env, --shallow-file) and kept two that don't actually consume a
+# following argument (--exec-path prints and exits; --super-prefix was
+# removed in 2.52) -- found by adversarial review of PR #40. Any flag missing
+# from this set causes the same bypass: segment_subcommand returns the flag's
+# VALUE as the subcommand, no-op'ing the entire gate.
+GIT_FLAGS_WITH_VALUE = {
+    "-C", "-c", "--config-env", "--git-dir", "--work-tree",
+    "--namespace", "--attr-source", "--shallow-file",
+}
+
+# No leading wildcard prefix before the keyword: an earlier version had
+# "[A-Za-z0-9_.\-]*" before the keyword alternation, which is a second
+# independent quantifier over an overlapping character class -- adversarially
+# repeated keyword-shaped text with no valid 16+ char terminator forced
+# polynomial-time backtracking (found by adversarial review of PR #40).
+# Anchoring directly on the keyword still matches AWS_SECRET_ACCESS_KEY= and
+# "api_key": (the suffix wildcard after the keyword covers those), it just no
+# longer also searches for an arbitrary-length prefix before it.
+SECRET_KEYWORDS = "key|secret|password|passwd|pwd|token"
+SECRET_PATTERN = re.compile(
+    r"(?i)(?:" + SECRET_KEYWORDS + r")[A-Za-z0-9_.\-]*['\"]?\s*[:=]\s*"
+    r"['\"]?([A-Za-z0-9+/_.\-]{16,})"
+)
+# Bounds any single line's scan time regardless of the pattern's complexity;
+# no real secret assignment is anywhere close to this long.
+SECRET_SCAN_MAX_LEN = 2048
+# Bounds TOTAL scan time across every staged line, since the per-line cap
+# alone doesn't bound aggregate time against many adversarial lines (~1000
+# adversarially-crafted 2048-char lines measured at ~18s combined even with
+# the per-line cap in place).
+SCAN_TIME_BUDGET_SECONDS = 2.0
+URL_CREDENTIAL_PATTERN = re.compile(r"[a-zA-Z][a-zA-Z0-9+.\-]*://[^\s:/@]+:[^\s@/]+@")
+EM_DASH_PATTERN = re.compile("\u2014")
+
+
+QUOTE_SPAN_PATTERN = re.compile(r"\$'(?:[^'\\]|\\.)*'|'[^']*'|\"(?:[^\"\\]|\\.)*\"")
+
+
+def mask_quotes(command):
+    # Replaces each quoted span (single, double, ANSI-C $'...') with a same-
+    # LENGTH run of NUL placeholder characters -- never a real separator or
+    # token character -- so that a real control operator INSIDE a quoted
+    # string (a commit message like "git add later; do it now") doesn't get
+    # mistaken for a real one when command_segments() scans this masked copy
+    # for split positions. Unlike deleting the quoted span (an earlier
+    # version of this hook did that, via a function named strip_quotes),
+    # preserving length means split positions found in the masked copy line
+    # up character-for-character with the ORIGINAL command, so
+    # command_segments() can slice the real, still-quoted text for each
+    # segment -- deleting the span instead erased the "git"/"commit" tokens
+    # themselves whenever either was quoted (`git "commit" -m x`), silently
+    # disabling the entire gate including the secret scan on a real staged
+    # secret. Found by adversarial review of PR #42 in a sibling hook
+    # (enforce-scope.sh.template/F023, same root cause: quote-erasure
+    # deleting content load-bearing for the gate's decision), then
+    # independently confirmed in THIS hook and fixed as F025 (PR #44).
+    def repl(m):
+        return "\0" * len(m.group(0))
+
+    return QUOTE_SPAN_PATTERN.sub(repl, command)
+
+
+ANSI_C_SIMPLE_ESCAPES = {
+    "\\": "\\", "'": "'", '"': '"',
+    "a": "\a", "b": "\b", "e": "\x1b", "f": "\f",
+    "n": "\n", "r": "\r", "t": "\t", "v": "\v",
+}
+ANSI_C_ESCAPE_PATTERN = re.compile(
+    r"\\(?:x([0-9A-Fa-f]{1,2})|([0-7]{1,3})|c(.)"
+    r"|u([0-9A-Fa-f]{1,4})|U([0-9A-Fa-f]{1,8})|(.))"
+)
+
+
+def _decode_ansi_c_escape(m):
+    # Ported verbatim from enforce-scope.sh.template's own decoder (F038),
+    # since this hook's own unquote_token() (below) had the identical gap:
+    # a $'...' wrapper was stripped with a plain regex substitution that
+    # never decoded what was INSIDE it, so an escaped spelling of "git"
+    # (`$'\x67it'`) reached is_git_token() undecoded and failed to match --
+    # which, because is_git_token() is the ONLY thing deciding whether a
+    # segment is git-shaped at all, silently disabled this hook's ENTIRE
+    # analysis (both the compound-stage-and-commit check and the secret
+    # scan) for that segment, not just a cosmetic miss (F051, adversarial
+    # review of PR #77). See enforce-scope.sh.template's own copy of this
+    # function for the full formula verification, version-split notes
+    # (bash 3.2.57 vs 5.3.15's differing \c? behavior), and the surrogate/
+    # multi-char-uppercase crash history (F038 rounds 1-3) -- reproduced
+    # here unchanged since the decode logic itself is bash-version
+    # behavior, not specific to either hook.
+    hexdigits, octdigits, ctrlchar, u4, u8, other = (
+        m.group(1), m.group(2), m.group(3), m.group(4), m.group(5), m.group(6)
+    )
+    if hexdigits is not None:
+        return chr(int(hexdigits, 16))
+    if octdigits is not None:
+        return chr(int(octdigits, 8) & 0xFF)
+    if ctrlchar is not None:
+        upper = ctrlchar.upper()
+        if upper == "?":
+            return "\x7f"
+        if len(upper) != 1:
+            upper = ctrlchar
+        return chr(ord(upper) & 0x1F)
+    if u4 is not None:
+        return _unicode_escape_or_literal(u4, "u")
+    if u8 is not None:
+        return _unicode_escape_or_literal(u8, "U")
+    return ANSI_C_SIMPLE_ESCAPES.get(other, "\\" + other)
+
+
+def _unicode_escape_or_literal(hexdigits, prefix):
+    # Ported alongside _decode_ansi_c_escape() (F051); see
+    # enforce-scope.sh.template's own copy for the full incident this
+    # closes (a lone surrogate crashing this hook's own denial-printing
+    # step into a silent no-op).
+    codepoint = int(hexdigits, 16)
+    if 0xD800 <= codepoint <= 0xDFFF or codepoint > 0x10FFFF:
+        return "\\" + prefix + hexdigits
+    return chr(codepoint)
+
+
+def unquote_token(token):
+    # Strips quote characters from a single ALREADY-TOKENIZED word -- never
+    # used to re-segment or re-tokenize, only to normalize a token (which may
+    # be fully quoted, "commit"/'commit'/$'commit', or partially quoted,
+    # com"mit") before comparing it to "git", a subcommand name, or a flag
+    # string. Safe here specifically because split_tokens() has already
+    # resolved token boundaries using mask_quotes(); this function never
+    # looks at whitespace or separators (F025, PR #44).
+    #
+    # A $'...' span's inner text is now decoded per bash's ANSI-C quoting
+    # grammar in this SAME substitution, and a bare backslash outside
+    # quotes is now stripped too (both ported from enforce-scope.sh.
+    # template's own unquote_token(), F033/F038 and F031 respectively) --
+    # this function previously only stripped the $'...' WRAPPER without
+    # decoding what was inside it, and never touched an interior backslash
+    # at all, so `g\it`/`\g\i\t`/`$'\x67it'` all reached is_git_token()
+    # still spelling something other than the bare string "git", silently
+    # disabling this hook's entire analysis for that segment (F051, found
+    # by adversarial review of PR #77). Confirmed live before this fix:
+    # `g\it commit -a -m "test"` and `$'\x67it' commit -a -m "test"` both
+    # silently ALLOWed a real compound-stage-and-commit violation, and
+    # with a real secret staged, `g\it commit -m "add config"` silently
+    # ALLOWed it through where the bare `git commit -m "add config"`
+    # correctly denied secret-assignment.
+    token = re.sub(
+        r"\$'((?:[^'\\]|\\.)*)'",
+        lambda m: ANSI_C_ESCAPE_PATTERN.sub(_decode_ansi_c_escape, m.group(1)),
+        token,
+    )
+    token = token.replace("'", "").replace('"', "")
+    return re.sub(r"\\(.)", r"\1", token)
+
+
+def _flag_view(tok):
+    # A SEPARATE view from unquote_token(), used ONLY for decisions that
+    # STOP the flag scan or SKIP a token as an opaque value (the "--"
+    # pathspec-separator check, and every "this flag takes a bare value,
+    # skip the next token" decision) -- never for the flag-string MATCH
+    # itself, where over-recognizing due to unquote_token()'s own blanket
+    # backslash-strip is safe-directional (a false DENY, never a false
+    # ALLOW). Unlike unquote_token(), this does NOT strip a bare backslash
+    # outside quotes: real bash treats a backslash INSIDE single or double
+    # quotes as a literal character, not an escape, but unquote_token()'s
+    # final backslash-strip line (ported from enforce-scope.sh's own
+    # accepted residual there, F031/F051) is quote-context-BLIND -- it
+    # strips a backslash the same way whether it came from inside a quote
+    # (where it should stay literal) or from an entirely unquoted token
+    # (where real bash DOES strip it). That residual is genuinely harmless
+    # in enforce-scope.sh (it only ever changes a PATH VALUE compared
+    # against a scope prefix), but dangerous here: `git commit -m x '\--'
+    # -i tracked.txt` passes git the LITERAL 3-character pathspec "\--"
+    # (single quotes preserve everything, confirmed against real git:
+    # errors "pathspec '\--' did not match" unless a file literally named
+    # "--" happens to exist and be tracked, in which case the command
+    # genuinely stages AND commits tracked.txt via -i in one step) -- NOT
+    # the 2-character string "--", so it must not be treated as the real
+    # pathspec separator. unquote_token()'s own blanket backslash-strip
+    # reduced it to plain "--" anyway, which the (pre-this-fix) separator
+    # check then wrongly treated as ending the flag scan before it ever
+    # reached the real -i -- a genuine fail-open this PR's own escape-
+    # decoding fix introduced as a side effect (F051 round 2, adversarial
+    # review of PR #79). has_staging_flag()'s long-flag/short-flag-cluster
+    # bare-value skips use this view for the same reason (see
+    # _consumes_next_token()). segment_subcommand()'s own GIT_FLAGS_WITH_VALUE
+    # 2-token skip and generic "-"-prefix 1-token skip were NOT converted:
+    # they only ever run on tokens BEFORE the subcommand, and confirmed
+    # against real git, any token whose raw form has this same
+    # backslash-preserved-by-quotes shape (`git '\-C' commit ...`, `git
+    # '\--' commit ...`) makes real git reject the whole invocation
+    # ("'\-C' is not a git command") before anything is staged or committed
+    # -- unlike the post-subcommand case above, where git tolerates the
+    # divergent token as an ordinary pathspec and keeps parsing later
+    # flags. Not independently reachable, so left on the raw token.
+    # Not stripping the backslash here means a rare unquoted-and-escaped
+    # separator (`\--`, no quotes at all -- where real bash DOES strip the
+    # backslash, giving a genuine "--") is no longer recognized as one
+    # either, over-denying instead of under-denying: an accepted,
+    # documented trade in the safe direction, not a new bypass (confirmed:
+    # such a token doesn't even start with "-" once viewed this way, so it
+    # falls through as an ordinary non-flag token, extending the scan
+    # rather than truncating it).
+    tok = re.sub(
+        r"\$'((?:[^'\\]|\\.)*)'",
+        lambda m: ANSI_C_ESCAPE_PATTERN.sub(_decode_ansi_c_escape, m.group(1)),
+        tok,
+    )
+    return tok.replace("'", "").replace('"', "")
+
+
+def split_tokens(segment):
+    # Splits a command segment into whitespace-delimited tokens, but whitespace
+    # INSIDE a quoted span is not a token boundary (exactly like the shell):
+    # \S+ runs are found in a quote-MASKED copy (so masked-out quoted
+    # whitespace can't match \S, keeping a quoted multi-word string as one
+    # run) but sliced from the ORIGINAL segment, mirroring command_segments()'s
+    # own mask-then-slice discipline one level deeper. A naive segment.split()
+    # instead treated whitespace inside a quoted commit message as real token
+    # boundaries, shattering it into pseudo-tokens that has_staging_flag then
+    # misread: a quoted "--" anywhere in the message (`git commit -m "see --"
+    # -a`) could shadow a REAL staging flag later in the segment (fail-open:
+    # the "--" pseudo-token was misread as the pathspec separator, and the
+    # scan stopped before reaching the real -a), and flag-shaped words inside
+    # a quoted message ("fix: handle -a and -i staging flags") could trigger a
+    # false compound-stage-and-commit denial on a clean repo. This was masked
+    # by accident under the OLD strip_quotes()-based design (which deleted the
+    # message text these pseudo-tokens came from) and only became visible once
+    # F025 started preserving quoted content -- found by adversarial review of
+    # PR #44.
+    masked = mask_quotes(segment)
+    return [segment[m.start():m.end()] for m in re.finditer(r"\S+", masked)]
+
+
+def command_segments(command):
+    # Splits on shell control operators, including a literal newline -- a
+    # multi-line command (a heredoc'd commit message, or two commands
+    # separated by a newline rather than ;/&&) must not let a "git" token on
+    # one line pair with an unrelated token on another line. "&" (background
+    # execution, and the leading half of "|&") is itself a control operator
+    # exactly like ";" -- an earlier version omitted it, so everything before
+    # an "&" stayed glued to everything after it and only the first
+    # segment's subcommand was ever seen (found by adversarial review of PR
+    # #40, round 6). "&&" is listed as its own alternative before the
+    # single-character class, so it is still consumed whole and never
+    # mistaken for two lone "&" separators. Split positions are found in a
+    # quote-MASKED copy (see mask_quotes) but sliced from the ORIGINAL
+    # command text, so a segment's real "git"/"commit" tokens survive intact
+    # for tokenization even when quoted (see mask_quotes for why deleting
+    # them instead was a critical bug, F025). A "&" is NOT a segment
+    # separator when it immediately follows a ">": real bash lexes ">&" as
+    # one fd-duplication operator (`2>&1`, `>&2`), not a redirect
+    # immediately followed by a background/AND "&" -- splitting there was a
+    # REAL GATE BYPASS, not just a usability false-positive (unlike the
+    # identical bug in the sibling hook enforce-scope.sh.template, F030):
+    # `git commit 2>&1 -am "x"` split into segments ['git commit 2>',
+    # '1 -am "x"'], so has_staging_flag() never saw the real -am flag in
+    # the second segment (its first token is "1", not "git"/"commit", so
+    # segment_subcommand() never even recognized it as a git-commit
+    # segment) -- confirmed against real bash that this genuinely stages
+    # and commits in one step (found by adversarial review of PR #53,
+    # F030, filed as F034). The mirror shape needs the SAME treatment: a
+    # "&" is ALSO not a separator when immediately FOLLOWED by a ">" --
+    # `&>`/`&>>` is bash's combined stdout+stderr redirect, one operator,
+    # not background-"&" followed by a redirect. An initial version of
+    # this fix only guarded the "&" PRECEDED by ">" (matching enforce-
+    # scope.sh's own needs, where this shape is harmless -- that hook
+    # extracts write targets independently of segment/command-recognition
+    # boundaries, so a `&>`-caused split still leaves the redirect target
+    # itself checkable in the fragment it lands in). Here it is NOT
+    # harmless: `git commit &> out.log -a -m "bypass"` split into
+    # segments ['git commit', '> out.log -a -m "bypass"'], putting the
+    # real staging flags in a segment whose first token is ">", not
+    # "git"/"commit" -- segment_subcommand() never recognized it, so
+    # has_staging_flag() never ran, an identical bypass to the `2>&1`
+    # case this feature was filed to close (found by adversarial review
+    # of PR #58, F034). `&&` is unaffected (consumed whole by its own
+    # earlier alternative); real background "&" (not adjacent to any ">"
+    # on either side) still splits.
+    masked = mask_quotes(command)
+    segments = []
+    start = 0
+    for m in re.finditer(r"\|\||&&|[|;\n]|(?<!>)&(?!>)", masked):
+        segments.append(command[start:m.start()])
+        start = m.end()
+    segments.append(command[start:])
+    return [s.strip() for s in segments if s.strip()]
+
+
+def is_git_token(tok):
+    # Matches "git" invoked via a path (/usr/bin/git, ./git), wrapped in a
+    # subshell paren ("(git add ..."), or backslash-prefixed ("\git ...", the
+    # standard idiom for bypassing a shell alias named git, not adversarial
+    # evasion) -- not just the bare literal "git". Found by adversarial
+    # review of PR #40 (bare-literal matching let /usr/bin/git and (git ...
+    # no-op the gate entirely); \git found in round 5 of the same review.
+    return os.path.basename(tok.lstrip("(\\")) == "git"
+
+
+SHELL_LEADING_KEYWORDS = {"then", "do", "else", "elif"}
+
+
+def segment_subcommand(tokens):
+    # Returns (subcommand_token, index_in_tokens) for a "git <subcommand> ..."
+    # segment, e.g. ("commit", 3) for ["git", "-C", ".", "commit", "-m", "x"].
+    # Skips "VAR=value" env-assignment prefixes, the closed set of shell
+    # reserved words that can lead a simple command inside a control
+    # structure (SHELL_LEADING_KEYWORDS -- "if true; then git commit -m x; fi"
+    # splits into a segment starting "then git commit ...", and without this
+    # skip "then" is mistaken for the whole segment being non-git-shaped;
+    # found by adversarial review of PR #40, round 6), and git global flags --
+    # both the ones that take no argument and the ones that do (see
+    # GIT_FLAGS_WITH_VALUE). Returns (None, None) if this segment isn't a
+    # real "git <subcommand>" invocation at all. A "case ... in PATTERN)"
+    # segment is NOT handled here: unlike the four reserved words above, the
+    # token immediately before the command is an arbitrary case pattern, not
+    # a fixed word to skip -- accepted as a residual hole (see header).
+    i = 0
+    while i < len(tokens) and (
+        re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", tokens[i])
+        or tokens[i] in SHELL_LEADING_KEYWORDS
+    ):
+        i += 1
+    if i >= len(tokens) or not is_git_token(tokens[i]):
+        return None, None
+    i += 1
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok in GIT_FLAGS_WITH_VALUE:
+            i += 2
+            continue
+        if tok.startswith("-"):
+            i += 1
+            continue
+        return tok, i
+    return None, None
+
+
+def join_continuations(command):
+    # Joins a backslash-newline shell continuation to a space, but only when
+    # the backslash immediately before the newline is itself unescaped: an
+    # ODD run of backslashes right before a newline means the last one
+    # escapes the newline (a real continuation); an EVEN run (including
+    # zero) means the newline is a real command separator and the
+    # backslashes are literal characters, which must be left alone. The
+    # first version of this fix used a blanket command.replace("\\n", " ")
+    # with no parity check, which wrongly joined "echo a\\\\" + newline +
+    # "git commit" (an ESCAPED backslash followed by a genuine separator
+    # newline) into one segment, hiding the second command from the gate
+    # entirely -- found by adversarial review of PR #40, round 6.
+    def repl(m):
+        backslashes = m.group(1)
+        if len(backslashes) % 2 == 1:
+            return backslashes[:-1] + " "
+        return backslashes + "\n"
+
+    return re.sub(r"(\\*)\n", repl, command)
+
+
+def parse_command(command):
+    # Segments the raw command once, then finds each segment's git subcommand
+    # (if any) -- a single source of truth shared by the no-op decision and
+    # the compound-stage-and-commit check below. Backslash-newline
+    # continuations are joined to a space before anything else, so a
+    # continued command isn't split into fragments that individually fail to
+    # tokenize as git-shaped (see header). Tokens are split from the still-
+    # quoted segment text with split_tokens() (quote-aware, so whitespace
+    # inside a quoted string isn't a token boundary) and THEN unquoted one at
+    # a time -- never the other way around -- so a quoted token like "commit"
+    # or com"mit" is still recognized as the word "commit" once tokenized,
+    # instead of being erased before tokenization ever saw it (F025).
+    joined = join_continuations(command)
+    parsed = []
+    for seg in command_segments(joined):
+        raw_tokens = split_tokens(seg)
+        tokens = [unquote_token(t) for t in raw_tokens]
+        # views[i] is _flag_view(raw_tokens[i]) -- computed from the RAW,
+        # still-quoted token, never from tokens[i] (which has ALREADY had
+        # its quotes AND backslashes stripped by this point, so calling
+        # _flag_view() on tokens[i] instead of raw_tokens[i] would be a
+        # no-op: the very distinction it exists to preserve is already
+        # gone). has_staging_flag() uses this parallel list -- not tokens
+        # -- for its one dangerous "does this consume the next token"
+        # decision (F051 round 2, adversarial review of PR #79).
+        views = [_flag_view(t) for t in raw_tokens]
+        sc, idx = segment_subcommand(tokens)
+        parsed.append((tokens, sc, idx, views))
+    return parsed
+
+
+# Short flags that take an attached value in a cluster like "-mfix" or
+# "-Fdraft.txt" -- once one of these appears, the rest of that cluster is its
+# value, not further flag letters. Without this, "-mfix" was denied for
+# containing the letter "i", and "-- -a.txt" (a pathspec after "--", not a
+# flag at all) was denied too (found by adversarial review of PR #40).
+VALUE_TAKING_SHORT_FLAGS = set("mFtSCcu")
+
+# Subset of VALUE_TAKING_SHORT_FLAGS whose BARE form (last char of a cluster,
+# nothing attached) also consumes the NEXT token as its value. -S/-u are
+# real git optargs (PARSE_OPT_OPTARG): bare "-S"/"-u" use a built-in default
+# and do NOT take the next token -- `git commit -u -a -m x` and `git commit
+# -S -a -m x` both genuinely stage and commit in real git (confirmed against
+# git 2.52.0: bare -S/-u behave exactly like no-value flags such as -n/-s).
+# Treating all seven letters as bare-value-taking (an earlier version of this
+# fix did) made a bare/clustered "-u"/"-S" swallow the token after it as if
+# it were a value, hiding a REAL trailing staging flag beyond it -- a gate
+# bypass `main` never had (found by adversarial review of PR #49, round 2).
+# -S/-u still belong in VALUE_TAKING_SHORT_FLAGS above: their ATTACHED form
+# (`-uall`, `-Skeyid`) is a real value and must not be misread as more flag
+# letters (confirmed: `-ua` -> "Invalid untracked files mode 'a'", so "a" is
+# -u's value, not the staging flag; `-Sa` -> "a" is the keyid, nothing
+# staged) -- only the BARE/next-token form was wrong.
+REQUIRED_VALUE_SHORT_FLAGS = set("mFtCc")
+
+
+# Returns (is_staging_flag, took_bare_value) for a single "-xyz"-shaped
+# cluster token: is_staging_flag is True if -a/-i appears anywhere in the
+# cluster; took_bare_value is True only if a REQUIRED-value short flag
+# (REQUIRED_VALUE_SHORT_FLAGS, not merely VALUE_TAKING_SHORT_FLAGS) is the
+# LAST character in the cluster (so its value is the NEXT token, not part of
+# this one) -- e.g. "-m" or "-sm", but not "-mfix" or "-ma" (same reasoning
+# as "-mfix": "m" isn't the LAST char in the cluster, so everything after it
+# -- "fix", or "a" -- is its attached value, not a further flag letter; real
+# git confirms "-ma" reads as message "a" with nothing staged, so that "a"
+# is never a staging flag here), or "-S"/"-u" bare (optarg, no next-token
+# value at all). A first pass checked only `len(tok) == 2` (bare
+# "-m" alone), missing every multi-letter cluster ending on a value-taking
+# flag like "-sm" or "-nm" -- found by adversarial review of PR #49 (F027),
+# confirmed against real git: `git commit -sm -- -a` both signs off AND
+# stages via a real trailing -a that the narrower check never reached. The
+# position-aware fix for THAT gap then wrongly applied to -S/-u too, see
+# REQUIRED_VALUE_SHORT_FLAGS's own comment above.
+def _scan_short_flag_cluster(tok):
+    body = tok[1:]
+    for idx, c in enumerate(body):
+        if c in ("a", "i"):
+            return True, False
+        if c in VALUE_TAKING_SHORT_FLAGS:
+            return False, c in REQUIRED_VALUE_SHORT_FLAGS and idx == len(body) - 1
+    return False, False
+
+
+def _consumes_next_token(view):
+    # True if VIEW (always _flag_view()'s output, never the raw/fully-
+    # unquoted token) represents a flag that consumes the NEXT token as an
+    # opaque, bare value -- either a long flag (exact or an unambiguous
+    # abbreviation) resolving to VALUE_TAKING_LONG_FLAGS, or a short-flag
+    # cluster ending in a required-value flag. Isolated into its own
+    # function so has_staging_flag() can call it with EXACTLY the
+    # conservative view, never the fully backslash-stripped token, for
+    # this one specific decision (F051 round 2; see _flag_view()'s own
+    # comment for why this decision specifically is the dangerous
+    # direction and the flag-MATCH checks elsewhere in this file are not).
+    if view.startswith("--") and len(view) > 2 and "=" not in view:
+        return _resolve_long_flag(view) in VALUE_TAKING_LONG_FLAGS
+    if view.startswith("-") and not view.startswith("--") and len(view) > 1:
+        _, took_bare_value = _scan_short_flag_cluster(view)
+        return took_bare_value
+    return False
+
+
+def has_staging_flag(tokens, views):
+    i = 0
+    n = len(tokens)
+    while i < n:
+        tok = tokens[i]
+        view = views[i]
+        if view == "--":
+            break  # everything after this is a pathspec, never a flag
+        if tok in STAGING_FLAGS:
+            return True
+        if tok.startswith("--") and len(tok) > 2 and "=" not in tok:
+            # Resolves an EXACT long flag too (in which case this is just a
+            # slower path to the same answer the old exact-match check
+            # gave), but also a real, unambiguous ABBREVIATION of one --
+            # `git commit --mess -- -a` staging+committing in real git,
+            # exactly like the fully-spelled form, is why this branch
+            # exists at all (found by adversarial review of PR #56). Same
+            # abbreviation resolution also catches a real staging flag
+            # abbreviated (`--inc` -> --include), a related gap the fixed
+            # exact-match STAGING_FLAGS check above never covered either.
+            # This match is against the fully-unquoted `tok`, not `view`,
+            # deliberately: over-recognizing an abbreviation due to
+            # unquote_token()'s own blanket backslash-strip only makes
+            # this branch DENY more eagerly, never less -- safe-
+            # directional, unlike the "consumes next token" decision below
+            # (see _consumes_next_token()'s own comment).
+            resolved = _resolve_long_flag(tok)
+            if resolved in STAGING_FLAGS:
+                return True
+        elif tok.startswith("-") and not tok.startswith("--") and len(tok) > 1:
+            is_staging, _ = _scan_short_flag_cluster(tok)
+            if is_staging:
+                return True
+        # A bare value-taking flag (e.g. "-m", or a cluster ending on one
+        # like "-sm", or an abbreviated long flag like "--mess") takes its
+        # value from the NEXT token, whatever that token's own content
+        # looks like -- it is opaque data, never itself a flag or the "--"
+        # pathspec separator (F027). This decision is made against `view`
+        # exclusively, never `tok`: wrongly believing a token consumes the
+        # next one, when real bash/git would not (e.g. a single-quoted
+        # literal pathspec that unquote_token()'s own backslash-strip
+        # happens to reduce to a real flag's spelling), skips past
+        # whatever REAL flag follows it -- the fail-open F051 round 2
+        # exists to close.
+        if _consumes_next_token(view):
+            i += 1
+        i += 1
+    return False
+
+
+def check_compound_stage_and_commit(parsed):
+    subcommands = [sc for _, sc, _, _ in parsed]
+    has_stage = any(sc in ("add", "stage") for sc in subcommands)
+    commit_present = any(sc == "commit" for sc in subcommands)
+    if has_stage and commit_present:
+        return DENY_COMPOUND
+    for tokens, sc, idx, views in parsed:
+        if sc == "commit" and has_staging_flag(tokens[idx + 1:], views[idx + 1:]):
+            return DENY_COMPOUND
+    return None
+
+
+def staged_diff(project_root):
+    timeout = float(os.environ.get("COMMIT_GATE_DIFF_TIMEOUT", "5"))
+    result = subprocess.run(
+        ["git", "diff", "--cached", "-U0"],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def added_lines(diff_text):
+    # -U0 means every hunk carries only '+'/'-' lines, no unchanged context
+    # lines, so the running counter is never thrown off by context. `in_hunk`
+    # distinguishes a REAL "+++ " diff header (only ever seen before a file's
+    # first "@@" hunk marker) from STAGED CONTENT that happens to read like one
+    # (e.g. a line from a staged .patch/.diff file) -- treating the latter as a
+    # header would both misattribute file/line in a denial message (leaking
+    # staged content into it) and, if the fake path matched *.env.example,
+    # forge the exemption and skip scanning the rest of the diff. git
+    # terminates a "+++"/"---" header with a trailing tab when the path
+    # contains a space; strip it.
+    current_file = None
+    current_line = None
+    in_hunk = False
+    for line in diff_text.splitlines():
+        if line.startswith("diff --git "):
+            current_file, current_line, in_hunk = None, None, False
+            continue
+        if not in_hunk and line.startswith("+++ "):
+            path = line[4:].split("\t", 1)[0]
+            current_file = path[2:] if path.startswith("b/") else path
+            continue
+        if line.startswith("@@"):
+            in_hunk = True
+            m = re.search(r"\+(\d+)", line)
+            current_line = int(m.group(1)) if m else None
+            continue
+        if in_hunk and line.startswith("+") and current_file and current_line:
+            yield current_file, current_line, line[1:]
+            current_line += 1
+
+
+def is_exempt(path):
+    return fnmatch.fnmatch(path.rsplit("/", 1)[-1], "*.env.example")
+
+
+def find_secret(lines, deadline):
+    for path, lineno, content in lines:
+        if time.monotonic() > deadline:
+            return None
+        if is_exempt(path):
+            continue
+        scanned = content[:SECRET_SCAN_MAX_LEN]
+        if SECRET_PATTERN.search(scanned):
+            return (
+                f"secret-assignment: a staged addition at {path}:{lineno} looks "
+                f"like a secret value (key/token/password assignment, length >= "
+                f"16). Repair: {REPAIR_STAGED}."
+            )
+        if URL_CREDENTIAL_PATTERN.search(scanned):
+            return (
+                f"url-credential: a staged addition at {path}:{lineno} contains a "
+                f"URL with embedded credentials. Repair: {REPAIR_STAGED}."
+            )
+    return None
+
+
+def find_style_violation(lines, deadline):
+    for path, lineno, content in lines:
+        if time.monotonic() > deadline:
+            return None
+        if EM_DASH_PATTERN.search(content):
+            return (
+                f"style-violation: a staged addition at {path}:{lineno} violates "
+                f"house style (em dash). Repair: {REPAIR_STYLE}."
+            )
+    return None
+
+
+def style_gate_enabled(project_root):
+    path = os.path.join(project_root, ".harness", "harness.json")
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return False
+    style_gate = data.get("style_gate")
+    if not isinstance(style_gate, dict):
+        return False
+    return bool(style_gate.get("enabled", False))
+
+
+def main():
+    command = sys.argv[1]
+    project_root = sys.argv[2]
+
+    parsed = parse_command(command)
+    if not any(sc == "commit" for _, sc, _, _ in parsed):
+        return
+
+    reason = check_compound_stage_and_commit(parsed)
+    if reason:
+        print(reason)
+        return
+
+    try:
+        diff_text = staged_diff(project_root)
+        if diff_text is None:
+            return
+        lines = list(added_lines(diff_text))
+        deadline = time.monotonic() + SCAN_TIME_BUDGET_SECONDS
+        reason = find_secret(lines, deadline)
+        if reason:
+            print(reason)
+            return
+        if style_gate_enabled(project_root):
+            reason = find_style_violation(lines, deadline)
+            if reason:
+                print(reason)
+    except subprocess.TimeoutExpired:
+        return
+    except Exception as exc:
+        print(type(exc).__name__, file=sys.stderr)
+
+
+main()
+PYEOF
+)
+
+if [ -n "$DENY_REASON" ]; then
+    deny_json "$DENY_REASON"
+fi
+
+exit 0

--- a/.claude/hooks/enforce-scope.sh
+++ b/.claude/hooks/enforce-scope.sh
@@ -1,11 +1,77 @@
 #!/bin/bash
 # VV Claude Code Harness - PreToolUse scope enforcement hook
-# Runs before Edit/Write tool calls when a teammate scope file exists.
-# Exit code 0 = allow edit
-# Exit code 2 = block edit (file outside scope)
+# Runs before Edit/Write/MultiEdit tool calls (scope enforcement) and before Bash tool
+# calls (best-effort write-boundary coverage) when a teammate scope file exists.
+# The pre-existing out-of-scope Edit/Write check below is a legacy path: it blocks by
+# exiting 2, unchanged since before state ownership + Bash coverage were added. The two
+# denial paths added for that feature -- lead-owned state files, and Bash write
+# commands -- use the hookSpecificOutput.permissionDecision:"deny" JSON form (exit 0)
+# instead, per cross-harness reconciliation (OVI-51).
+# Failure posture: fail-open for ENVIRONMENT failures, fail-closed for per-segment
+# ANALYSIS failures (F042). If PROJECT_ROOT can't be resolved, the scope file is
+# unreadable, or the tool-input JSON can't be parsed, the action is ALLOWED, not
+# blocked. Residual: a broken environment silently disables enforcement rather than
+# blocking everything. Bash coverage is pattern-based and evadable by construction
+# (compound commands, command substitution/subshells, and a write hidden inside a
+# heredoc body fed to a nested interpreter are known false-negative surfaces) --
+# the goal is stopping accidental drift, not defeating an adversarial teammate.
+# Once a segment's own analysis begins, though, an exception anywhere in it (a
+# decoder crash, or anything else _check_segment() can't handle) denies that
+# segment unconditionally instead -- see main()'s own comment for why. The same
+# split applies one layer up, at the FILE_PATH/COMMAND extraction near the top of
+# this file (F043): the JSON itself failing to parse stays fail-open, but anything
+# that goes wrong AFTER a successful parse (a raw surrogate crashing the final
+# print(), or any other unexpected shape) fails closed instead.
+# Straightforward single/double/ANSI-C quoting of a separator or a write target is
+# handled (see mask_quotes()/unquote_token()); nested or otherwise unusual quoting
+# is not attempted. Known false-positive residual: redirect-target extraction
+# matches every >/>> on the line, so a bare comparison like [[ "$v" > "1.0" ]]
+# (no real redirect) can still be mistaken for one even with quotes correctly
+# preserved and stripped from the captured group -- the regex has no way to tell
+# a real redirect from a test-bracket comparison operator; distinguishing them
+# would need real shell parsing, judged disproportionate for this hook. Since
+# write_targets() now checks every target it finds (F024) and denies on the
+# FIRST out-of-scope one, a bogus match like this can deny a command before a
+# real, later, genuinely in-scope redirect is ever reached -- broader than
+# when only the last match was checked, but still the same underlying
+# trade-off, not a new one.
+# write_targets()/redirect_targets() return EVERY write target in a segment,
+# not just one: a command with multiple real write targets (`rm a b`, `tee`
+# or `sed -i` given two files, multiple redirects like `> f1 2> f2`, or a
+# real write command followed by an unrelated trailing redirect like
+# `tee f1 > f2`) is checked against ALL of them, not just whichever one an
+# earlier version happened to find first -- an out-of-scope target elsewhere
+# in the segment went uncaught otherwise (found by adversarial review of PR
+# #42/F023 and PR #46, reported as F024). `cp -t DIR`/`-tDIR`/`mv -t DIR` and
+# `--target-directory=DIR` (GNU-only; not present on BSD/macOS cp) put the
+# real destination in a flag argument instead of the last positional one;
+# cp_mv_targets() recognizes all three forms, treating every other flagless
+# argument as a source (read, not written) once any is present -- clustered
+# short flags (`-rt DIR`, combining -r and -t) are not recognized, a
+# documented residual. `--` as a pathspec separator (e.g. `rm -- -a.txt`,
+# where -a.txt is a real filename, not a flag) is recognized by
+# all_flagless_tokens()/last_flagless_token() the same way commit-gate.sh
+# .template's has_staging_flag() handles the same shape (F029): the first
+# "--" ends flag parsing, so every later token is kept as a real pathspec
+# even if it starts with "-". cp_mv_targets()'s own -t/--target-directory=
+# scan and sed_inplace_targets()'s flag-detection (including its two
+# any()-based guards, not just its token-walking loop) are "--"-aware the
+# same way (F029 rounds 2-3).
+# normalize()/FILE_PATH resolve "."/".." path traversal (F026). A backslash-
+# escaped traversal segment (`\..`) is also resolved (F031): unquote_token()
+# strips shell backslash-escapes, not just quote characters, before
+# normalize() ever sees the token. One related gap remains, documented in
+# full where the code lives (normalize()'s own comment): the resolution is
+# purely lexical, so a symlink inside a scope directory can make the real
+# write land somewhere normpath can't see.
+# verified live 2026-07-24 on Claude Code 2.1.218
 
 # Read hook input from stdin
 INPUT=$(cat)
+
+# Anchor to the project root so the hook works from any working directory
+PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+cd "$PROJECT_ROOT" 2>/dev/null || exit 0
 
 # Only enforce if a scope file exists (teammates only, not lead agents)
 SCOPE_FILE=".claude/teammate-scope.txt"
@@ -13,37 +79,1493 @@ if [ ! -f "$SCOPE_FILE" ]; then
     exit 0
 fi
 
-# Extract file path from tool input
-FILE_PATH=$(echo "$INPUT" | python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-print(data.get('tool_input', {}).get('file_path', ''))
-" 2>/dev/null)
+ANNOTATION="(verified live 2026-07-24 on Claude Code 2.1.218)"
 
-if [ -z "$FILE_PATH" ]; then
+deny_json() {
+    python3 - "$1" <<'PYEOF'
+import json
+import sys
+
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": sys.argv[1],
+    }
+}))
+PYEOF
     exit 0
+}
+
+# Extract file path (Edit/Write/MultiEdit) and command (Bash) from tool input.
+# FILE_PATH is normalized here (project-root prefix stripped, then "."/".."
+# segments resolved) rather than with plain bash substring stripping, so a
+# traversal that escapes scope (`src/parser/../other/y.py`) or reaches a
+# lead-owned file (`src/parser/../../.harness/features.json`) can't survive
+# as a string that merely STARTS WITH the allowed prefix or fails the
+# lead-owned exact-match -- this is the SAME bug normalize() (used by the
+# Bash-command path below) had, in the MORE authoritative gate (Edit/Write/
+# MultiEdit tool calls are blocked outright; Bash coverage is only best-
+# effort). Unlike normalize(), no trailing-"/" restore is needed here: an
+# Edit/Write/MultiEdit file_path is always a file, never a directory, so
+# there's no directory-style scope-pattern case to preserve -- confirmed
+# dead code by mutation-testing (removing it changed zero assertions),
+# consistent with this project's "no error handling for impossible states"
+# standard (found by adversarial review of PR #48, F026 round 2). Literal
+# `path.startswith(...)` (not a bash glob pattern) also means a project
+# root containing shell metacharacters (e.g. "root[1]") can't break this
+# the way the OLD bash-side `${FILE_PATH#$PROJECT_ROOT/}` could (unquoted
+# $PROJECT_ROOT in pattern position; a documented, unadvertised side
+# benefit found in the same round).
+FILE_PATH=$(echo "$INPUT" | python3 -c "
+import json, os, sys
+# The JSON parse itself is in its OWN try/except, exiting 2 on failure:
+# a genuinely unparseable tool-input document is this file's own
+# documented fail-open contract (see the header), and rc 2 tells the
+# caller to leave that behavior alone. Everything AFTER a successful
+# parse -- extracting the field, normalizing it, and printing it -- is a
+# SEPARATE try/except that exits 1 instead (F043): a raw lone UTF-16
+# surrogate (0xD800-0xDFFF) arriving directly in the input JSON (e.g.
+# {\"tool_input\":{\"file_path\":\"src/other/\ud800pwned.txt\"}}) is
+# perfectly valid JSON -- json.load() decodes its \uD800 escape into a
+# real Python str containing a lone surrogate with no error at all -- but
+# crashes the FINAL print(path) with UnicodeEncodeError once stdout isn't
+# a tty (confirmed live: identical code succeeds interactively, raises
+# under \$(...) capture). The 2>/dev/null on this whole command
+# substitution swallowed that traceback, FILE_PATH came back empty, and
+# the caller's own \"if [ -n \\\"\$FILE_PATH\\\" ]\" then skipped the
+# ENTIRE Edit/Write scope check -- silently allowing what should have
+# gone through this file's own AUTHORITATIVE gate (Edit/Write/MultiEdit
+# calls are blocked outright, not best-effort like the Bash coverage path
+# F038 already patches for its own \$'...' decoder). Two distinct exit
+# codes (not 'any nonzero') are required here: an uncaught exception's
+# default exit code is 1 regardless of which try/except raised it, so a
+# single except-and-exit(1) around BOTH stages would make a genuinely
+# unparseable document fail closed too, silently reversing this file's
+# own documented environment-failure contract -- rc 2 vs rc 1 is what
+# lets the caller (below) tell 'can't parse at all, stay fail-open' apart
+# from 'parsed fine, but unsafe to process further, fail closed'.
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(2)
+try:
+    path = data.get('tool_input', {}).get('file_path', '')
+    project_root = sys.argv[1]
+    if path:
+        if path.startswith(project_root + '/'):
+            path = path[len(project_root) + 1:]
+        path = os.path.normpath(path)
+    print(path)
+except Exception:
+    sys.exit(1)
+" "$PROJECT_ROOT" 2>/dev/null)
+FILE_PATH_RC=$?
+if [ "$FILE_PATH_RC" -eq 1 ]; then
+    echo "Edit blocked: file_path could not be safely extracted from tool input (treating as outside your assigned scope). $ANNOTATION"
+    exit 2
 fi
 
-# Normalize absolute paths to relative (tool input uses absolute paths,
-# scope patterns use relative paths like "src/auth/")
-PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-if [[ "$FILE_PATH" == "$PROJECT_ROOT/"* ]]; then
-    FILE_PATH="${FILE_PATH#$PROJECT_ROOT/}"
+COMMAND=$(echo "$INPUT" | python3 -c "
+import json, sys
+# Same two-stage split as FILE_PATH above, and for the same reason: a
+# crash AFTER a successful JSON parse -- the identical raw-surrogate
+# print() crash, reachable here via tool_input.command instead of
+# file_path -- fails closed (rc 1), while a genuinely unparseable
+# document stays fail-open (rc 2) (F043).
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(2)
+try:
+    print(data.get('tool_input', {}).get('command', ''))
+except Exception:
+    sys.exit(1)
+" 2>/dev/null)
+COMMAND_RC=$?
+if [ "$COMMAND_RC" -eq 1 ]; then
+    deny_json "command could not be safely extracted from tool input (best-effort, pattern-based check; treating as outside your assigned scope). $ANNOTATION"
 fi
 
-# Check if file path matches any scope pattern
-while IFS= read -r pattern || [ -n "$pattern" ]; do
-    # Skip empty lines and comments
-    [[ -z "$pattern" || "$pattern" =~ ^# ]] && continue
-    # Use bash pattern matching
-    if [[ "$FILE_PATH" == $pattern* ]]; then
-        exit 0
+if [ -n "$FILE_PATH" ]; then
+    case "$FILE_PATH" in
+        .harness/features.json|.harness/context_summary.md|.harness/claude-progress.txt)
+            deny_json "state file is lead-owned; report via SendMessage instead. $ANNOTATION"
+            ;;
+    esac
+
+    # Legacy path (unchanged): check if file path matches any scope pattern
+    while IFS= read -r pattern || [ -n "$pattern" ]; do
+        # Skip empty lines and comments
+        [[ -z "$pattern" || "$pattern" =~ ^# ]] && continue
+        # Use bash pattern matching
+        if [[ "$FILE_PATH" == $pattern* ]]; then
+            exit 0
+        fi
+    done < "$SCOPE_FILE"
+
+    echo "Edit blocked: $FILE_PATH is outside your assigned scope."
+    echo "Your scope (from $SCOPE_FILE):"
+    cat "$SCOPE_FILE" | grep -v '^#' | grep -v '^$'
+    echo ""
+    echo "Repair: request a scope expansion from the lead: SendMessage({ type: \"message\", recipient: \"team-lead\", content: \"Requesting scope expansion to $FILE_PATH because [reason].\" })"
+    exit 2
+fi
+
+if [ -n "$COMMAND" ]; then
+    SCOPE_PATTERNS=()
+    while IFS= read -r pattern || [ -n "$pattern" ]; do
+        [[ -z "$pattern" || "$pattern" =~ ^# ]] && continue
+        SCOPE_PATTERNS+=("$pattern")
+    done < "$SCOPE_FILE"
+
+    DENY_REASON=$(python3 - "$COMMAND" "$PROJECT_ROOT" "${SCOPE_PATTERNS[@]}" <<'PYEOF'
+import os
+import re
+import sys
+
+LEAD_OWNED = {
+    ".harness/features.json",
+    ".harness/context_summary.md",
+    ".harness/claude-progress.txt",
+}
+ANNOTATION = "(verified live 2026-07-24 on Claude Code 2.1.218)"
+
+# A narrow, enumerated allowlist of ordinary character-device sinks (never
+# part of the project tree, so a write to one of these is never a real scope
+# violation) -- deliberately NOT the whole /dev/* namespace. An earlier
+# version of this exemption matched any path starting with "/dev/", which
+# also silently allowed /dev/shm/* (a real writable tmpfs on Linux, where
+# this template runs in CI) and bash's /dev/tcp/HOST/PORT network-redirect
+# extension (confirmed live: bash attempts a real TCP connect for this path,
+# not a "no such file" error -- a live egress channel, not a device node) --
+# found by adversarial review of PR #53, round 1. /dev/fd/N (bash's
+# process-substitution/fd-as-path idiom) is matched by pattern, not the
+# fixed set, since N is unbounded.
+DEV_EXEMPT_EXACT = {"/dev/null", "/dev/zero", "/dev/stdout", "/dev/stderr", "/dev/tty"}
+DEV_FD_PATTERN = re.compile(r"^/dev/fd/\d+$")
+
+
+def is_dev_exempt(norm):
+    return norm in DEV_EXEMPT_EXACT or DEV_FD_PATTERN.match(norm) is not None
+
+
+def strip_heredoc_bodies(command):
+    # Heredoc bodies are excluded from matching entirely (not split, not scanned)
+    # so payload text can never trigger a false denial.
+    lines = command.split("\n")
+    kept = []
+    in_heredoc = False
+    strip_tabs = False
+    marker = None
+    for line in lines:
+        if in_heredoc:
+            check = line.lstrip("\t") if strip_tabs else line
+            if check == marker:
+                in_heredoc = False
+            continue
+        kept.append(line)
+        m = re.search(r"<<(-?)\s*(['\"]?)(\w+)\2", line)
+        if m:
+            strip_tabs = bool(m.group(1))
+            marker = m.group(3)
+            in_heredoc = True
+    return "\n".join(kept)
+
+
+def join_continuations(command):
+    # Joins a backslash-newline shell continuation to a space, but only when
+    # the backslash immediately before the newline is itself unescaped: an
+    # ODD run of backslashes right before a newline means the last one
+    # escapes the newline (a real continuation); an EVEN run (including
+    # zero) means the newline is a real command separator and the
+    # backslashes are literal characters, which must be left alone. Ported
+    # from commit-gate.sh.template (F011/OVI-64, round 6), which needed this
+    # as soon as it started splitting on a literal newline -- without it, a
+    # continued command like `sed \` + newline + `-i 's/a/b/' file` splits
+    # into two fragments, neither of which alone carries the `-i` flag next
+    # to `sed`, so sed_inplace_targets() never recognizes it (found by
+    # adversarial review of PR #42, F023 round 1).
+    def repl(m):
+        backslashes = m.group(1)
+        if len(backslashes) % 2 == 1:
+            return backslashes[:-1] + " "
+        return backslashes + "\n"
+
+    return re.sub(r"(\\*)\n", repl, command)
+
+
+QUOTE_SPAN_PATTERN = re.compile(r"\$'(?:[^'\\]|\\.)*'|'[^']*'|\"(?:[^\"\\]|\\.)*\"")
+
+
+def mask_quotes(command):
+    # Replaces each quoted span (single, double, ANSI-C $'...') with a same-
+    # LENGTH run of NUL placeholder characters -- never a real separator or
+    # target character -- so that a real "&"/"|"/";" INSIDE a quoted string
+    # (sed's 's/foo/[&]/' whole-match idiom, a filename like "a & b.txt")
+    # doesn't get mistaken for a shell control operator when segments_of()
+    # below scans this masked copy for split positions. Unlike deleting the
+    # quoted span (an earlier version of this fix did that, via a function
+    # named strip_quotes, ported from commit-gate.sh.template verbatim),
+    # preserving length means split positions found in the masked copy line
+    # up character-for-character with the ORIGINAL command, so segments_of()
+    # can slice the real, still-quoted text for each segment -- the quoted
+    # write target itself must survive segmentation intact, unlike in
+    # commit-gate.sh where quotes only ever wrap non-target text (a commit
+    # message) and erasing them is harmless. Deleting the span instead of
+    # masking it erased the write target whenever it was quoted at all
+    # (`echo x > "src/forbidden/a.txt"`, `rm "src/forbidden/a.txt"`, and the
+    # lead-owned-state-file guard the same way) -- a much bigger bypass than
+    # the one this hook exists to close, since quoting a path is the
+    # ordinary way to write one, not an adversarial evasion (found by
+    # adversarial review of PR #42, F023 round 2).
+    def repl(m):
+        return "\0" * len(m.group(0))
+
+    return QUOTE_SPAN_PATTERN.sub(repl, command)
+
+
+ANSI_C_SIMPLE_ESCAPES = {
+    "\\": "\\", "'": "'", '"': '"',
+    "a": "\a", "b": "\b", "e": "\x1b", "f": "\f",
+    "n": "\n", "r": "\r", "t": "\t", "v": "\v",
+}
+ANSI_C_ESCAPE_PATTERN = re.compile(
+    r"\\(?:x([0-9A-Fa-f]{1,2})|([0-7]{1,3})|c(.)"
+    r"|u([0-9A-Fa-f]{1,4})|U([0-9A-Fa-f]{1,8})|(.))"
+)
+
+
+def _decode_ansi_c_escape(m):
+    # One match alternative fires per call, per ANSI_C_ESCAPE_PATTERN's own
+    # six groups (hex, octal, control-char, 4-hex Unicode, 8-hex Unicode,
+    # single-char) -- verified against real bash 3.2.57 (`printf '%s'
+    # $'a\x2eb'`, `$'a\056b'`, `$'a\eb'`, `$'a\qb'`, `$'a\8b'`, `$'a\xzb'`):
+    # \xHH (1-2 hex digits, case-insensitive) and \nnn (1-3 octal digits)
+    # decode to that byte; \\, \', \", \a, \b, \e, \f, \n, \r, \t, \v
+    # decode to their usual meaning; any OTHER backslash escape (including
+    # \8/\9, not valid octal, and \x with no hex digit following) is left
+    # as a literal backslash followed by that character, UNCHANGED -- bash
+    # does not drop the backslash for an escape it doesn't recognize
+    # inside $'...'. \cX/\uHHHH/\UHHHHHHHH (F038) were a documented,
+    # unverified-in-this-environment residual until now: this repo's bash
+    # 3.2.57 does not decode \u/\U at all (confirmed: `$'a.b'` prints
+    # literally, backslash intact), so the traversal risk was inert on
+    # THIS machine specifically -- but installing bash 5.3.15 via Homebrew
+    # to check directly (rather than leaving it "believed added around
+    # bash 4.2, unverified") confirmed ./\U0000002e both genuinely
+    # decode to "." on any bash new enough, a live, not merely theoretical,
+    # bypass class identical to F033's own. \cX decodes on BOTH bash
+    # versions already (found by adversarial review of PR #57), using
+    # `ord(X.upper()) & 0x1F` -- verified against 10+ characters spanning
+    # letters, digits, and punctuation on BOTH bash versions (bash's real
+    # formula masks to the low 5 bits; a naive "XOR 0x40" convention some
+    # documentation implies gives the WRONG byte for digits/`~`/`{`/`|`/
+    # space on either version). "?" (0x3F) is a genuine, disclosed
+    # version split, not a single fixed answer: bash 3.2.57 decodes \c? to
+    # 0x1F (matching the general formula), but bash 5.3.15 special-cases
+    # it to 0x7F (DEL) -- confirmed on both directly (found by adversarial
+    # review of PR #66, round 1, which caught an earlier version of this
+    # comment wrongly claiming a single universal 0x1F answer verified
+    # against 5.3.15, when 5.3.15 itself gives 0x7F). Matching modern
+    # bash's special case here, since a newer bash is what most
+    # environments actually run. \cX can only ever produce a non-printable
+    # control byte (0x00-0x1F) or DEL (0x7F), never "." (0x2e) or "/"
+    # (0x2f), so it is not independently traversal-exploitable the way
+    # \u/\U are -- implemented anyway for completeness now that the
+    # pattern is being extended regardless, and its exact value IS
+    # observable through this hook's own ALLOW/DENY interface despite
+    # looking like it shouldn't be: the byte survives into the resolved
+    # path and the JSON-encoded denial message renders it as a distinct,
+    # inspectable escape sequence (found by the same review round, which
+    # used exactly this to prove the wrong formula was uncaught by any
+    # test). \u/\U are both GREEDY up to their digit cap (4 for \u, 8 for
+    # \U), matching \x's own greedy 1-2 digit behavior -- confirmed
+    # empirically (`\u2b` consumes BOTH hex-looking characters as one
+    # 2-digit codepoint 0x2B ('+'), not \u2 followed by literal "b"), and
+    # the resulting codepoint is encoded the same way Python's own str
+    # type stores it (chr()), which downstream scope-pattern string
+    # comparisons consume directly with no further byte-level re-encoding
+    # needed. Both \u and \U reject two ranges into the literal-text
+    # fallback rather than calling chr() unconditionally: a codepoint
+    # outside Unicode's own valid range (above 0x10FFFF -- real bash uses
+    # an extended, pre-RFC-3629 UTF-8 byte encoding for these that
+    # Python's chr() cannot represent) and, CRITICALLY, the UTF-16
+    # surrogate range 0xD800-0xDFFF. An earlier version of this fix only
+    # guarded the out-of-range case (a try/except around chr() catching
+    # ValueError) and let a lone surrogate through unchecked, since
+    # Python's chr() happily constructs a string containing one WITHOUT
+    # raising -- this was a genuine, newly-introduced fail-open, not a
+    # residual: this hook's own later json.dumps()/print() of the denial
+    # message DOES raise (UnicodeEncodeError: surrogates not allowed) once
+    # a resolved path contains one, and because this hook's whole design
+    # is fail-OPEN on any exception (DENY_REASON coming back empty means
+    # deny_json() is never called), a plain out-of-scope write with NO
+    # traversal at all -- just a lone \ud800 anywhere in the target --
+    # silently bypassed detection entirely, and composed with the EXISTING
+    # F031/F033 defenses too (a real `..` PLUS a trailing \ud800 also
+    # crashed past the point where the real target had already been
+    # correctly resolved) (found by adversarial review of PR #66, round 1;
+    # confirmed by direct execution: the write genuinely lands, rc 0, no
+    # deny fields, traceback on stderr only). Neither a surrogate nor an
+    # out-of-range codepoint can ever spell "." or "/" regardless of exact
+    # byte representation, so rejecting both into the literal fallback
+    # costs nothing security-wise while removing the crash-to-silent-
+    # ALLOW lever entirely.
+    hexdigits, octdigits, ctrlchar, u4, u8, other = (
+        m.group(1), m.group(2), m.group(3), m.group(4), m.group(5), m.group(6)
+    )
+    if hexdigits is not None:
+        return chr(int(hexdigits, 16))
+    if octdigits is not None:
+        return chr(int(octdigits, 8) & 0xFF)
+    if ctrlchar is not None:
+        upper = ctrlchar.upper()
+        if upper == "?":
+            return "\x7f"
+        if len(upper) != 1:
+            # ANSI_C_ESCAPE_PATTERN's c(.) captures ANY single character, and
+            # for 102 distinct Unicode characters str.upper() returns TWO
+            # characters (e.g. U+00DF, the German sharp s, uppercases to the
+            # two-character string "SS"), which
+            # made ord() raise TypeError -- crashing this hook's Python
+            # subprocess, which this hook's own fail-open design (see header)
+            # then turns into a SILENT ALLOW for the entire command, not just
+            # a missed decode: `$'src/parser/\c<that char>q.txt'` anywhere in
+            # a compound command let an UNRELATED, plain-ASCII, ordinarily-
+            # denied out-of-scope write elsewhere in the SAME command through
+            # too, confirmed live on main (found by adversarial review of PR
+            # #67, the exact same fail-open class the surrogate fix above
+            # closes, recurring one branch over with a different exception
+            # type no source-range guard on \u/\U could ever have caught).
+            # Falling back to the ORIGINAL (non-uppercased) character instead
+            # of crashing diverges from real bash's own byte-wise result for
+            # these characters, but \cX can never spell "." or "/" on either
+            # reading, so only not-crashing matters here.
+            upper = ctrlchar
+        return chr(ord(upper) & 0x1F)
+    if u4 is not None:
+        return _unicode_escape_or_literal(u4, "u")
+    if u8 is not None:
+        return _unicode_escape_or_literal(u8, "U")
+    return ANSI_C_SIMPLE_ESCAPES.get(other, "\\" + other)
+
+
+def _unicode_escape_or_literal(hexdigits, prefix):
+    # Shared by \uHHHH and \UHHHHHHHH: rejects a codepoint that Python's
+    # chr() would accept but this hook's own later JSON encoding cannot --
+    # see _decode_ansi_c_escape()'s own comment for the full incident this
+    # closes (a lone surrogate crashed the hook into a silent ALLOW).
+    codepoint = int(hexdigits, 16)
+    if 0xD800 <= codepoint <= 0xDFFF or codepoint > 0x10FFFF:
+        return "\\" + prefix + hexdigits
+    return chr(codepoint)
+
+
+def unquote_token(token):
+    # Strips quote characters from a single ALREADY-EXTRACTED target token --
+    # never used to re-segment or re-tokenize, only to normalize a target
+    # string (which may be fully quoted, "foo"/'foo'/$'foo', or partially
+    # quoted, foo/"bar".txt) before comparing it against scope patterns. Safe
+    # here specifically because segments_of() has already correctly resolved
+    # segment boundaries using mask_quotes(); this function never looks at
+    # separators. A $'...' span's inner text is decoded per bash's ANSI-C
+    # quoting grammar (F033) in this SAME substitution -- not left for the
+    # generic backslash-unescape pass below to mangle, and not merely
+    # stripped of its wrapper unresolved: before this, `$'src/parser/
+    # \x2e\x2e/other/x.txt'` genuinely resolves to src/other/x.txt in real
+    # bash (\x2e decodes to "."), but the hook never decoded the escape, so
+    # normalize() never saw a real ".." to resolve and the traversal was
+    # wrongly ALLOWED (found by adversarial review of PR #50, F031, filed
+    # separately as F033: a different mechanism from F031 -- escape
+    # DECODING inside an already-recognized $'...' span, not escape
+    # REMOVAL outside quotes). \cX (control-char), \uHHHH, and \UHHHHHHHH
+    # escapes are ALSO decoded (F038) -- see _decode_ansi_c_escape()'s own
+    # comment for the exact formulas, verification, and the one disclosed
+    # residual (a \U codepoint outside Unicode's valid range, or landing
+    # in the surrogate range, is left undecoded rather than crashing).
+    token = re.sub(
+        r"\$'((?:[^'\\]|\\.)*)'",
+        lambda m: ANSI_C_ESCAPE_PATTERN.sub(_decode_ansi_c_escape, m.group(1)),
+        token,
+    )
+    token = token.replace("'", "").replace('"', "")
+    # Outside quotes, real bash strips a backslash and makes the next
+    # character literal -- e.g. "\.." really means "..", letting a traversal
+    # segment hide from normalize()'s os.path.normpath() resolution, which
+    # only recognizes the exact string ".." (F031). Applied uniformly after
+    # quote-stripping since this function no longer tracks which spans were
+    # originally quoted (where bash treats a backslash as ordinary,
+    # non-special text, true of both single- and double-quoted spans) --
+    # an accepted, documented residual, same as the rest of this
+    # pattern-based, evadable-by-construction hook: a real literal
+    # backslash in a quoted filename is normalized away too.
+    return re.sub(r"\\(.)", r"\1", token)
+
+
+def segments_of(command):
+    # Splits on shell control operators. An earlier version omitted a literal
+    # newline and "&" (background execution, and the leading half of "|&"):
+    # without them, two separately-written commands glue into one segment.
+    # At the time this was fixed, write_target()/redirect_target() (singular)
+    # only ever checked the LAST target found across the whole (possibly
+    # merged) segment, so an in-scope write later in the command masked an
+    # out-of-scope write earlier in it. write_targets()/redirect_targets()
+    # (plural, F024) now check every target in a segment, which independently
+    # bounds that specific consequence, but correct segmentation still
+    # matters for its own sake (a target belongs to a specific logical
+    # command, not an accidental merge of two). The identical missing-
+    # newline bug was found and fixed in commit-gate.sh.template (F011/
+    # OVI-64, round 3); this hook never got the same fix (found by
+    # adversarial review of PR #40, reported as F023). Adding the newline
+    # split required join_continuations() as a prerequisite, exactly as it
+    # did in commit-gate.sh (found by adversarial review of PR #42, F023
+    # round 1). Split positions are found in a quote-MASKED copy (see
+    # mask_quotes) but sliced from the ORIGINAL, still-quoted text, so a
+    # segment's real write target survives intact for
+    # write_targets()/redirect_targets() to extract -- deleting quotes
+    # outright (as round 1's first attempt did) erased the target whenever
+    # it was quoted, a much bigger bypass than the one being fixed (found by
+    # adversarial review of PR #42, F023 round 2). A "&" is NOT a segment
+    # separator when it immediately follows a ">": real bash lexes ">&" as
+    # one fd-duplication operator (`2>&1`, `>&2`), not a redirect
+    # immediately followed by a background/AND "&" -- splitting there
+    # fragmented the redirect, leaving a dangling ">" with no target after
+    # it for strip_redirects()/redirect_targets() to recognize, so it
+    # survived into rm/tee's own target extraction as a bogus write target
+    # (F030). A bare "&" anywhere else (background, "&&", or the leading
+    # half of `&> file`) is unaffected and still splits as before.
+    sanitized = strip_heredoc_bodies(command)
+    joined = join_continuations(sanitized)
+    masked = mask_quotes(joined)
+    segments = []
+    start = 0
+    for m in re.finditer(r"[|;\n]|(?<!>)&", masked):
+        segments.append(joined[start:m.start()])
+        start = m.end()
+    segments.append(joined[start:])
+    return [s.strip() for s in segments if s.strip()]
+
+
+def all_flagless_tokens(tokens):
+    # A literal "--" ends flag parsing for the rest of THIS token list, same
+    # as commit-gate.sh.template's has_staging_flag(): every token after it
+    # is a real pathspec, never a flag, even if it starts with "-" (e.g. the
+    # real filename in `rm -- -a.txt`). Before this, a token starting with
+    # "-" was excluded unconditionally, so "--" and "-a.txt" were BOTH
+    # dropped and no target was found at all -- an out-of-scope -a.txt was
+    # then silently ALLOWED, not merely misnamed (F029). Only the FIRST
+    # "--" is a separator; any later one is already past it, so it's just
+    # ordinary token text, kept like any other post-separator token. The
+    # separator check and the "starts with -" flag check both run against
+    # _flag_view(tok), not the raw token -- a quoted "--" (e.g. `cp "--"
+    # "-t" src/parser/d/ src/other/x`) is just as real a separator to the
+    # RECEIVING command as an unquoted one, since the shell strips quotes
+    # before the program ever sees its argv. Comparing only the flag
+    # checks against the view while leaving THIS "--" check on the raw
+    # token (an earlier version of the F035 fix did exactly that) created a
+    # NEW asymmetry: quoted flags were recognized but a quoted "--" was
+    # not, so `past_separator` never became True for it, silently
+    # swallowing the real (possibly out-of-scope) destination that follows
+    # -- found by adversarial review of PR #59, F035, the same
+    # guard-vs-check asymmetry class F029 round 3 already fixed once for a
+    # different trigger (a value-consumed "--" there; a quoted "--" here).
+    result = []
+    past_separator = False
+    for tok in tokens:
+        if not tok:
+            continue
+        view = _flag_view(tok)
+        if view == "--" and not past_separator:
+            past_separator = True
+            continue
+        if past_separator or not view.startswith("-"):
+            result.append(tok)
+    return result
+
+
+def last_flagless_token(tokens):
+    flagless = all_flagless_tokens(tokens)
+    return flagless[-1] if flagless else None
+
+
+def redirect_targets(segment):
+    # Finds the token after EVERY REAL >/>> on the line, regardless of other
+    # operators (e.g. <<EOF) on the same line, so a heredoc-into-redirect
+    # line is still caught. An earlier version returned only the LAST match,
+    # so `echo x > out-of-scope 2> in-scope` in one segment checked only the
+    # in-scope target and masked the out-of-scope one -- found by
+    # adversarial review of PR #42/F023, reported as F024. Matching runs
+    # against a quote-MASKED copy (so a ">" INSIDE a quoted string, e.g.
+    # echo "a => b" > file, is masked to a NUL run and can't match) but each
+    # match's target text is sliced from the ORIGINAL segment at the same
+    # position, so a legitimately quoted target still returns its real
+    # (still-quoted) text for write_targets()/unquote_token() to normalize --
+    # matching directly against the unmasked segment, as an earlier version
+    # of the F024 fix did, treated every quoted ">" as a real redirect too.
+    masked = mask_quotes(segment)
+    targets = [
+        segment[m.start(1):m.end(1)]
+        for m in re.finditer(r">>?\s*([^\s<>|&;]+)", masked)
+    ]
+    # `>&word` with word NOT purely digits/"-" is `&>word`, an ordinary FILE
+    # redirect (bash: `echo x >&outfile.txt` genuinely creates outfile.txt),
+    # not fd-duplication -- this was a real fail-open, confirmed identical on
+    # main and after F030's own fix: the pattern above can never match it
+    # (the char class it captures into explicitly excludes "&", so a target
+    # class starting right at "&" fails to match at all). Whitespace or
+    # quoting between `>&` and the word doesn't change bash's behavior (`>&
+    # outfile.txt`, `>&'outfile.txt'` both still create the file, confirmed
+    # against real bash) -- found by adversarial review of PR #53, round 3.
+    # Whether a given word counts as "purely digits/-" has to be decided on
+    # its UNQUOTED value, not the raw/masked text: `>&'1'` is STILL
+    # fd-duplication in real bash (quoting doesn't change the classification,
+    # confirmed empirically), so checking the masked capture (a NUL run for
+    # a quoted span) would wrongly treat it as a real target. This pattern
+    # deliberately matches `>&word` with ANY preceding fd digit (or none) --
+    # an earlier version of this fix claimed EVERY fd-prefixed word form
+    # (`2>&outfile.txt`) is a hard "ambiguous redirect" syntax error, so no
+    # fd-prefix handling was needed; that claim is true for fd 0, 2, and
+    # 3+, but FALSE for fd 1 specifically: `1>&outfile.txt` is a real,
+    # long-standing bash extension (confirmed against real bash and bash's
+    # own redir.c: a dedicated `redirector == 1` branch converts it to the
+    # same r_err_and_out redirect as `&>`) that genuinely writes the file,
+    # capturing both stdout and stderr -- found by adversarial review of PR
+    # #63, round 1. This function's own pattern was never anchored to "no
+    # fd prefix" in the first place (it just looks for `>&` anywhere in the
+    # segment), so `1>&outfile.txt` was already correctly caught here even
+    # under the old, wrong justification; strip_redirects() below is the
+    # function that actually needed the fix once this was understood.
+    # Digit-or-dash classification also has a known, narrow, non-regression
+    # residual: it decides on unquote_token()'s output, which strips
+    # backslashes as well as quotes, but real bash classifies fd-dup-vs-file
+    # on the word BEFORE backslash/quote removal -- `>&'\1'` genuinely
+    # creates a file named "1" in real bash (confirmed), which this check
+    # wrongly treats as fd-duplication and allows. Reachable target is only
+    # ever a bare digit-named file or "-" in the cwd (never a real path,
+    # since "/" can't satisfy .isdigit()), and main allowed every `>&word`
+    # unconditionally, so this is not a regression -- found by the same
+    # review round, not fixed here.
+    for m in re.finditer(r">&\s*([^\s<>|&;]+)", masked):
+        raw_word = segment[m.start(1):m.end(1)]
+        view_word = unquote_token(raw_word)
+        if view_word == "-" or view_word.isdigit():
+            continue
+        targets.append(raw_word)
+    return targets
+
+
+TARGET_DIRECTORY_FLAGS = ("-t", "--target-directory")
+
+
+def _flag_view(tok):
+    # Unquoted view of a token for FLAG RECOGNITION only (cp_mv_targets()/
+    # sed_inplace_targets()' own comparisons against known flag strings) --
+    # never returned or stored as a target/token itself. A raw, still-
+    # quoted token is always what gets returned to write_targets(), which
+    # applies its OWN single unquote_token() pass over the final target
+    # list -- calling unquote_token() a SECOND time on an already-unquoted
+    # string would silently undo F031's backslash-escape traversal defense
+    # (unquote_token() is not idempotent: e.g. "a\\\\b.txt" unquoted once is
+    # "a\\b.txt", unquoted TWICE becomes "ab.txt"). Before this, cp_mv_targets()
+    # and sed_inplace_targets() compared flag tokens RAW, so quoting a flag
+    # evaded recognition entirely: `cp "-t" "src/other/d/" src/parser/a`
+    # was wrongly ALLOWED (real bash writes to src/other/d/ via -t, but the
+    # quoted "-t" token never matched TARGET_DIRECTORY_FLAGS, so
+    # cp_mv_targets() fell through to last_flagless_token() and picked the
+    # wrong argument) -- found by adversarial review of PR #51, F028,
+    # filed as F035.
+    return unquote_token(tok)
+
+
+def _attached_value_raw(tok, prefix_len):
+    # Returns the RAW (not-yet-unquoted) suffix of `tok` starting right after
+    # its recognized `prefix_len`-character flag prefix (e.g. 2 for "-t", or
+    # len("--target-directory=")), for write_targets()'s single later
+    # unquote_token() pass to resolve -- mirroring how the bare "-t DIR"/
+    # "--target-directory DIR" forms already return tokens[i+1] untouched.
+    # An earlier version sliced the VIEW instead (view.split("=", 1)[1] /
+    # view[2:]), handing write_targets() an ALREADY-unquoted-and-unescaped
+    # string that its own unquote_token() pass then processed a SECOND time.
+    # unquote_token() is not idempotent (F031's backslash-unescape isn't),
+    # so this silently mis-resolved any backslash in the destination:
+    # confirmed both directions by sweeping 3,645 backslash-bearing -t
+    # destinations against real GNU cp -- 70 unquoted cases regressed
+    # DENY->ALLOW (a fail-open: `cp -ts\\rc/parser/x a.txt` really targets
+    # the literal directory `s\rc/parser/x`, confirmed via `gcp` execution,
+    # but double-unquoting silently stripped the surviving backslash and
+    # made it look like the in-scope "src/parser/x") and 1,376 regressed
+    # ALLOW->DENY (found by adversarial review of PR #59, round 2).
+    # Since unquote_token() strips quote characters from ANYWHERE in a
+    # token (not just matched pairs at the edges) and unescapes backslashes
+    # globally, the fix below walks the RAW token counting non-quote
+    # characters until `prefix_len` of them are consumed, skipping over
+    # (but preserving in the returned suffix) any quote characters seen
+    # along the way. This correctly locates the raw split point whether the
+    # flag prefix is bare, only the value is quoted, or the WHOLE token
+    # (prefix included) is quoted -- in every case the returned suffix still
+    # carries any quote/backslash characters untouched, for write_targets()
+    # to resolve in exactly one pass, the same as the bare-form path.
+    # Documented residual (found by adversarial review of PR #59, round 3):
+    # a backslash-escaped character INSIDE the flag prefix itself (as opposed
+    # to inside the value) throws off the count by one per escape, since this
+    # walk counts a quote character as free but a backslash as a real,
+    # counted character -- `cp -\tsrc/parser/x a.txt`, `cp $'-t'src/parser/x
+    # a.txt`, and `cp --target-\directory=src/parser/x a.txt` are all
+    # genuinely in scope but wrongly DENIED (18 false positives found across
+    # 112 brute-forced prefix/destination spellings, zero fail-opens --
+    # strictly over-denial, not a bypass, and a new-vs-main regression only
+    # in this narrow, adversarial-quoting shape). Not fixed: nobody escapes
+    # characters inside a bare flag name in practice, and closing this
+    # would require tracking escape state through the prefix walk itself,
+    # not just counting past it.
+    seen = 0
+    for idx, ch in enumerate(tok):
+        if ch in ("'", '"'):
+            continue
+        seen += 1
+        if seen == prefix_len:
+            return tok[idx + 1 :]
+    return ""
+
+
+TARGET_DIRECTORY_EQUALS_LEN = len("--target-directory=")
+
+
+def cp_mv_targets(tokens):
+    # cp/mv normally write to only the LAST flagless argument (the
+    # destination); every earlier flagless argument is a SOURCE, read not
+    # written. `-t DIR`/`-tDIR`/`--target-directory=DIR` name the destination
+    # explicitly instead, in which case EVERY flagless argument is a source
+    # and DIR is the sole write target -- an earlier version didn't look for
+    # any of these forms at all, so an out-of-scope -t destination was never
+    # checked (found by adversarial review of PR #42/F023, reported as
+    # F024). Clustered short flags (`-rt DIR`, -r and -t combined) are not
+    # recognized, a documented residual (see header). The scan stops at a
+    # literal "--" (end of flag parsing): without this, a real filename that
+    # happens to start with "-t" after "--" (e.g. `mv -- -t.txt dest.txt`)
+    # was misread as the -t flag itself, string-sliced into a bogus target
+    # ".txt", and the REAL destination (dest.txt, via the last_flagless_token
+    # fallback, never reached because this loop already returned) went
+    # unchecked -- the exact failure mode F029 exists to close, just in this
+    # sibling function instead of all_flagless_tokens() (found by
+    # adversarial review of PR #52, F029). The "--" check and every FLAG
+    # comparison below run against _flag_view(tok), not the raw token, so a
+    # quoted flag OR a quoted "--" can't evade recognition (F035): a quoted
+    # "--" (e.g. `cp "--" "-t" src/parser/d/ src/other/x`) is just as real a
+    # separator to the receiving command as an unquoted one, since the
+    # shell strips quotes before the program's argv is built. An earlier
+    # version of this fix left the "--" check on the raw token, reasoning
+    # it matched all_flagless_tokens()'s own then-current convention and
+    # was out of F035's reported shape -- that was wrong on both counts: it
+    # created a NEW asymmetry (flags view-aware, "--" not) that let a
+    # quoted "--" swallow the real destination that follows, and
+    # all_flagless_tokens() itself needed the identical correction for the
+    # identical reason (found by adversarial review of PR #59, F035). The
+    # bare `-t DIR`/`--target-directory DIR` forms return the RAW next
+    # token (tokens[i+1], untouched, unquoted exactly once later by
+    # write_targets()); the attached `--target-directory=DIR`/`-tDIR` forms
+    # go through _attached_value_raw() for the identical reason (see its
+    # own docstring) -- an earlier version extracted their value from the
+    # VIEW instead, framed as "a documented, narrower residual"; a reviewer
+    # proved that framing wrong (it flips scope decisions in BOTH
+    # directions vs. main, a regression, not a residual) and this replaces
+    # it (F035 round 2, PR #59 round-2 review).
+    for i, tok in enumerate(tokens):
+        view = _flag_view(tok)
+        if view == "--":
+            break
+        if view in TARGET_DIRECTORY_FLAGS and i + 1 < len(tokens):
+            return [tokens[i + 1]]
+        if view.startswith("--target-directory="):
+            return [_attached_value_raw(tok, TARGET_DIRECTORY_EQUALS_LEN)]
+        if view.startswith("-t") and not view.startswith("--") and len(view) > 2:
+            return [_attached_value_raw(tok, 2)]
+    last = last_flagless_token(tokens)
+    return [last] if last else []
+
+
+SED_SCRIPT_VALUE_FLAGS = ("-e", "-f", "--expression", "--file")
+
+# The full set of long options GNU sed recognizes, used as the
+# disambiguation universe for _resolve_sed_long_flag() (F041) -- mirroring
+# commit-gate.sh's GIT_COMMIT_LONG_OPTIONS/_resolve_long_flag() (F032).
+# Mechanically extracted from `gsed --help` (GNU sed 4.10, installed via
+# `brew install gnu-sed` specifically to ground-truth this), not assembled
+# from memory: --quiet/--silent are both listed as -n's long form; the
+# rest are one option each. GNU sed accepts any prefix of a long option
+# that uniquely identifies it among this FULL set (confirmed: `gsed --xyz`
+# errors "unrecognized option"; `gsed --f=x` errors "option '--f=x' is
+# ambiguous; possibilities: '--file' '--follow-symlinks'"), the same
+# unambiguous-prefix rule real git uses. Before this, sed_inplace_targets()'s in-place-
+# presence guard recognized only the exact string "--in-place" or the
+# attached "--in-place=" prefix -- confirmed against real gsed that
+# --i, --in, --in-p, --in-pla, --in-plac (bare) and --i=.bak, --in-p=.bak
+# (attached, abbreviated) all genuinely perform a real in-place edit,
+# since --in-place is the only long option starting with "--i" (no
+# ambiguity to resolve), and every one of these was wrongly ALLOWED
+# (F041). The identical abbreviation gap also affects has_explicit_script's
+# own --expression=/--file= recognition, AND the main token-walking loop's
+# 2-token skip for -e/-f/--expression/--file, AND _separator_index()'s own
+# copy of that same skip -- all four sites now recognize a bare OR
+# attached abbreviated form via _sed_consumes_next_as_script() below, not
+# just an exact SED_SCRIPT_VALUE_FLAGS string.
+#
+# An earlier version of this fix recognized the bare abbreviated form ONLY
+# in the in-place guard, leaving the other three sites (has_explicit_script,
+# the walking loop, _separator_index()) matching the exact-string
+# SED_SCRIPT_VALUE_FLAGS set only, on the theory that a single bare
+# abbreviated script flag's "wrong by one token" error in the (unfixed)
+# walking loop exactly cancels has_explicit_script's own "wrong by one
+# token" error, landing on the same real target either way. That theory is
+# FALSE whenever the flag's value is not itself a flagless token -- i.e.
+# starts with "-" (a script/script-file argument that happens to look like
+# a flag, e.g. a file named "-x.sed") or is exactly "--". In that case the
+# walking loop's `view.startswith("-"): i += 1` branch swallows the VALUE
+# as if it were an unrelated flag instead of leaving it for the
+# (unfixed) 2-token skip to consume, so the cancellation breaks down and
+# the REAL target is what gets swallowed as the implicit script instead --
+# a genuine fail-open, not a cosmetic mis-naming. Confirmed against real
+# gsed 4.10 (adversarial review of PR #71): `sed -i --fi -x.sed
+# out-of-scope-file` and `sed -i --fi -- out-of-scope-file` (with a file
+# literally named "--" containing a script) both genuinely in-place edit
+# the real file, and the hook (with only the in-place guard fixed)
+# silently ALLOWed both -- reachable even against this fix's OWN newly
+# recognized --in-place, since `sed --in-place --fi -x.sed file` hits the
+# identical gap one flag later. This fix closes it at all four sites with
+# one shared predicate, confirmed by mutation testing that: (a) all four
+# shapes above now DENY and name the real file, (b) the previously
+# mis-named 2-flag case (`sed -i --exp 's/a/b/' --exp 's/c/d/'
+# out-of-scope-file`) now correctly names the real file instead of the
+# second script fragment, and (c) a genuine pre-existing FALSE POSITIVE is
+# also fixed as a side effect: `sed --fi -i.bak file1 file2` was wrongly
+# DENIED (the unrecognized `--fi` left "-i.bak" looking like a flag
+# position, which IN_PLACE_CLUSTER_PATTERN then mismatched as enabling
+# in-place mode) even though real gsed treats "-i.bak" as --file's own
+# script-file value and performs no in-place edit at all -- the same
+# "value that looks like a flag" bug class PR #52 round 4 already fixed
+# for the exact-spelling form, reintroduced here via abbreviation.
+SED_LONG_OPTIONS = (
+    "--quiet", "--silent", "--debug", "--expression", "--file",
+    "--follow-symlinks", "--in-place", "--line-length", "--posix",
+    "--regexp-extended", "--separate", "--sandbox", "--unbuffered",
+    "--null-data", "--help", "--version",
+)
+
+
+def _resolve_sed_long_flag(view):
+    # Resolves a "--xxx" token to its full long-option name if it's an
+    # exact match or an UNAMBIGUOUS prefix of exactly one entry in
+    # SED_LONG_OPTIONS, mirroring commit-gate.sh's _resolve_long_flag()
+    # (F032). Returns None on no match or an ambiguous prefix -- in the
+    # ambiguous case, real GNU sed itself errors out and nothing runs, so
+    # treating it as "not a recognized flag" here is always safe, never a
+    # bypass. Operates on the flag-name part only: callers split off any
+    # attached "=value" suffix before calling this, since GNU's own
+    # abbreviation resolution happens on the option name, not the value
+    # (confirmed: `gsed --i=.bak` and `gsed --in-place=.bak` resolve
+    # identically).
+    if view in SED_LONG_OPTIONS:
+        return view
+    matches = [o for o in SED_LONG_OPTIONS if o.startswith(view)]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _sed_long_flag_name(tok):
+    # Splits a (possibly _flag_view-unquoted) token into its flag-name part
+    # -- everything before the first "=" -- and resolves THAT against
+    # SED_LONG_OPTIONS, so both the bare form ("--in-place") and the
+    # attached form ("--in-place=.bak", or an abbreviation of either) are
+    # recognized identically (F041). Returns None for a non-"--" token
+    # without ever calling _resolve_sed_long_flag on it, since a short
+    # flag or a plain filename could otherwise coincidentally prefix-match
+    # (e.g. an empty string is a prefix of everything).
+    if not tok.startswith("--"):
+        return None
+    return _resolve_sed_long_flag(tok.split("=", 1)[0])
+
+
+def _sed_consumes_next_as_script(view):
+    # True if `view` is a BARE (not self-contained) script-value flag that
+    # consumes the NEXT token as its value -- either an exact
+    # SED_SCRIPT_VALUE_FLAGS entry, or an unambiguous abbreviation of
+    # --expression/--file with no attached "=value" (F041). An attached
+    # form ("--exp=script") is a single self-contained token that must NOT
+    # be counted here (no extra token to skip) -- distinguished by the
+    # absence of "=" in `view`, since _sed_long_flag_name() resolves the
+    # name portion the same way for both attached and bare forms and can't
+    # itself tell them apart. This is the ONE predicate all four places in
+    # this function that need to agree on "does this flag position consume
+    # 2 tokens or 1" must share -- _separator_index(), the flag_positions
+    # walk, has_explicit_script, and the main token-walking loop -- so an
+    # abbreviated flag can never be recognized at one site and missed at
+    # another (the same guard-vs-loop disagreement risk F029/F052
+    # established for this file, now extended to abbreviation as well as
+    # quoting).
+    if view in SED_SCRIPT_VALUE_FLAGS:
+        return True
+    return "=" not in view and _sed_long_flag_name(view) in ("--expression", "--file")
+
+
+# Matches a short-flag cluster ending in "i" (F037): both GNU's and BSD/
+# macOS's own argument-less short flags may precede "i" in the same token
+# (`-ri`, `-ni`, `-Ei`, `-nsi`, ... on GNU; `-ai.bak`, `-Hi.bak`, `-ali.bak`
+# on BSD/macOS's own /usr/bin/sed, confirmed against it directly -- this
+# repo's own stated platform, and this same function already accommodates
+# a BSD idiom elsewhere, the `-i ''` empty-suffix skip below). "e"/"f" are
+# excluded on both flavors since they take their OWN argument and consume
+# the REST of the token once encountered, so "-fi" is -f's value "i" (a
+# file literally named "i"), never -f combined with -i (confirmed against
+# real GNU sed: `sed -fi file` prints to stdout, unmodified). "l" is a
+# genuine, irreconcilable conflict between the two flavors and included
+# here as a deliberate choice, not an oversight: BSD's `-l` takes no
+# argument (line-buffered output; confirmed via `sed -li.bak ...`
+# genuinely in-place edits), but GNU's `-l N` takes a MANDATORY numeric
+# one (confirmed via `gsed -li file`: prints to stdout, unmodified -- "i"
+# is consumed as -l's line-length value, not a flag). Including "l"
+# closes the real BSD fail-open at the cost of over-denying an unusual
+# GNU combination (`sed -li... ` intending -l's own value, not -i) --
+# accepted, same class as this hook's other documented safe-direction
+# residuals, since a fail-open is worse than an over-caution and BSD/macOS
+# is the platform this repo itself runs on. "a"/"H" (BSD-only, confirmed
+# via `sed -ai.bak`/`sed -Hi.bak`) cost nothing on GNU either way: real
+# GNU sed rejects them outright as invalid options, so a command using
+# them can never reach GNU's own in-place logic regardless of what this
+# hook decides (found by adversarial review of PR #65, round 1).
+IN_PLACE_CLUSTER_PATTERN = re.compile(r"^-[nrEsuzalH]*i")
+
+
+def _separator_index(args):
+    # Returns the index of the first literal "--" that acts as a REAL
+    # separator, skipping any "--" consumed as an -e/-f/--expression/--file
+    # VALUE (e.g. `sed -f -- 's/a/b/'`, where "--" is a script file's own
+    # name, not the pathspec separator). Mirrors sed_inplace_targets()'s own
+    # token-walking loop for separator-finding purposes, so callers that
+    # need to know "where does flag parsing end" (the two any() guards)
+    # agree with the loop that actually walks past that point -- a naive
+    # `args.index("--")` could disagree and truncate one token too early
+    # (found by adversarial review of PR #52, round 3). Does not replicate
+    # the loop's `-i ''` two-token skip: that skip is gated on the NEXT
+    # token's unquoted view being empty, which can never equal "--" (a
+    # real "--" always has a non-empty view), so it cannot change where
+    # the real separator is and is safely omitted
+    # here (verified by adversarial review of PR #52, round 4: brute-forced
+    # every arg sequence up to length 4 over this function's own alphabet,
+    # zero disagreements with the full loop). Compares _flag_view(args[i]),
+    # not the raw token, against SED_SCRIPT_VALUE_FLAGS -- so a quoted
+    # "-e"/"-f" is recognized as consuming the next token too, keeping this
+    # in agreement with sed_inplace_targets()'s own now-view-aware checks
+    # (F035); using the raw token here instead would silently reintroduce
+    # the exact guard-vs-loop disagreement bug class F029 round 3 fixed,
+    # just triggered by quoting instead of a value-consumed "--".
+    i = 0
+    while i < len(args):
+        if _flag_view(args[i]) == "--":
+            return i
+        i += 2 if _sed_consumes_next_as_script(_flag_view(args[i])) else 1
+    return len(args)
+
+
+def sed_inplace_targets(args):
+    # Walks sed's own arguments token by token (mirroring commit-gate.sh's
+    # segment_subcommand flag-walking loop) instead of assuming a fixed
+    # position is "the script": -e/-f/--expression/--file each consume
+    # their OWN following value as a script fragment, not a file (closing a
+    # false denial the first version had for `sed -i -e '...' -e '...'
+    # file`, since each -e's value is itself a flagless token); a bare "-i"
+    # immediately followed by an empty-quote token ("''"/'""') is the
+    # mandatory-backup-suffix BSD/macOS idiom (`sed -i '' 's/a/b/' file`) --
+    # that empty-suffix token is consumed too, never mistaken for the script
+    # or a file (the first version denied this ordinary, in-scope command on
+    # this repo's own platform). GNU's `--expression=value`/`--file=value`
+    # attached forms need no special skip logic: the value is part of the
+    # same token as the flag, so it's never a flagless token in the first
+    # place, but a script provided this way means there is no POSITIONAL
+    # script argument to skip either -- has_explicit_script tracks that so
+    # the first real file isn't mistaken for an implicit script and dropped
+    # (found by adversarial review of PR #46). Documented residual: a bare
+    # "-i" followed by a NON-empty separate backup-suffix token (`sed -i
+    # '.bak' 's/a/b/' file`, as opposed to the far more common attached
+    # form `-i.bak` or the empty-suffix form `-i ''`) is not recognized --
+    # that token is misread as the implicit script, denying an in-scope
+    # command. Not fixed: the check only matches a token whose unquoted
+    # view IS empty, and widening it to "any token after a bare -i"
+    # would reintroduce the exact ambiguity this function exists to resolve
+    # (GNU's bare "-i" never takes a following value at all) (found by
+    # adversarial review of PR #46, round 2). Same "--" gap as
+    # cp_mv_targets()/all_flagless_tokens() (F029): before this, EVERY token
+    # starting with "-" was skipped as a flag unconditionally, including a
+    # literal "--" itself and a real filename after it (e.g. `sed -i -- -a
+    # .txt`), so a real out-of-scope file target following "--" was never
+    # recognized and went unchecked (found by adversarial review of PR #52,
+    # F029). Once "--" is seen, EVERY flag-detection scan in this function --
+    # the `-i`/`--in-place` presence check and the has_explicit_script check
+    # immediately below, not just the token-walking loop further down --
+    # stops looking at flags for the rest of the arguments; every later
+    # token falls through to the same implicit-script-then-target logic as
+    # an ordinary flagless token. Missing this for the two `any()` checks
+    # (round 1 of PR #52 only fixed the loop) both under- and over-denies: a
+    # real out-of-scope FILE target that happens to start with "-i" (e.g.
+    # `sed 's/a/b/' -- -input.txt`, no actual -i flag at all) would wrongly
+    # trigger the in-place guard, and a real target literally named "-e" or
+    # "-f" after "--" would wrongly trigger has_explicit_script -- both
+    # found by adversarial review of PR #52, round 2). Round 2's fix used a
+    # NAIVE first-literal-"--" index for the two any() guards, but the
+    # token-walking loop below uses a FLAG-AWARE walk that skips a "--"
+    # consumed as an -e/-f/--expression/--file VALUE (e.g. `sed -f -- ...`,
+    # a script FILE literally named "--"). When a "--" is consumed as a
+    # value, the naive index and the flag-aware walk disagree about where
+    # the real separator is, so the guards could truncate one token too
+    # early and miss a genuine -i flag positioned after the value-consumed
+    # "--" (found by adversarial review of PR #52, round 3). _separator_index()
+    # duplicates the loop's own flag-aware walk (not the loop itself, to
+    # keep it a plain boundary lookup with no target-collection side
+    # effects) so the guards and the loop always agree on where flag
+    # parsing actually ends.
+    # Every FLAG comparison in this function (the two any() guards above and
+    # the loop below), AND the "--" check itself, run against _flag_view(tok),
+    # not the raw token, so a quoted flag OR a quoted "--" can't evade
+    # recognition -- e.g. `sed "-i" "" -e "s/a/b/" src/other/f.txt` was
+    # wrongly ALLOWED before this, since a quoted "-i" never matched the
+    # bare-"-i" guard (found by adversarial review of PR #51, F028, filed
+    # as F035). An earlier version of this fix left the "--" check raw,
+    # reasoning it matched all_flagless_tokens()'s then-current convention
+    # -- that reasoning, and the convention itself, were both wrong: a
+    # quoted "--" (e.g. `sed -i "--" -i src/other/f.txt`, where the real
+    # script becomes the literal text "-i" and the real target is
+    # src/other/f.txt) is just as real a separator to the receiving sed as
+    # an unquoted one, and leaving it raw while flags were view-aware
+    # silently swallowed the real destination that follows (found by
+    # adversarial review of PR #59, F035).
+    # In-place presence used to recognize only a BARE "-i", an attached
+    # short-flag suffix ("-i" as a literal prefix, e.g. "-i.bak"), or an
+    # EXACT "--in-place" -- missing two real, ordinary invocation shapes
+    # (F037): CLUSTERED short flags where -i is not first in the token
+    # (`sed -ri 's/a/b/' file`, `sed -ni 's/a/b/p' file`), and the attached
+    # long-form suffix `--in-place=.bak`. Both are more reachable in
+    # ordinary usage than anything F029 fixed (no unusual quoting or "--"
+    # needed, just an everyday flag-combining habit). See
+    # IN_PLACE_CLUSTER_PATTERN's own comment above for exactly which short
+    # flags may precede "i" in a cluster and why (a GNU/BSD flavor
+    # difference this repo's own platform makes relevant, not an
+    # arbitrary choice).
+    # Takes ARGS (the tokens AFTER the command name), not the full token
+    # list including the command name itself -- the caller (write_targets())
+    # is the single place responsible for deciding this segment really
+    # invokes sed, via _resolve_command_tokens() (F044), which recognizes
+    # quoted/escaped spellings (F040), path-form indirection (/bin/sed,
+    # ./sed), env-assignment prefixes (FOO=1 sed), and wrapper commands
+    # (sudo/env/command/xargs sed). An earlier version of this function
+    # duplicated a NARROWER piece of that same resolution internally
+    # (`_flag_view(tokens[0]) != "sed"`, recognizing only quoting/escaping,
+    # not indirection) -- once write_targets() gained the fuller resolver
+    # for its own cp/mv/tee/rm dispatch, keeping a second, weaker copy of
+    # the same decision here would have silently reintroduced the exact
+    # indirection bypass F044 fixes, just for sed specifically instead of
+    # cp/mv/tee/rm.
+    pre_separator_args = args[: _separator_index(args)]
+    # The two presence-checking any() guards below only scan FLAG
+    # positions, not positions consumed as a preceding -e/-f/--expression/
+    # --file's own VALUE -- mirrors the main token-walking loop's own skip
+    # logic further down, so a value that merely LOOKS like a flag can't
+    # be misread as one. Without this, `sed -f -i.bak file` (a real file
+    # named "-i.bak" used as -f's own script-file argument, confirmed
+    # against real gsed: prints to stdout, unmodified, no in-place edit
+    # happens at all) was wrongly treated as specifying -i, over-denying
+    # an ordinary read command that writes nothing (found by adversarial
+    # review of PR #52, round 4; folded into this fix per that review's
+    # own note).
+    flag_positions = []
+    fi = 0
+    while fi < len(pre_separator_args):
+        flag_positions.append(fi)
+        if _sed_consumes_next_as_script(_flag_view(pre_separator_args[fi])):
+            fi += 2
+        else:
+            fi += 1
+    if not any(
+        IN_PLACE_CLUSTER_PATTERN.match(_flag_view(pre_separator_args[idx]))
+        or _sed_long_flag_name(_flag_view(pre_separator_args[idx])) == "--in-place"
+        for idx in flag_positions
+    ):
+        return []
+    has_explicit_script = any(
+        _flag_view(pre_separator_args[idx]) in SED_SCRIPT_VALUE_FLAGS
+        or _sed_long_flag_name(_flag_view(pre_separator_args[idx]))
+        in ("--expression", "--file")
+        for idx in flag_positions
+    )
+    targets = []
+    consumed_implicit_script = has_explicit_script
+    past_separator = False
+    i = 0
+    while i < len(args):
+        tok = args[i]
+        view = _flag_view(tok)
+        if view == "--" and not past_separator:
+            past_separator = True
+            i += 1
+            continue
+        if not past_separator:
+            if _sed_consumes_next_as_script(view):
+                i += 2
+                continue
+            if view == "-i" and i + 1 < len(args) and _flag_view(args[i + 1]) == "":
+                i += 2
+                continue
+            if view.startswith("-"):
+                i += 1
+                continue
+        if not consumed_implicit_script:
+            consumed_implicit_script = True
+            i += 1
+            continue
+        targets.append(tok)
+        i += 1
+    return targets
+
+
+def strip_redirects(segment):
+    # Removes every real (mask-aware) >/>> operator, its OPTIONAL leading
+    # file-descriptor digits, and its target from the segment, leaving only
+    # the command and its own arguments -- so cp/mv/tee/rm/sed-i target
+    # extraction below doesn't misread a trailing redirect's operator or
+    # target as one of the COMMAND's OWN arguments (found by adversarial
+    # review of PR #46, round 1). The fd digits (`2>`, `1>`) are matched
+    # ONLY when they form a complete token of their own (whitespace or
+    # start-of-segment immediately before them) -- a real bash fd prefix is
+    # a word consisting ENTIRELY of digits, so a real argument that merely
+    # ENDS in a digit right before an unprefixed redirect (`file2> out`,
+    # where "file2" is one whole word) must not have that trailing digit
+    # mistaken for an fd number and stripped off with it: `echo abc2> out`
+    # writes "abc2" in real bash, not "abc" (found by adversarial review of
+    # PR #46, round 2 -- an earlier version's `>>?\s*[^\s<>|&;]+` pattern
+    # left a bare digit token behind whenever the redirect had an explicit
+    # fd prefix, which the command extractors then misread as a real write
+    # target). ONLY the optional digit run is anchored to a token boundary
+    # (as its own capture-free group), not the whole match -- an earlier
+    # version of this fix anchored the ENTIRE match, which made a BARE ">"
+    # (no fd prefix at all) fail to match unless it was ALSO preceded by
+    # whitespace, so a real redirect glued directly onto the end of a
+    # command argument with no separating space (`cp a b> log`, real bash:
+    # this writes to "log" and reads/copies from "a"/"b") was never stripped
+    # at all -- cp/mv's own destination detection then fell through to the
+    # UNSTRIPPED trailing text and picked the redirect's own in-scope target
+    # instead of the real, possibly out-of-scope destination, reintroducing
+    # the exact masking bug F024 exists to close (found by adversarial
+    # review of PR #46, round 3). A leading alternative strips the
+    # fd-duplication form `[n]>&<digits-or-dash>` (`2>&1`, `>&2`, `2>&-`)
+    # too: real bash never writes to a file for THIS specific, digit-or-
+    # dash-only form (it duplicates one fd onto another, or closes one), so
+    # it can never be a real write target, but left unstripped it survived
+    # into command_tokens as a bogus flagless "target" once segments_of()
+    # stopped fragmenting it (F030) -- its own `[^\s<>|&;]+` target-char
+    # class already excludes "&", so this form never matched the plain-
+    # redirect alternative either. Deliberately narrower than `>&word` for
+    # any word: bash's `>&word` with a NON-numeric, non-"-" word (e.g.
+    # `>&outfile.txt`) is `&>word`, an ordinary FILE redirect, not fd
+    # duplication -- confirmed against real bash (`echo HELLO >&outfile.txt`
+    # creates outfile.txt) -- so widening this alternative's `(?:\d+|-)` to
+    # match any word would silently create a NEW unstripped-redirect gap,
+    # the opposite of this fix's purpose (found by adversarial review of
+    # PR #53, round 1). A THIRD alternative below closes that gap properly
+    # (F036): `>&word` is matched and removed like any other real redirect,
+    # regardless of whether `word` turns out to be digits/"-"
+    # (redirect_targets() is what decides whether a given occurrence is a
+    # real target worth denying; this function's only job is removing
+    # redirect text so the command's OWN arguments parse cleanly, so the
+    # two functions can disagree about "is this fd-dup or a file" without a
+    # bug -- stripping a genuine `>&1` here too is harmless, since the
+    # plain fd-dup alternative already strips it first at the same
+    # position). This alternative DOES take the same optional FD_PREFIX as
+    # the plain-redirect alternative -- an earlier version of this fix
+    # omitted it, on the reasoning that an fd-prefixed word form
+    # (`2>&outfile.txt`) is always a hard bash syntax error with nothing to
+    # strip. That reasoning is right for fd 0, 2, and 3+, but wrong for fd
+    # 1: `1>&outfile.txt` is a genuine, long-standing bash extension that
+    # writes the file (confirmed against real bash and bash's own
+    # `redir.c`, which special-cases `redirector == 1`) -- without
+    # FD_PREFIX here, the leading "1" survived unstripped as a bogus
+    # flagless argument, which could shadow the real target in a
+    # last-flagless-token context (cp/mv) or just report the wrong target
+    # in a denial (found by adversarial review of PR #63, round 1). The
+    # fd-dup alternative's own `(?:\d+|-)` is anchored with a trailing
+    # negative lookahead ensuring it only matches a COMPLETE digit/dash
+    # word, not a prefix of a longer one -- without it, `>&12abc` (a real
+    # file redirect to "12abc", confirmed against real bash) let the greedy
+    # `\d+` consume just "12", stripping only `>&12` and leaving "abc" as a
+    # phantom trailing argument; the fallback `>&word` alternative below now
+    # correctly claims the whole match once the fd-dup alternative can't
+    # (found by the same review round).
+    masked = mask_quotes(segment)
+    kept = []
+    last = 0
+    FD_PREFIX = r"(?:(?:^|(?<=\s))\d+)?"
+    pattern = (
+        FD_PREFIX + r">&(?:\d+|-)(?![^\s<>|&;])|"
+        + FD_PREFIX + r">&\s*[^\s<>|&;]+|"
+        + FD_PREFIX + r">>?\s*[^\s<>|&;]+"
+    )
+    for m in re.finditer(pattern, masked):
+        kept.append(segment[last:m.start()])
+        last = m.end()
+    kept.append(segment[last:])
+    return "".join(kept)
+
+
+def split_tokens(segment):
+    # Splits a command segment into whitespace-delimited tokens, but
+    # whitespace INSIDE a quoted span is not a token boundary (exactly like
+    # the shell): \S+ runs are found in a quote-MASKED copy (so masked-out
+    # quoted whitespace can't match \S, keeping a quoted multi-word string
+    # as one run) but sliced from the ORIGINAL segment -- the same
+    # mask-then-slice discipline segments_of()/redirect_targets() already
+    # use one level up, ported from commit-gate.sh.template's split_tokens()
+    # (F011/OVI-64). Before this, write_targets() fed command_tokens a plain
+    # `.split()`, which shattered a quoted target containing a space into
+    # TWO pseudo-tokens: `rm "my file.txt"` was wrongly DENIED naming just
+    # "file.txt" (the quotes stripped from each half independently, no
+    # single real path ever reconstructed), and worse, `cp a "out-of-scope
+    # in-scope-looking-tail"` was wrongly ALLOWED, since cp/mv's own
+    # last-flagless-token destination logic picked the tail fragment -- a
+    # reachable fail-open, not just a cosmetic misnaming (found by
+    # adversarial review of PR #51, F028; F028 was originally filed
+    # against a DIFFERENT function, redirect_target()'s own regex, which
+    # F024 closed as a side effect before this feature was picked up --
+    # this second, still-open root cause is the one F028's own "Likely fix"
+    # note already named).
+    masked = mask_quotes(segment)
+    return [segment[m.start():m.end()] for m in re.finditer(r"\S+", masked)]
+
+
+# Wrapper commands that immediately exec the NEXT real command name given to
+# them, rather than being the write-relevant command themselves (F044).
+# xargs is included even though its full semantics (building an argv from
+# stdin, possibly with an unrelated leading command) are more elaborate than
+# the other three -- confirmed against real bash that `xargs rm` (piped a
+# filename on stdin) genuinely runs rm, and treating "xargs CMD ..." as "this
+# segment can end up running CMD ..." is the same order of approximation
+# this hook already makes elsewhere (best-effort, not a full shell parser).
+# Other real exec-wrappers (nohup, exec, nice, time, setsid, stdbuf, timeout,
+# busybox, doas) are NOT included -- a documented, deliberate residual (not
+# an oversight): the feature this set closes named exactly these four,
+# extending it further is a scope decision for a future feature, not silently
+# assumed complete here (found by adversarial review of PR #76).
+COMMAND_WRAPPERS = ("sudo", "env", "command", "xargs")
+
+# Each wrapper's own flags (short AND long form) that take a value as a
+# SEPARATE argument token (as opposed to attached, e.g. "-uroot"/"-n1"/
+# "--user=root", which the walk below already handles correctly without
+# this set, since an attached value is part of the SAME token and never
+# needs an extra one consumed). Without this, `sudo -u root rm file`,
+# `xargs -n 1 rm file`, and `env -u FOO rm file` were all wrongly treated
+# as invoking the FLAG'S OWN VALUE ("root"/"1"/"FOO") as the command name,
+# silently allowing the real rm -- confirmed against real bash that
+# `env -u FOO rm`/`echo f | xargs -n 1 rm` both genuinely delete the
+# target file (found by adversarial review of PR #76 round 2, which noted
+# the round-1 comment's claim that wrapper flags are "fully skipped" was
+# true only for the attached form). Round 2 of that same review confirmed
+# TWO further live gaps a short-flag-only set missed: a CLUSTERED short
+# flag ending in a value-taking one (`env -iu FOO rm`, `xargs -0n 1 rm`
+# -- handled by _is_wrapper_value_flag()'s own cluster check below, not by
+# widening this set) and a LONG option given its value as a separate
+# argument (`xargs --max-args 1 rm`, `env --unset FOO rm` -- handled by
+# including the long form directly in this set, same as the short one).
+# Sourced from this platform's own `sudo`/`env`/`xargs` --help output
+# (BSD/macOS, this repo's stated platform) plus the reviewer's own
+# cross-checked GNU-coreutils list; not independently verified against
+# every GNU/Linux coreutils version or every possible long-option spelling
+# -- a disclosed, not silent, residual for any flag this set is missing.
+WRAPPER_VALUE_FLAGS = {
+    "sudo": (
+        "-u", "--user", "-g", "--group", "-h", "--host", "-p", "--prompt",
+        "-r", "-t", "-U", "-C", "--close-from", "-D", "--chdir",
+        "-R", "--chroot", "-T",
+    ),
+    "env": ("-u", "--unset", "-C", "--chdir", "-S", "--split-string", "-P"),
+    "xargs": (
+        "-E", "--eof", "-I", "--replace", "-J", "-L", "--max-lines",
+        "-n", "--max-args", "-P", "--max-procs", "-s", "--max-chars",
+        "-a", "--arg-file", "-d", "--delimiter",
+    ),
+    "command": (),
+}
+
+VAR_ASSIGNMENT_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def _is_wrapper_value_flag(view, value_flags):
+    # True if `view` is a flag position that consumes the NEXT token as a
+    # separate-argument value: either an exact match against `value_flags`
+    # (covers both a bare short flag like "-u" and any long option
+    # registered there like "--user"), or a CLUSTERED short-flag token
+    # (e.g. "-iu") whose LAST character is itself one of the short flags
+    # in `value_flags` -- confirmed against real bash that `env -iu FOO`
+    # and `xargs -0n 1` both genuinely consume the following token as the
+    # clustered flag's value, the same way a bare "-u"/"-n" would (F044
+    # round 3, adversarial review of PR #76 round 2).
+    if view in value_flags:
+        return True
+    if view.startswith("--") or not view.startswith("-") or len(view) <= 2:
+        return False
+    last_flag = "-" + view[-1]
+    return last_flag in value_flags
+
+
+def _resolve_command_tokens(tokens):
+    # Returns (command_name, args) -- the REAL write-relevant command name
+    # this segment ultimately invokes, and every token after it -- resolving
+    # three kinds of indirection real bash honors but the bare
+    # `command_tokens[0] in (...)` comparison this replaced did not (F044):
+    # a path-form command name (`/bin/rm`, `./rm`; resolved via
+    # os.path.basename(), the same mechanism commit-gate.sh's is_git_token()
+    # already uses for git, extended here to cp/mv/tee/rm/sed), one or more
+    # leading `VAR=value` environment-assignment prefixes (`FOO=1 rm file`,
+    # a real bash feature for setting a variable for one command, not
+    # adversarial), and the wrapper commands in COMMAND_WRAPPERS (each of
+    # which is followed by its OWN leading flags, also skipped, before the
+    # real command name). Confirmed live against real bash that every one of
+    # these forms genuinely runs the wrapped/indirected command: `/bin/rm`,
+    # `FOO=1 rm`, `command rm`, `env rm`, and `xargs rm` (piped a filename)
+    # all deleted the target file; `sudo rm` is the same mechanism as
+    # `command`/`env` (immediate exec of the given argv) and not separately
+    # re-verified here since this repo's own sandbox has no sudo access.
+    # Bounded by len(tokens) (not an unconditional while True) so a
+    # pathological all-wrapper token list (e.g. "env env env env") can never
+    # loop indefinitely -- it simply resolves to (None, []) once every token
+    # is consumed without finding a real command name, the same "not a
+    # recognized write command" outcome as any other unrecognized name.
+    i = 0
+    n = len(tokens)
+    while i < n:
+        view = _flag_view(tokens[i])
+        if VAR_ASSIGNMENT_PATTERN.match(view):
+            i += 1
+            continue
+        name = os.path.basename(view.lstrip("(\\"))
+        if name in COMMAND_WRAPPERS:
+            value_flags = WRAPPER_VALUE_FLAGS.get(name, ())
+            i += 1
+            while i < n and _flag_view(tokens[i]).startswith("-"):
+                if _is_wrapper_value_flag(_flag_view(tokens[i]), value_flags) and i + 1 < n:
+                    i += 2
+                else:
+                    i += 1
+            continue
+        return name, tokens[i + 1:]
+    return None, []
+
+
+def write_targets(segment):
+    # Returns EVERY real write target in a segment, not just one -- a command
+    # can write to multiple targets at once (`rm a b`, `tee f1 f2`, `sed -i`
+    # given multiple files, or multiple redirects on one line), and checking
+    # only one (an earlier version checked only the last) let an out-of-scope
+    # target earlier in the segment go unchecked (F024). Redirect targets and
+    # command-type targets (cp/mv/tee/rm/sed -i) are BOTH collected, not
+    # treated as alternatives -- an earlier version only checked command-type
+    # targets when the segment had NO redirect at all, so a real write
+    # command followed by an unrelated trailing redirect (`tee out-of-scope >
+    # in-scope-log`) only ever had the redirect's target checked, masking the
+    # command's own real target (found by adversarial review of PR #46).
+    targets = redirect_targets(segment)
+    command_tokens = split_tokens(strip_redirects(segment))
+    if command_tokens:
+        # _resolve_command_tokens() (F044) handles BOTH the quoting/escaping
+        # indirection F040 fixed (a backslash-escaped or quoted command name
+        # like `\rm src/other/f.txt`, `"rm" src/other/f.txt` -- ordinary
+        # everyday shell, not adversarial, since real bash runs it as plain
+        # rm regardless) AND path-form/wrapper-command/env-assignment
+        # indirection (`/bin/rm`, `sudo rm`, `FOO=1 rm`, ... -- see its own
+        # comment). This is a command-NAME recognition check, not a target-
+        # VALUE extraction, so there is no double-unquote risk: the command
+        # name itself is never returned as a target.
+        command_name, args = _resolve_command_tokens(command_tokens)
+        if command_name in ("cp", "mv"):
+            targets = targets + cp_mv_targets(args)
+        elif command_name in ("tee", "rm"):
+            targets = targets + all_flagless_tokens(args)
+        elif command_name == "sed":
+            targets = targets + sed_inplace_targets(args)
+    # Truncate at the first embedded NUL, matching real bash: a NUL byte
+    # inside a word (e.g. from a $'...' escape like \x00/\000/\c@/\U00000000)
+    # can never survive into a real argv element, since argv strings are
+    # NUL-terminated C strings -- real bash silently truncates the WORD
+    # there when building the target filename. Confirmed against real bash:
+    # `echo x > $'src/other/bad.txt\x00/../../parser/ok.txt'` genuinely
+    # creates "src/other/bad.txt" (truncated at the NUL, out of scope), but
+    # this hook previously processed the WHOLE string including everything
+    # after the NUL, resolving the "../.." past it and landing on the
+    # in-scope-looking "src/parser/ok.txt" -- wrongly ALLOWED (F039,
+    # confirmed pre-existing on main before F033 too, not a regression;
+    # F033 just made it more directly reachable once \x00 genuinely decodes
+    # to a real NUL byte instead of staying inert 4-character text).
+    # Applied HERE, after unquote_token()'s own decoding is complete and
+    # before normalize()/the scope-prefix comparison ever see the target,
+    # so it covers every decode route (F031's backslash-unescape, F033's
+    # \x/\nnn, F038's \c/\u/\U) that could produce an embedded NUL, not
+    # just one specific escape spelling.
+    #
+    # A decoder exception here is NOT caught locally (F042): main()'s own
+    # per-segment try/except is the single place that decides what happens
+    # on ANY analysis failure, covering this call and everything else that
+    # processes this segment's targets -- see main()'s own comment for why
+    # an EARLIER version of this fix tried a per-target raw-text fallback
+    # here instead, and why that was a real bypass, not a residual.
+    return [unquote_token(t).split("\0", 1)[0] for t in targets]
+
+
+def normalize(path, project_root):
+    # Strips the project-root prefix, then resolves "."/".." segments so a
+    # write target that escapes an allowed directory via traversal
+    # (`src/allowed/../forbidden/x.txt`, which real bash resolves to
+    # src/forbidden/x.txt) no longer merely STARTS WITH the allowed prefix
+    # string -- an earlier version returned the path unresolved, so the
+    # scope-prefix check (a bare .startswith()) and the lead-owned exact-
+    # match check (both read this same return value) were both fooled by
+    # traversal. A path that resolves to something outside the project
+    # entirely (more ".." than real leading segments, e.g. "../../etc/x")
+    # is left with a leading ".." by os.path.normpath, which correctly
+    # never matches any scope pattern (found by adversarial review of PR
+    # #42/F023, reported as F026). os.path.normpath also strips a trailing
+    # "/", which this hook's directory-style scope patterns (and a `cp -t
+    # DIR/` destination) rely on for prefix matching -- restored if the
+    # pre-normalize path had one, so a destination that IS a scope
+    # directory (e.g. "src/parser/") still compares equal to the pattern
+    # itself, not just its own strict subdirectories. os.path.normpath is
+    # purely lexical (string manipulation only, no filesystem access) --
+    # if a scope directory contains a symlink, a target that traverses
+    # THROUGH it (e.g. "src/allowed/link/../escape.txt" where "link" points
+    # outside "src/allowed/") resolves lexically to "src/allowed/escape.txt"
+    # (in scope) while the real write, after the kernel follows the
+    # symlink, lands somewhere else entirely. Accepted: this hook has no
+    # filesystem access either (it only ever sees the command string), so
+    # resolving symlinks would need to run in a live checkout and still
+    # couldn't know what the symlink pointed to WHEN the write actually
+    # happens; not a regression versus the pre-F026 behavior, which had no
+    # traversal resolution at all (found by adversarial review of PR #48,
+    # round 1).
+    if path.startswith(project_root + "/"):
+        path = path[len(project_root) + 1:]
+    resolved = os.path.normpath(path)
+    if path.endswith("/") and not resolved.endswith("/"):
+        resolved += "/"
+    return resolved
+
+
+def main():
+    command = sys.argv[1]
+    project_root = sys.argv[2]
+    patterns = sys.argv[3:]
+    for segment in segments_of(command):
+        try:
+            if _check_segment(segment, project_root, patterns):
+                return
+        except Exception:
+            # ANY exception anywhere while analyzing this segment -- a
+            # decoder crash inside write_targets() (still none currently
+            # known; F038 rounds 2-3 closed the only two ever found, this
+            # is defense-in-depth against the next one), or anywhere else
+            # in normalize()/is_dev_exempt()/the scope-comparison below --
+            # means denying UNCONDITIONALLY, never comparing any
+            # attacker-controlled fallback text against scope (F042).
+            #
+            # An earlier version of this fix instead fell back to treating
+            # raw, undecoded text (either one target's raw token, or the
+            # whole raw segment) as if it were a real path to compare
+            # against scope patterns, reasoning that a still-escaped
+            # string "essentially never" matches a real scope-directory
+            # prefix. That reasoning was FALSE: the attacker chooses the
+            # raw text, and can trivially place an in-scope-looking prefix
+            # (e.g. "src/parser/") immediately before the crash-triggering
+            # escape, making the exact SAME construction this fix's own
+            # tests used to prove "processing continues past the crash"
+            # into a genuine bypass instead -- confirmed live (adversarial
+            # review of PR #73): `src/parser/$'\Qx' > src/other/evil.txt`
+            # silently ALLOWed the real out-of-scope redirect, because the
+            # raw segment fallback text happened to start with "src/parser/".
+            # Comparing ANY fallback text against scope patterns is
+            # unsound in general, since the fallback text is exactly the
+            # part of the input that couldn't be safely analyzed -- there
+            # is no text to fall back to that isn't also attacker-
+            # controlled. Denying unconditionally removes that lever
+            # entirely: a segment (or anything in it) that can't be
+            # analyzed is always treated as a violation, full stop, same
+            # as this hook already refuses to run rather than guess when
+            # PROJECT_ROOT/the scope file/the tool-input JSON can't be
+            # resolved (see this file's own header). This also closes a
+            # SEPARATE gap the per-target/per-segment split had: the
+            # final `print(f"Bash write to '{norm}' is outside...")` call
+            # below crashes with UnicodeEncodeError if `norm` ever
+            # contains a raw lone surrogate (the actual F038 round 2
+            # incident -- a surrogate reaching PRINT, not a ValueError
+            # from chr() itself, which F038's own fix already prevents by
+            # returning literal escape text instead of a real surrogate
+            # character) -- that print() call sits INSIDE this same
+            # try/except now, not in a separate uncovered path.
+            #
+            # A one-line stderr note is added here (F042 round 2): before
+            # this fix, ANY decoder crash left a visible Python traceback
+            # on stderr; the earlier per-target/per-segment fallback made
+            # that failure completely silent, removing the only signal
+            # that anything went wrong (found by adversarial review of PR
+            # #73). stderr is never captured into DENY_REASON, so this
+            # costs nothing operationally.
+            print(f"enforce-scope: segment analysis failed, denying: {segment!r}", file=sys.stderr)
+            print(
+                f"Bash write target in {segment!r} could not be safely analyzed "
+                f"(best-effort, pattern-based check; treating as outside your "
+                f"assigned scope). {ANNOTATION}"
+            )
+            return
+
+
+def _check_segment(segment, project_root, patterns):
+    # Returns True once a real scope decision has been printed for this
+    # segment (main() must stop entirely at that point, not keep scanning
+    # later segments) -- False means this segment raised no violation, so
+    # main()'s own loop should move on to the next one.
+    for target in write_targets(segment):
+        norm = normalize(target, project_root)
+        # normalize() runs before this check so equivalent spellings of
+        # an exempt path (`/dev//null`, `/dev/./null`)
+        # are recognized as the same exact string is_dev_exempt() checks
+        # against -- NOT to prevent traversal from laundering a real
+        # out-of-scope path INTO looking exempt: is_dev_exempt() is
+        # exact-set/pattern membership, not a prefix match, so
+        # `/dev/../etc/passwd` (which resolves to `/etc/passwd`) was
+        # never going to match regardless of ordering -- confirmed by
+        # mutation-testing this ordering claim itself (moving the check
+        # before normalize() changed zero assertions). An earlier
+        # version of this comment claimed the ordering was load-bearing
+        # against traversal laundering; that was true of round 1's
+        # broad `startswith("/dev/")` prefix check, but became false
+        # once this round narrowed the check to exact membership --
+        # found by adversarial review of PR #53, round 2. Ordering WOULD
+        # become load-bearing again if DEV_EXEMPT_EXACT/DEV_FD_PATTERN
+        # were ever widened back to a prefix-style match.
+        if is_dev_exempt(norm):
+            continue
+        if norm in LEAD_OWNED:
+            print(f"state file is lead-owned; report via SendMessage instead. {ANNOTATION}")
+            return True
+        if not any(norm.startswith(p) for p in patterns):
+            print(
+                f"Bash write to '{norm}' is outside your assigned scope "
+                f"(best-effort, pattern-based check; see .claude/teammate-scope.txt). "
+                f"{ANNOTATION}"
+            )
+            return True
+    return False
+
+
+main()
+PYEOF
+)
+
+    if [ -n "$DENY_REASON" ]; then
+        deny_json "$DENY_REASON"
     fi
-done < "$SCOPE_FILE"
+fi
 
-echo "Edit blocked: $FILE_PATH is outside your assigned scope."
-echo "Your scope (from $SCOPE_FILE):"
-cat "$SCOPE_FILE" | grep -v '^#' | grep -v '^$'
-echo ""
-echo "If you need access to this file, message the lead: SendMessage({ type: \"message\", recipient: \"team-lead\", content: \"Need access to $FILE_PATH because [reason].\" })"
-exit 2
+exit 0

--- a/.claude/hooks/harness_state.py
+++ b/.claude/hooks/harness_state.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+
+CLAIMABLE_STATUSES = ("pending", "failed")
+
+
+def load_valid_features(path):
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except (OSError, ValueError) as exc:
+        print(f"harness_state: cannot parse {path}: {exc}", file=sys.stderr)
+        return []
+    features = data.get("features", []) if isinstance(data, dict) else []
+    valid = []
+    for entry in features:
+        try:
+            entry.get("status")
+        except AttributeError:
+            print(f"harness_state: skipping malformed feature entry: {entry!r}", file=sys.stderr)
+            continue
+        valid.append(entry)
+    return valid
+
+
+def compute_claimable(valid):
+    passing_ids = {f.get("id") for f in valid if f.get("status") == "passing"}
+    claimable = []
+    for f in valid:
+        try:
+            deps_ok = all(dep in passing_ids for dep in f.get("depends_on") or [])
+        except TypeError as exc:
+            print(
+                f"harness_state: skipping malformed feature entry {f.get('id')!r}: {exc}",
+                file=sys.stderr,
+            )
+            continue
+        if f.get("status") in CLAIMABLE_STATUSES and deps_ok:
+            claimable.append(f)
+    return claimable
+
+
+def write_atomic_tmp(path, data):
+    tmp_path = path + ".tmp"
+    try:
+        os.remove(tmp_path)
+    except OSError:
+        pass
+    try:
+        with open(tmp_path, "w") as fh:
+            json.dump(data, fh, indent=2)
+            fh.write("\n")
+    except OSError as exc:
+        print(f"harness_state: could not write {tmp_path}: {exc}", file=sys.stderr)
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+        return False
+    return True
+
+
+def cmd_load(path):
+    print(json.dumps(load_valid_features(path)))
+    return 0
+
+
+def cmd_next_claimable(path):
+    claimable = compute_claimable(load_valid_features(path))
+    if not claimable:
+        print("no claimable feature")
+        return 0
+    claimable.sort(key=lambda f: f.get("priority", 999))
+    print(json.dumps({"count": len(claimable), "next": claimable[0]}))
+    return 0
+
+
+def cmd_counts(path):
+    valid = load_valid_features(path)
+    passing = sum(1 for f in valid if f.get("status") == "passing")
+    in_progress = [f.get("id") for f in valid if f.get("status") == "in-progress"]
+    print(json.dumps({"passing": passing, "total": len(valid), "in_progress": in_progress}))
+    return 0
+
+
+def cmd_increment_correction_cycles(path, feature_id):
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except (OSError, ValueError) as exc:
+        print(f"harness_state: cannot parse {path}: {exc}", file=sys.stderr)
+        return 1
+    features = data.get("features", []) if isinstance(data, dict) else []
+    match = next(
+        (f for f in features if isinstance(f, dict) and f.get("id") == feature_id), None
+    )
+    if match is None:
+        print(f"harness_state: no feature with id {feature_id!r}", file=sys.stderr)
+        return 3
+    if match.get("status") != "in-progress":
+        return 0
+    current = match.get("correction_cycles")
+    match["correction_cycles"] = (current if current is not None else 0) + 1
+    return 0 if write_atomic_tmp(path, data) else 1
+
+
+USAGE = (
+    "usage: harness_state.py <load|next-claimable|counts|increment-correction-cycles> "
+    "<features.json> [feature_id]"
+)
+
+
+def main(argv):
+    if len(argv) < 3:
+        print(USAGE, file=sys.stderr)
+        return 2
+    verb, path = argv[1], argv[2]
+    if verb == "load":
+        return cmd_load(path)
+    if verb == "next-claimable":
+        return cmd_next_claimable(path)
+    if verb == "counts":
+        return cmd_counts(path)
+    if verb == "increment-correction-cycles":
+        if len(argv) < 4:
+            print(USAGE, file=sys.stderr)
+            return 2
+        return cmd_increment_correction_cycles(path, argv[3])
+    print(f"harness_state: unknown verb {verb!r}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/hooks/verify-git-identity.sh
+++ b/.claude/hooks/verify-git-identity.sh
@@ -3,9 +3,17 @@
 # Runs before Bash tool calls that contain git push/pull/clone.
 # Exit code 0 = allow
 # Exit code 2 = block (identity mismatch)
+# Failure posture: fail-open. Missing harness.json, or a harness.json with no recorded
+# git_identity, allows the command (exit 0) rather than blocking it; only an actually
+# detected mismatch blocks (exit 2). Residual: an incomplete harness.json silently
+# disables identity verification.
 
 # Read hook input from stdin
 INPUT=$(cat)
+
+# Anchor to the project root so the hook works from any working directory
+PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+cd "$PROJECT_ROOT" 2>/dev/null || exit 0
 
 # Extract the command from tool input
 COMMAND=$(echo "$INPUT" | python3 -c "

--- a/.claude/hooks/verify-task-quality.sh
+++ b/.claude/hooks/verify-task-quality.sh
@@ -9,10 +9,17 @@
 #   Stage 2: full_test  — complete suite with coverage
 # Failing at Stage 1 avoids the cost of a full test run.
 # correction_cycles is incremented in features.json on any rejection.
+# Formatting: this hook's features.json writes own indent=2, a trailing
+# newline, and atomic replacement (.tmp + mv); only the targeted feature
+# is modified.
+# Failure posture: fail-closed for the core gate -- a missing .harness/init.sh or any
+# smoke/full test failure rejects completion (exit 2). Fail-open/best-effort for the
+# correction_cycles bookkeeping side effect: a harness_state.py write failure there is
+# noted on stderr but never changes the accept/reject verdict.
 
 set -euo pipefail
 
-PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 cd "$PROJECT_ROOT"
 
 # Read hook input from stdin
@@ -40,29 +47,26 @@ if [ ! -f ".harness/init.sh" ]; then
     exit 2
 fi
 
-# Increment correction_cycles for all in-progress features.
-# This tracks how many times the quality gate rejected completion —
-# useful for retrospectives and dynamic model selection.
+# Increment correction_cycles for the targeted in-progress feature via the
+# shared state module. This tracks how many times the quality gate rejected
+# completion — useful for retrospectives and dynamic model selection.
+STATE_MODULE=".claude/hooks/harness_state.py"
 increment_correction_cycles() {
-    if [ -f ".harness/features.json" ]; then
-        python3 - "$FEATURE_ID" <<'PYEOF'
-import json, sys
-target_id = sys.argv[1] if len(sys.argv) > 1 and sys.argv[1] else None
-try:
-    with open('.harness/features.json', 'r') as f:
-        data = json.load(f)
-    changed = False
-    for feature in data.get('features', []):
-        if feature.get('status') == 'in-progress':
-            if target_id is None or feature.get('id') == target_id:
-                feature['correction_cycles'] = feature.get('correction_cycles', 0) + 1
-                changed = True
-    if changed:
-        with open('.harness/features.json', 'w') as f:
-            json.dump(data, f, indent=2)
-except Exception as e:
-    pass  # Don't fail the hook on JSON errors
-PYEOF
+    if [ -z "$FEATURE_ID" ]; then
+        echo "verify-task-quality: no feature_id in task metadata or subject;" \
+             "skipping the correction_cycles update." >&2
+        return 0
+    fi
+    if [ ! -f ".harness/features.json" ]; then
+        return 0
+    fi
+    # Clear any tmp orphaned by an earlier killed run: the guarded mv below
+    # must only ever promote a tmp that THIS invocation wrote.
+    rm -f .harness/features.json.tmp
+    python3 "$STATE_MODULE" increment-correction-cycles .harness/features.json "$FEATURE_ID" \
+        2>&1 || true
+    if [ -f ".harness/features.json.tmp" ]; then
+        mv .harness/features.json.tmp .harness/features.json
     fi
 }
 
@@ -87,6 +91,70 @@ FULL_OUTPUT=$(bash .harness/init.sh full_test 2>&1) || {
     increment_correction_cycles
     exit 2
 }
+
+# Coverage target gate: compare the targeted feature's own recorded `coverage`
+# number against its `coverage_target` (falls back to 95). Skipped entirely when
+# coverage isn't a number yet (e.g. this repo's own descriptive strings) --
+# proportional: don't punish projects without numeric coverage tooling.
+if [ -n "$FEATURE_ID" ] && [ -f ".harness/features.json" ]; then
+    COVERAGE_RESULT=$(python3 - ".harness/features.json" "$FEATURE_ID" <<'PYEOF'
+import json
+import sys
+
+path, feature_id = sys.argv[1], sys.argv[2]
+with open(path) as fh:
+    data = json.load(fh)
+match = next((f for f in data.get("features", []) if f.get("id") == feature_id), None)
+if match is None:
+    sys.exit(0)
+coverage = match.get("coverage")
+if not isinstance(coverage, (int, float)) or isinstance(coverage, bool):
+    sys.exit(0)
+target = match.get("coverage_target")
+if not isinstance(target, int) or isinstance(target, bool):
+    target = 95
+if coverage < target:
+    print(f"{coverage}|{target}")
+PYEOF
+)
+    if [ -n "$COVERAGE_RESULT" ]; then
+        ACHIEVED="${COVERAGE_RESULT%%|*}"
+        TARGET="${COVERAGE_RESULT##*|}"
+        echo "Task rejected: coverage $ACHIEVED% is below the target $TARGET%."
+        increment_correction_cycles
+        exit 2
+    fi
+fi
+
+# Claim-matched proof: warn (never block) when this feature accepts with no
+# proof recorded, or with proof whose evidence_type doesn't match its declared
+# qa_binding. Reads both fields directly off the feature object -- no external
+# lookup, no re-parsing of prose.
+if [ -n "$FEATURE_ID" ] && [ -f ".harness/features.json" ]; then
+    PROOF_WARNING=$(python3 - ".harness/features.json" "$FEATURE_ID" <<'PYEOF'
+import json
+import sys
+
+path, feature_id = sys.argv[1], sys.argv[2]
+with open(path) as fh:
+    data = json.load(fh)
+match = next((f for f in data.get("features", []) if f.get("id") == feature_id), None)
+if match is None:
+    sys.exit(0)
+proof = match.get("proof")
+qa_binding = match.get("qa_binding")
+if not proof:
+    print(f"WARN: {feature_id} accepted with no proof recorded.")
+elif qa_binding and proof.get("evidence_type") != qa_binding:
+    print(
+        f"WARN: {feature_id}'s proof.evidence_type "
+        f"'{proof.get('evidence_type')}' does not match its declared "
+        f"qa_binding '{qa_binding}'. Fix the proof or the binding."
+    )
+PYEOF
+)
+    [ -n "$PROOF_WARNING" ] && echo "$PROOF_WARNING"
+fi
 
 # Remind about stale in-progress features
 if [ -f ".harness/features.json" ]; then

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -1,7 +1,7 @@
 {
   "project": "vv-claude-harness",
   "created": "2026-07-22",
-  "total_features": 54,
+  "total_features": 55,
   "passing": 39,
   "features": [
     {
@@ -1547,6 +1547,29 @@
       "approaches_tried": [],
       "failure_reason": null,
       "discovered_via": "F047",
+      "spec": null
+    },
+    {
+      "id": "F055",
+      "description": "check-remaining-tasks.sh.template's TeammateIdle guidance has no concept of teammate ROLE: it re-nudges any idle teammate toward the next claimable feature for as long as ANY feature is claimable, regardless of whether that teammate is an implementer (for whom this is correct) or a reviewer/other non-implementer role with no further review assigned (for whom claiming an unrelated feature would itself be scope creep under the agent-teams protocol). CONFIRMED live, twice: review-pr69-f040 hit this originally (leading to F046's filing), and review-pr81-f047 hit it again after F046's stdout-to-stderr fix was live and working correctly -- the hook fired exactly to spec (rc=2, correct guidance on stderr) but a reviewer with a completed, delivered review had no way to signal 'done, nothing claimable is mine' short of messaging the lead directly or violating scope by self-claiming an implementation feature. The TeammateIdle payload itself carries no teammate identity (an existing, confirmed constraint), so the hook cannot distinguish roles on its own -- role-aware behavior would need to live in the agent definitions (e.g. a reviewer's own definition recognizing 'my assignment is done, message the lead and go idle' rather than treating check-remaining-tasks.sh's nudge as instruction to claim new work), not in this shared hook.",
+      "priority": 38,
+      "status": "pending",
+      "scope": [
+        "agents/reviewer.md",
+        "skills/harness-init/check-remaining-tasks.sh.template"
+      ],
+      "depends_on": [
+        "F046"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Raised by review-pr81-f047 (not filed by them -- explicitly deferred the filing decision to the lead, correctly declining to self-claim an unrelated implementation feature as a workaround, which would itself be the scope creep the agent-teams protocol prohibits). This is the second live occurrence of the same root cause that led to F046 being filed (review-pr69-f040 hit it first). depends_on F046 since it builds on the stderr-delivery fix; F046's own notes already flagged this as 'a separate design question, not addressed by this fix.'",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": "F046",
       "spec": null
     }
   ]

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -1,7 +1,7 @@
 {
   "project": "vv-claude-harness",
   "created": "2026-07-22",
-  "total_features": 53,
+  "total_features": 54,
   "passing": 39,
   "features": [
     {
@@ -1376,7 +1376,9 @@
         ".claude/hooks/check-remaining-tasks.sh",
         ".claude/hooks/verify-task-quality.sh",
         ".claude/hooks/verify-git-identity.sh",
-        ".claude/hooks/statusline.sh"
+        ".claude/hooks/harness_state.py",
+        ".claude/hooks/commit-gate.sh",
+        "test/run-tests.sh"
       ],
       "depends_on": [
         "F046"
@@ -1384,7 +1386,7 @@
       "assigned_to": null,
       "test_file": "test/run-tests.sh",
       "coverage": "n/a (shell suite, no coverage tooling; full_test is the gate -- count omitted here since it drifts on every sibling feature merge; see the header total_features/passing fields for the current count)",
-      "notes": "Reported by teammate review-pr69-f040 while investigating its own TeammateIdle idle-loop issue (F046): noticed the live hook it was reading didn't match the template's current structure at all. Independently confirmed via `diff skills/harness-init/<name>.sh.template .claude/hooks/<name>` for all 5 hooks before filing -- sizes above are measured, not estimated. depends_on F046 only in the sense that F046's fix should land in the template FIRST, so this resync picks up the corrected version rather than needing a second resync immediately after. This is a resync/copy operation, not new logic -- should be a mechanical diff-and-replace per hook plus a full_test run to confirm nothing in this repo's own workflow depended on the old (buggy) installed behavior, but still needs the standard review cycle since it changes what actually gates every future teammate's actions in this repo.\n\nFIXED: re-copied all four hook templates (enforce-scope.sh, check-remaining-tasks.sh, verify-task-quality.sh, verify-git-identity.sh) plus harness_state.py.template (entirely missing before this fix, and required by the current templates of the first two) into .claude/hooks/, verbatim, no logic changes. statusline.sh needed no resync -- confirmed it's sourced from this plugin's own hooks/statusline.sh, not from skills/harness-init/, and was already byte-identical. Verified against the live repo before relying on it: confirmed no .claude/teammate-scope.txt exists for this lead session, so the resynced enforce-scope.sh still exits 0 for all of my own edits; verify-git-identity.sh still allows this session's git identity; check-remaining-tasks.sh now correctly reports claimable features (rc=2, guidance on stderr, matching F047's live-repro trigger) instead of the stale inline logic. Ran both full_test and smoke_test after resyncing, both green. Added a permanent drift guard to test/run-tests.sh (5 assertions, one per resynced file) that diffs this repo's installed copy against its template and fails loudly on any future divergence, rather than relying on a teammate stumbling into the live bug again (which is exactly how this session re-discovered F046's stale-hook manifestation). Mutation-tested by reverting the installed hooks to their pre-fix state: exactly the 5 new assertions fail, nothing else. Full suite 1198/1198.",
+      "notes": "Reported by teammate review-pr69-f040 while investigating its own TeammateIdle idle-loop issue (F046): noticed the live hook it was reading didn't match the template's current structure at all. Independently confirmed via `diff skills/harness-init/<name>.sh.template .claude/hooks/<name>` for all 5 hooks before filing -- sizes above are measured, not estimated. depends_on F046 only in the sense that F046's fix should land in the template FIRST, so this resync picks up the corrected version rather than needing a second resync immediately after. This is a resync/copy operation, not new logic -- should be a mechanical diff-and-replace per hook plus a full_test run to confirm nothing in this repo's own workflow depended on the old (buggy) installed behavior, but still needs the standard review cycle since it changes what actually gates every future teammate's actions in this repo.\n\nFIXED: re-copied all four hook templates (enforce-scope.sh, check-remaining-tasks.sh, verify-task-quality.sh, verify-git-identity.sh) plus harness_state.py.template (entirely missing before this fix, and required by the current templates of the first two) into .claude/hooks/, verbatim, no logic changes. statusline.sh needed no resync -- confirmed it's sourced from this plugin's own hooks/statusline.sh, not from skills/harness-init/, and was already byte-identical. Verified against the live repo before relying on it: confirmed no .claude/teammate-scope.txt exists for this lead session, so the resynced enforce-scope.sh still exits 0 for all of my own edits; verify-git-identity.sh still allows this session's git identity; check-remaining-tasks.sh now correctly reports claimable features (rc=2, guidance on stderr, matching F047's live-repro trigger) instead of the stale inline logic. Ran both full_test and smoke_test after resyncing, both green. Added a permanent drift guard to test/run-tests.sh (5 assertions, one per resynced file) that diffs this repo's installed copy against its template and fails loudly on any future divergence, rather than relying on a teammate stumbling into the live bug again (which is exactly how this session re-discovered F046's stale-hook manifestation). Mutation-tested by reverting the installed hooks to their pre-fix state: exactly the 5 new assertions fail, nothing else. Full suite 1198/1198.\n\nROUND 2 (review of PR #81): reviewer found the fix itself correct but the record around it incomplete in three ways, all independently confirmed before acting:\n1. scope array didn't match the diff (missing harness_state.py, added; test/run-tests.sh, modified; statusline.sh listed but correctly NOT touched) -- corrected above.\n2. commit-gate.sh.template was never installed to .claude/hooks/ at all (confirmed: `git log --all -- .claude/hooks/commit-gate.sh` returns nothing), the identical class of gap as harness_state.py's prior absence. Installed it verbatim (inert until wired -- nothing in settings.json invokes it yet, see point 3) and added it to the drift guard, plus a 6th assertion for statusline.sh (compared against hooks/statusline.sh, the plugin's own copy, since there is no skills/harness-init/statusline.sh.template).\n3. This repo's .claude/settings.json wires enforce-scope.sh only on the Edit|Write|MultiEdit matcher, NOT on Bash -- unlike SKILL.md's own canonical settings.json, which wires enforce-scope.sh AND commit-gate.sh on the Bash matcher too. Confirmed: a scoped teammate could write outside its scope via Bash in this repo today, and even with commit-gate.sh now installed, nothing invokes it. NOT fixed in this PR: wiring a new hook onto every future Bash tool call is a live behavior change for the rest of this session's autonomous sweep (every commit, every teammate's Bash-based file write), not a mechanical resync -- filed separately as F054 for its own dedicated testing and review rather than silently folding a behavioral change into this PR. Also folded into F054: settings.json invokes hooks as `bash .claude/hooks/<name>.sh` where context_summary.md's OVI-48 decision records `\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/<name>.sh` -- harmless in practice (every hook self-anchors via PROJECT_ROOT) but the same settings.json-vs-documented-decision drift family.\n\nThis feature's own claim is narrowed accordingly: F047 fixes FILE-LEVEL drift (installed hook content vs. template content) only. Hook-WIRING drift (what's actually invoked, and how) in .claude/settings.json is real, confirmed, and tracked separately as F054 -- not silently left unaddressed. Re-ran full suite after all three fixes: 1200/1200. Mutation-tested the 2 new assertions (commit-gate.sh, statusline.sh): reverting/tampering each in turn gives exactly 1 failure per file, nothing else.",
       "correction_cycles": 0,
       "scope_expansions": [],
       "approaches_tried": [
@@ -1523,6 +1525,28 @@
       "approaches_tried": [],
       "failure_reason": null,
       "discovered_via": "F046",
+      "spec": null
+    },
+    {
+      "id": "F054",
+      "description": "This repo's .claude/settings.json wires enforce-scope.sh only on the PreToolUse Edit|Write|MultiEdit matcher -- unlike SKILL.md's own canonical settings.json (skills/harness-init/SKILL.md, ~lines 300-326), which wires enforce-scope.sh AND commit-gate.sh on the Bash matcher too (alongside verify-git-identity.sh, which IS wired there in this repo). CONFIRMED: this repo's Bash matcher only invokes verify-git-identity.sh; the entire F023-F046 scope-enforcement hardening arc for Bash-based writes (quoting, escaping, traversal, NUL-truncation, sed -i clustering, long-option abbreviation) is installed (once F047 merges) but never invoked here, and a scoped teammate could write outside its assigned scope via a Bash command today. commit-gate.sh (now installed by F047, but inert) is in the same state -- nothing invokes it. Separately, this repo's settings.json invokes hooks as `bash .claude/hooks/<name>.sh`, while context_summary.md's own OVI-48 decision (2026-07-22) records the canonical invocation as `\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/<name>.sh` -- harmless in practice since every hook self-anchors via PROJECT_ROOT=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}\", but the same settings.json-vs-documented-decision drift family, worth reconciling in the same pass. This is a live behavior change (gates every future Bash tool call in this repo, not a mechanical file resync), so it needs its own careful testing (in particular: confirm commit-gate.sh doesn't interfere with this repo's own normal add-then-commit workflow) and its own dedicated review, separate from F047's file-level resync.",
+      "priority": 37,
+      "status": "pending",
+      "scope": [
+        ".claude/settings.json"
+      ],
+      "depends_on": [
+        "F047"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Discovered by review-pr81-f047 while verifying F047's claim that this repo's own gating now reflects the hardened design -- found the file-level resync was correct but two settings.json gaps make parts of it inert (enforce-scope.sh and commit-gate.sh not wired on the Bash matcher) and one invocation-style drift from a documented decision (OVI-48's `\"$CLAUDE_PROJECT_DIR\"/...` form vs. the live `bash ...` form). Independently confirmed by the lead against SKILL.md's own canonical settings.json and against context_summary.md's OVI-48 entry before filing. depends_on F047 only in the sense that F047's file-level resync (in particular commit-gate.sh's installation) should land first, so wiring it doesn't reference a non-existent file.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": "F047",
       "spec": null
     }
   ]

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -2,7 +2,7 @@
   "project": "vv-claude-harness",
   "created": "2026-07-22",
   "total_features": 53,
-  "passing": 38,
+  "passing": 39,
   "features": [
     {
       "id": "F001",
@@ -1370,7 +1370,7 @@
       "id": "F047",
       "description": "This repo's OWN live `.claude/hooks/*.sh` (the hooks that actually gate work in THIS repo, as opposed to skills/harness-init/*.sh.template which are the distributable source) have drifted badly out of sync with their templates and were never re-synced as the templates were fixed across many sessions of this same OVI-44 sweep. CONFIRMED via `diff` against the current templates: enforce-scope.sh is 1301 diff lines behind (it predates every fix from F023 through F041 -- essentially the entire quoting/escaping/traversal/command-recognition hardening arc this sweep has been doing), verify-task-quality.sh is 122 lines behind, check-remaining-tasks.sh has diverged onto an inline-python implementation the template no longer uses (the template now delegates to harness_state.py's next-claimable), verify-git-identity.sh is a smaller 10-line drift. statusline.sh is effectively in sync (1-line trailing-newline diff only). This means every hook enforcing scope, task quality, and git identity for teammates spawned IN THIS REPO during this entire sweep has been running the OLD, pre-fix logic, not the hardened version this repo has spent dozens of features building -- the fixes exist only in the distributable template, not in the copy actually protecting this project's own teammates.",
       "priority": 31,
-      "status": "pending",
+      "status": "passing",
       "scope": [
         ".claude/hooks/enforce-scope.sh",
         ".claude/hooks/check-remaining-tasks.sh",
@@ -1382,12 +1382,14 @@
         "F046"
       ],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
-      "notes": "Reported by teammate review-pr69-f040 while investigating its own TeammateIdle idle-loop issue (F046): noticed the live hook it was reading didn't match the template's current structure at all. Independently confirmed via `diff skills/harness-init/<name>.sh.template .claude/hooks/<name>` for all 5 hooks before filing -- sizes above are measured, not estimated. depends_on F046 only in the sense that F046's fix should land in the template FIRST, so this resync picks up the corrected version rather than needing a second resync immediately after. This is a resync/copy operation, not new logic -- should be a mechanical diff-and-replace per hook plus a full_test run to confirm nothing in this repo's own workflow depended on the old (buggy) installed behavior, but still needs the standard review cycle since it changes what actually gates every future teammate's actions in this repo.",
+      "test_file": "test/run-tests.sh",
+      "coverage": "n/a (shell suite, no coverage tooling; full_test is the gate -- count omitted here since it drifts on every sibling feature merge; see the header total_features/passing fields for the current count)",
+      "notes": "Reported by teammate review-pr69-f040 while investigating its own TeammateIdle idle-loop issue (F046): noticed the live hook it was reading didn't match the template's current structure at all. Independently confirmed via `diff skills/harness-init/<name>.sh.template .claude/hooks/<name>` for all 5 hooks before filing -- sizes above are measured, not estimated. depends_on F046 only in the sense that F046's fix should land in the template FIRST, so this resync picks up the corrected version rather than needing a second resync immediately after. This is a resync/copy operation, not new logic -- should be a mechanical diff-and-replace per hook plus a full_test run to confirm nothing in this repo's own workflow depended on the old (buggy) installed behavior, but still needs the standard review cycle since it changes what actually gates every future teammate's actions in this repo.\n\nFIXED: re-copied all four hook templates (enforce-scope.sh, check-remaining-tasks.sh, verify-task-quality.sh, verify-git-identity.sh) plus harness_state.py.template (entirely missing before this fix, and required by the current templates of the first two) into .claude/hooks/, verbatim, no logic changes. statusline.sh needed no resync -- confirmed it's sourced from this plugin's own hooks/statusline.sh, not from skills/harness-init/, and was already byte-identical. Verified against the live repo before relying on it: confirmed no .claude/teammate-scope.txt exists for this lead session, so the resynced enforce-scope.sh still exits 0 for all of my own edits; verify-git-identity.sh still allows this session's git identity; check-remaining-tasks.sh now correctly reports claimable features (rc=2, guidance on stderr, matching F047's live-repro trigger) instead of the stale inline logic. Ran both full_test and smoke_test after resyncing, both green. Added a permanent drift guard to test/run-tests.sh (5 assertions, one per resynced file) that diffs this repo's installed copy against its template and fails loudly on any future divergence, rather than relying on a teammate stumbling into the live bug again (which is exactly how this session re-discovered F046's stale-hook manifestation). Mutation-tested by reverting the installed hooks to their pre-fix state: exactly the 5 new assertions fail, nothing else. Full suite 1198/1198.",
       "correction_cycles": 0,
       "scope_expansions": [],
-      "approaches_tried": [],
+      "approaches_tried": [
+        "mechanical re-copy from skills/harness-init/*.sh.template into .claude/hooks/, plus a permanent drift-detection test"
+      ],
       "failure_reason": null,
       "discovered_via": "F040",
       "spec": null

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1154,6 +1154,28 @@ else
   fail "ht: verify-task-quality has no mv-based atomic write"
 fi
 
+# F047: this repo runs on its own harness, so its OWN live .claude/hooks/*.sh
+# are what actually gate every teammate spawned in THIS repo -- not the
+# templates in skills/harness-init/, which are the distributable source. A
+# fix landing in a template does nothing for this repo's own teammates until
+# the installed copy is re-synced (confirmed live: a reviewer teammate hit
+# F046's exact stdout-only bug via THIS repo's own stale installed hook,
+# after F046's fix had already merged into the template). This guard fails
+# loudly the moment the two drift apart again, rather than relying on someone
+# noticing during the next unrelated review.
+for HOOK_NAME in enforce-scope.sh check-remaining-tasks.sh verify-task-quality.sh verify-git-identity.sh; do
+  if diff -q "$TEMPLATES_DIR/$HOOK_NAME.template" "$REPO_ROOT/.claude/hooks/$HOOK_NAME" > /dev/null 2>&1; then
+    pass "ht: this repo's installed $HOOK_NAME matches its template (F047)"
+  else
+    fail "ht: this repo's installed $HOOK_NAME has drifted from its template (F047) -- re-copy it"
+  fi
+done
+if diff -q "$TEMPLATES_DIR/harness_state.py.template" "$REPO_ROOT/.claude/hooks/harness_state.py" > /dev/null 2>&1; then
+  pass "ht: this repo's installed harness_state.py matches its template (F047)"
+else
+  fail "ht: this repo's installed harness_state.py has drifted from its template (F047) -- re-copy it"
+fi
+
 DIR_HS="$WORK/ht-scope"
 make_fixture "$DIR_HS"
 install_hooks "$DIR_HS"

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1163,7 +1163,7 @@ fi
 # after F046's fix had already merged into the template). This guard fails
 # loudly the moment the two drift apart again, rather than relying on someone
 # noticing during the next unrelated review.
-for HOOK_NAME in enforce-scope.sh check-remaining-tasks.sh verify-task-quality.sh verify-git-identity.sh; do
+for HOOK_NAME in enforce-scope.sh check-remaining-tasks.sh verify-task-quality.sh verify-git-identity.sh commit-gate.sh; do
   if diff -q "$TEMPLATES_DIR/$HOOK_NAME.template" "$REPO_ROOT/.claude/hooks/$HOOK_NAME" > /dev/null 2>&1; then
     pass "ht: this repo's installed $HOOK_NAME matches its template (F047)"
   else
@@ -1174,6 +1174,14 @@ if diff -q "$TEMPLATES_DIR/harness_state.py.template" "$REPO_ROOT/.claude/hooks/
   pass "ht: this repo's installed harness_state.py matches its template (F047)"
 else
   fail "ht: this repo's installed harness_state.py has drifted from its template (F047) -- re-copy it"
+fi
+# statusline.sh is sourced from this plugin's own hooks/statusline.sh, not from a
+# skills/harness-init/*.sh.template (there is no statusline template) -- the drift
+# check for it compares against that source instead.
+if diff -q "$REPO_ROOT/hooks/statusline.sh" "$REPO_ROOT/.claude/hooks/statusline.sh" > /dev/null 2>&1; then
+  pass "ht: this repo's installed statusline.sh matches the plugin's own copy (F047)"
+else
+  fail "ht: this repo's installed statusline.sh has drifted from the plugin's own copy (F047) -- re-copy it"
 fi
 
 DIR_HS="$WORK/ht-scope"


### PR DESCRIPTION
## Summary
- This repo runs on its own harness, so its installed `.claude/hooks/*.sh` are what actually gate every teammate spawned here -- not the templates in `skills/harness-init/`, which are the distributable source. These had drifted badly out of sync: `enforce-scope.sh` predated the entire F023-F045 quoting/escaping/traversal/command-recognition hardening arc (1597 diff lines), `check-remaining-tasks.sh` still had F046's stdout-only bug plus an inline implementation the template no longer uses, `verify-task-quality.sh` was 122 lines behind, `verify-git-identity.sh` 10. `harness_state.py`, which the current templates for the first two depend on, was entirely missing from `.claude/hooks/`.
- Re-copied all four hook templates plus `harness_state.py` verbatim -- no logic changes beyond what the templates already contain. `statusline.sh` needed no resync (sourced from this plugin's own `hooks/statusline.sh`, already in sync).
- Live impact: a reviewer teammate hit F046's exact stdout-only bug via this repo's own stale installed hook, after F046's fix had already merged into the template -- confirming this wasn't a hypothetical drift.

## Testing
- Verified against the live repo before relying on it: confirmed no `.claude/teammate-scope.txt` exists for this lead session, so the resynced `enforce-scope.sh` still exits 0 for all of my own edits; `verify-git-identity.sh` still allows this session's git identity; `check-remaining-tasks.sh` now correctly reports claimable features (rc=2, guidance on stderr) instead of the stale inline logic.
- Ran both `full_test` and `smoke_test` after resyncing, both green.
- Added a permanent drift guard to `test/run-tests.sh` (5 assertions) that diffs this repo's installed copy against its template per hook and fails loudly on any future divergence.
- Full suite: 1198/1198.
- Mutation-tested by reverting the installed hooks to their pre-fix state: exactly the 5 new assertions fail, nothing else.

## Dependencies
Builds on F046 (merged) -- this resync intentionally happened after F046 landed in the template so it picks up the corrected version.