### PR TITLE
feat: promotion ladder + ablation pass in Phase 5.5 (F015/OVI-55)

### DIFF
--- a/.harness/claude-progress.txt
+++ b/.harness/claude-progress.txt
@@ -569,3 +569,34 @@
   instruction to keep working through everything from Linear without waiting for
   check-ins.
 - Blockers: none.
+
+## Session 28 - 2026-08-01 (F015/OVI-55: promotion ladder + ablation pass)
+- Feature: F015 - promotion ladder + ablation pass in the Phase 5.5 retrospective
+- Status: complete
+- Documentation/skill-content only, no code. Added two mandatory passes to
+  harness-continue's Phase 5.5: a Promotion pass classifying each Meta-Pattern/
+  corroborated-MLD entry to its smallest durable owner (7-rung ladder:
+  spawn-prompt tweak -> rule file edit -> hook change -> schema field -> agent
+  definition -> plugin skill -> not-yet), and an Ablation pass giving every
+  control that fired this session a retain/revise/remove verdict.
+- New .harness/HARNESS_BACKLOG.md schema (date/observation/proposed
+  owner/evidence pointer/score/status/last_seen). Promotion requires score>=3
+  from distinct sessions; candidates decay to retired after 60 days stale; a
+  hard-capped 15-line "Learned conventions" section is the only permitted
+  always-on promotion target; gap entries get their own row type with a 3+
+  promotion threshold. rules/context-summary.md documents the new Meta-Patterns
+  disposition marker (promoted-to/backlog/watching) with a worked example.
+- P3.1 (corroborated MLD entries) hasn't shipped in this repo -- documented as
+  optional input, skipped gracefully when absent.
+- Self-caught a cross-reference bug before finishing: a "rule below" pointer
+  was wrong (the rule is above, in Step 5a) -- same read-it-back discipline
+  that caught F013's step-ordering bug.
+- Tests: 1400/1400 passing (full_test is the gate; +11 F015 assertions incl.
+  an AC7 "stated exactly once" guard, mutation-tested).
+- AC3's dry-run transcript is documented in the PR description (a classified
+  pattern + an ablation verdict), not committed as a file -- HARNESS_BACKLOG.md
+  is a per-project runtime artifact, not plugin distribution content.
+- Next: F016-F021 (six remaining Linear OVI-44 sub-issues) and F063
+  (discovered_via F013), per Ovidiu's standing instruction to keep working
+  through everything from Linear without waiting for check-ins.
+- Blockers: none.

--- a/.harness/context_summary.md
+++ b/.harness/context_summary.md
@@ -8,8 +8,9 @@ This file is referenced in CLAUDE.md and loaded every session.
 - Freshest arc (F055-F062, prior session, see Meta-Session 2026-07-31 below): the LEAD_OWNED protection family (harness.json, teammate-scope.txt, .harness/mld/) plus TeammateIdle/shutdown coordination fixes (F055, F059) plus one pure-research feature that resolved to documentation instead of code (F061).
 - **Correction, 2026-07-31**: the long-repeated "F012/F013 blocked awaiting Ovidiu's answers" claim (carried across many session handoffs since session 11) was stale, not current. `features.json`'s own `spec` field showed `verdict: "PASS"` for both, sha256(description) matched the stored hash exactly (no drift), and direct Linear queries (`get_issue`, `list_comments`) on OVI-53 and OVI-63 showed zero open-question comment threads. Ovidiu confirmed to proceed once this was surfaced. Lesson: a claim repeated across many handoffs with no fresh evidence is a signal to re-verify, not to re-relay.
 - F012/OVI-53 (portable readiness-stamp signing) shipped, merged to main (PR #98). Notable catch: the actual Linear spec text (fetched via `get_issue`, not the terse local `features.json` description mirror) specified a flat, presence-gated `prep.kick_command` -- the first implementation pass had nested it as `prep.runner.kick_command` with a leftover `enabled` flag, caught only by re-checking against the real spec source before committing. Full detail in F012's own `notes`/`approaches_tried`.
-- F013/OVI-63 (mechanical stamp for /harness-init) implemented. Tests: 1385/1385 (full_test is the gate; +19 assertions incl. the pre-existing "ht: settings block" test redirected to the new template file it now checks). `scripts/stamp.sh` emits every framework-fixed file (settings.json, 7 byte-verbatim hooks, harness.json/features.json skeletons) from a KEY=VALUE answers file with new/upgrade collision handling; harness-init/SKILL.md Steps 3/3.5/3.6 shrink to calling it (AC1: zero remaining inline `"hooks"` JSON). Caught and fixed a real step-ordering bug during implementation: a build-hook confirmation step was drafted to run physically after the stamp step it needed to precede, contradicting the file's own "follow steps in order" rule -- folded into the start of Step 3 instead of left as a misordered separate step. Full detail in F013's own `notes`/`approaches_tried`.
-- Ovidiu, before going to sleep, gave a standing instruction to keep working through everything from Linear until done, without waiting for check-ins between features -- F015-F021 (the seven remaining Linear OVI-44 sub-issues) are next, worked in the same autonomous loop (implement -> TDD/mutation-test -> review -> merge) as F012/F013.
+- F013/OVI-63 (mechanical stamp for /harness-init) shipped, merged to main (PR #99, 2 review rounds -- round 1 caught a real JSON-injection/crash bug via unescaped project_name substitution, fixed with json.dumps-based escaping). Full detail in F013's own `notes`/`approaches_tried`. Filed F063 (discovered_via F013, harness-doctor/fixes.py wiring drift, pre-existing and out of scope) as a follow-up.
+- F015/OVI-55 (promotion ladder + ablation pass in Phase 5.5) implemented. Documentation/skill-content only, no code: harness-continue's Phase 5.5 gains mandatory Promotion and Ablation passes writing to a new `.harness/HARNESS_BACKLOG.md` schema (score/status/last_seen lifecycle, 60-day decay, gap entries, a hard-capped 15-line always-on canon). Full detail in F015's own `notes`/`approaches_tried`.
+- Ovidiu, before going to sleep, gave a standing instruction to keep working through everything from Linear until done, without waiting for check-ins between features -- F016-F021 (six remaining Linear OVI-44 sub-issues) and F063 (discovered_via F013) are next, worked in the same autonomous loop (implement -> TDD/mutation-test -> review -> merge).
 - No other locally-discovered work is queued.
 
 ## Cross-Cutting Concerns
@@ -909,5 +910,39 @@ This file is referenced in CLAUDE.md and loaded every session.
   JSON) -- fixed by redirecting it to the new template file rather than
   deleting it, preserving the original test's intent against its new
   home.
+- Plan approval: not applicable -- single-session implementation, no
+  teammates spawned.
+
+## Meta-Session 2026-08-01 (F015/OVI-55: promotion ladder + ablation pass)
+- Scope accuracy: held the declared scope exactly
+  (skills/harness-continue/SKILL.md, rules/context-summary.md,
+  test/run-tests.sh); zero scope_expansions.
+- Design decisions made without the spec spelling them out, recorded as
+  assumptions in F015's own notes: P3.1 (corroborated MLD entries) has
+  not shipped in this repo -- the Promotion pass instructions treat it
+  as optional input, skipped gracefully when the corroboration marker
+  isn't present, matching the spec's own "consumes P3.1 entries when
+  present" (not a hard dependency) framing rather than blocking on an
+  undelivered sibling feature.
+- AC3 (dry-run producing a classified pattern + ablation verdict) was
+  satisfied as a PR-description transcript, not a committed file --
+  .harness/HARNESS_BACKLOG.md is a per-project runtime artifact the
+  skill creates when a real retrospective actually runs, not plugin
+  distribution content, so it wasn't created in this repo's own
+  .harness/ as part of implementing the capability itself.
+- A self-caught cross-reference bug: a "run the abbreviated ladder per
+  the existing minimum-retrospective rule below" pointer was wrong --
+  that rule lives in Step 5a, well ABOVE Phase 5.5 in the same file, not
+  below it. Caught by reading the new content back top-to-bottom before
+  finishing, the same discipline that caught F013's step-ordering bug
+  last session.
+- Model calibration: single-session, no sub-agents spawned for
+  implementation.
+- Discovery lineage: none -- F015 was a pre-existing Linear-tracked
+  feature (OVI-55), not discovered mid-work.
+- Approach patterns: mutation-tested the AC7 "stated exactly once" guard
+  (duplicated the cap phrase, confirmed the count-based check flips from
+  pass to fail) -- the same discipline applied to a prose/documentation
+  assertion, not just a code assertion, confirming it generalizes.
 - Plan approval: not applicable -- single-session implementation, no
   teammates spawned.

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -548,7 +548,7 @@
       "id": "F015",
       "description": "[OVI-55] P3.2: Promotion ladder + ablation pass in the Phase 5.5 retrospective \u2014 Add two mandatory retrospective passes to harness-continue Phase 5.5: a promotion pass classifying each pattern/MLD entry to its smallest durable owner, and an ablation pass retiring controls that no longer earn their cost, with candidates written to a new .harness/HARNESS_BACKLOG.md. Amendment adds candidate lifecycle (score/status/last_seen), 60-day decay, a capped canon, and gap entries.",
       "priority": 15,
-      "status": "pending",
+      "status": "passing",
       "scope": [
         "skills/harness-continue/SKILL.md",
         "rules/context-summary.md",
@@ -560,12 +560,15 @@
         "F003"
       ],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
-      "notes": "Linear: OVI-55. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "test_file": "test/run-tests.sh (F015 section)",
+      "coverage": "n/a (shell/python fixture suite, no coverage tool)",
+      "notes": "Linear: OVI-55 (incl. Amendment 1, cross-harness reconciliation). Documentation/skill-content feature, no code -- adds a mandatory Promotion pass (classifies each Meta-Pattern/corroborated-MLD entry to its smallest durable owner via a 7-rung ladder) and Ablation pass (retain/revise/remove verdict on every control that fired this session) to harness-continue Phase 5.5, writing candidates to a new .harness/HARNESS_BACKLOG.md schema (date/observation/proposed owner/evidence pointer/score/status/last_seen). Promotion requires score>=3 from distinct sessions (single-session override allowed with an explicit reason); candidates decay to retired after 60 days stale; a hard-capped 15-line \"Learned conventions\" section is the only permitted always-on promotion target; gap entries (work fitting no existing role/scope/skill) get their own row type with a 3+ promotion threshold. rules/context-summary.md documents the new Meta-Patterns disposition marker (promoted-to/backlog/watching) with a worked example. P3.1 (corroborated MLD entries) has not shipped in this repo yet -- documented as an optional input, skipped gracefully when absent, matching the spec's \"consumes P3.1 entries when present\" (not hard-dependency) framing. AC3's dry-run transcript is in the PR description, not a committed file (HARNESS_BACKLOG.md is a per-project runtime artifact the skill creates when it actually runs, not plugin distribution content -- not created in this repo's own .harness/ as part of implementing the capability).",
       "correction_cycles": 0,
       "scope_expansions": [],
-      "approaches_tried": [],
+      "approaches_tried": [
+        "Read the full existing Phase 5.5 section end-to-end before editing, to place the two new mandatory passes at the exact point the spec calls for (\"after the existing Meta-Session entry\") without disturbing the existing Meta-Session / Meta-Patterns write-up the spec says to leave alone.",
+        "Mutation-tested the AC7 \"stated exactly once\" guard by duplicating the cap phrase and confirming the count-based check correctly flips from pass to fail."
+      ],
       "failure_reason": null,
       "discovered_via": null,
       "spec": {

--- a/rules/context-summary.md
+++ b/rules/context-summary.md
@@ -54,17 +54,6 @@ Create once, update continuously.
          session's retrospective can recognize a repeat and bump the score. -->
 - (none yet)
 
-Example:
-```markdown
-## Meta-Patterns
-- Ground-truthing a reviewer's finding before fixing it caught real bugs
-  every time it was tried this session. (promoted-to: rules/agent-teams-
-  protocol.md's "verify before acting" clause)
-- Opus reviewers occasionally cite a line number one off from the real
-  diff hunk; worth double-checking before treating a citation as ground
-  truth. (watching)
-```
-
 ## Meta-Session [DATE]
 <!-- One section per completed session's retrospective. Written at session end.
      Analyzes correction_cycles, scope_expansions, model fit, discovery lineage.
@@ -78,6 +67,18 @@ Example:
 ## Closed Work Streams
 <!-- Completed features. Reference only if dependency exists. -->
 - [Feature]: completed [date], see [PR/commit]
+```
+
+Example:
+
+```markdown
+## Meta-Patterns
+- Ground-truthing a reviewer's finding before fixing it caught real bugs
+  every time it was tried this session. (promoted-to: rules/agent-teams-
+  protocol.md's "verify before acting" clause)
+- Opus reviewers occasionally cite a line number one off from the real
+  diff hunk; worth double-checking before treating a citation as ground
+  truth. (watching)
 ```
 
 **Update when:** a decision is made, a pattern is discovered, a gotcha is encountered, a work stream completes, active context shifts, or a session retrospective completes.

--- a/rules/context-summary.md
+++ b/rules/context-summary.md
@@ -39,8 +39,31 @@ Create once, update continuously.
 <!-- Coordination insights that apply across features — NOT domain-specific.
      Written by the retrospective step at session end. These transfer to new
      projects: harness-init can import them as starting context.
-     Examples: when to use Opus, how to scope work, when plan_approval pays off. -->
+     Examples: when to use Opus, how to scope work, when plan_approval pays off.
+     Each entry carries a disposition marker set by Phase 5.5's promotion pass
+     (see skills/harness-continue/SKILL.md), so a pattern stops being restated
+     verbatim across sessions once it has a place to live:
+       - (promoted-to: X) -- already landed as a rule/hook/schema/agent/skill
+         change; X names it (e.g. "promoted-to: rules/agent-teams-protocol.md
+         Dynamic overrides"). Keep the entry as a one-line historical pointer,
+         not the full original prose.
+       - (backlog) -- filed as a row in .harness/HARNESS_BACKLOG.md, not yet
+         promoted; still worth restating until it lands somewhere durable.
+       - (watching) -- below the promotion score threshold (fewer than 3
+         distinct sessions have re-observed it); noted here so a future
+         session's retrospective can recognize a repeat and bump the score. -->
 - (none yet)
+
+Example:
+```markdown
+## Meta-Patterns
+- Ground-truthing a reviewer's finding before fixing it caught real bugs
+  every time it was tried this session. (promoted-to: rules/agent-teams-
+  protocol.md's "verify before acting" clause)
+- Opus reviewers occasionally cite a line number one off from the real
+  diff hunk; worth double-checking before treating a citation as ground
+  truth. (watching)
+```
 
 ## Meta-Session [DATE]
 <!-- One section per completed session's retrospective. Written at session end.

--- a/skills/harness-continue/SKILL.md
+++ b/skills/harness-continue/SKILL.md
@@ -383,10 +383,66 @@ Write findings to `## Meta-Patterns` for insights that generalize beyond this se
 
 ```markdown
 ## Meta-Patterns
-- [Insight that applies to future sessions, not just this domain]
+- [Insight that applies to future sessions, not just this domain] (backlog)
 ```
 
-Do NOT write domain-specific decisions here — those go in the Domain sections. Meta-Patterns are coordination insights: when to use Opus, how to scope, when to require plan approval.
+Do NOT write domain-specific decisions here — those go in the Domain sections. Meta-Patterns are coordination insights: when to use Opus, how to scope, when to require plan approval. Each entry carries a disposition marker (`promoted-to: X` | `backlog` | `watching`) at the end of the line; see `${CLAUDE_PLUGIN_ROOT}/rules/context-summary.md` for what each marker means and a worked example. The promotion pass below is what sets and updates these markers.
+
+**Promotion pass (mandatory).** This closes the loop the retrospective used to leave open: a lesson written to `## Meta-Patterns` above stayed prose forever, and no control was ever retired. Classify each Meta-Pattern entry from this session (and each corroborated MLD entry, when P3.1's corroboration marker is present in `.harness/mld/` -- skip this input if that mechanism isn't shipped yet) to its smallest durable owner, using the vv-native promotion ladder, smallest first:
+
+| Rung | What it means | Example |
+|---|---|---|
+| spawn-prompt tweak | Fix the wording of a future teammate spawn prompt | A teammate forgot to verify git identity because the spawn prompt never said to; add the line |
+| rule file edit | Add or tighten a rule in `rules/*.md` | A commit-hygiene lesson gets folded into `agent-teams-protocol.md` |
+| hook change | A mechanical check catches this instead of relying on instructions | `enforce-scope.sh` gains a new denied pattern after a near-miss |
+| schema field | A schema (e.g. `feature.schema.json`) gains a field to track this going forward | `qa_binding` added to catch a claim/proof-type mismatch |
+| agent definition | A teammate or reviewer agent's own `.md` definition changes | `reviewer.md` gains a new review dimension |
+| plugin skill | A whole skill's `SKILL.md` changes structurally | A skill's phase ordering is corrected after a self-contradiction is found |
+| not-yet | Not enough evidence yet to commit to a fix | A one-off oddity, not yet a repeated pattern |
+
+For each classified item, append (or update) a row in `.harness/HARNESS_BACKLOG.md` (schema below) rather than leaving the classification stranded only in Meta-Patterns prose. Set the corresponding Meta-Patterns entry's disposition marker to match: `promoted-to: <owner>` once actually landed, `backlog` while the row exists but isn't yet applied, `watching` while below the promotion threshold.
+
+**Ablation pass (mandatory).** List every control that fired this session -- a hook rejection, a plan-approval gate, a warning -- and judge it:
+- **retain**: it caught something real, or its absence would have let something real through.
+- **revise**: it fired, but too noisely or too narrowly to trust as-is.
+- **remove**: it fired zero times this session, or every time it fired it was pure friction (no real defect behind it).
+
+Append a `retain` / `revise` / `remove` verdict with its reason as a row in `.harness/HARNESS_BACKLOG.md` for anything not simply `retain`. Removing a control that no longer earns its carrying cost is a healthy, expected outcome of this pass, not a failure to report defensively.
+
+**`.harness/HARNESS_BACKLOG.md`** (lead-owned; create it the first time either pass produces a candidate). One table:
+
+```markdown
+# Harness Backlog
+
+Candidates the Phase 5.5 promotion and ablation passes have surfaced. Not
+auto-applied: a human or a dedicated session executes a row, then marks it
+promoted. Cross-project pattern aggregation is a future extension, not done
+here -- this file is per-project.
+
+| date | observation | proposed owner | evidence pointer | score | status | last_seen |
+|---|---|---|---|---|---|---|
+| 2026-03-23 | Reviewers occasionally cite an off-by-one line number | not-yet | Meta-Session 2026-03-23 | 1 | candidate | 2026-03-23 |
+```
+
+- `score`: count of DISTINCT sessions/episodes that independently produced this same observation. A brand-new row starts at 1.
+- `status`: `candidate` | `promoted` | `retired`.
+- `last_seen`: date of the most recent session that re-observed this pattern.
+
+On a repeat occurrence of the SAME observation in a later session, bump that row's `score` and `last_seen` instead of appending a duplicate row.
+
+**Promotion threshold**: a candidate needs `score >= 3` (three distinct sessions) before it is promoted into an actual rule/hook/schema/agent/skill change. A single-session promotion (`score` still 1) is allowed only with an explicit override reason recorded in the row (for example: "clear regression risk, promoting at score 1 rather than waiting").
+
+**Decay and retirement** (part of the ablation pass): any `candidate` row whose `last_seen` is more than 60 days old gets `status` flipped to `retired`, keeping a one-line reason -- never silently deleted, never moved to a separate archive.
+
+**Gap entries**: when this session's work fit no existing vv role, scope, or skill and had to be improvised, log a `gap`-type row in the same table (`proposed owner` = `gap`, describing what didn't fit). Three or more similar `gap` rows are themselves a promotion candidate for a new agent or skill -- classify that pattern through the normal ladder above.
+
+**Bounded always-on canon**: a promotion that would land in ALWAYS-loaded context (`templates/CLAUDE.md`'s own invariants, or a SessionStart rule pointer) goes into exactly one "Learned conventions" section, hard-capped at 15 lines total. Exceeding the cap requires evicting the lowest-`score` line first, not silently growing past it. Everything else -- anything that isn't needed in every single session -- goes to `context_summary.md`'s Domain sections instead; this cap exists so always-on context stays bounded even as the backlog grows.
+
+**Linear filing alternative**: if `.harness/harness.json` has a `prep` block with a Linear workspace configured, offer to file promotion/ablation candidates as Linear issues instead of appending to `HARNESS_BACKLOG.md` (reuse the same MCP tool-discovery `harness-issue-prep` already does). Never do both for the same candidate.
+
+**Single-session mode**: run the abbreviated ladder per the existing minimum-retrospective rule in Step 5a above -- classification only; the ablation pass is optional.
+
+**First session on a project**: no retrospective history exists yet -- both passes emit "no data, skipping" and stop; never fabricate a classification or an ablation verdict to fill the section.
 
 **MLD telemetry (lead-only, mandatory)**: the lead — never a teammate — writes `.harness/mld/YYYY-MM-DD-<session-id>.md` with `## Mistakes` / `## Learnings` / `## Desires` sections before Phase 5 teardown. Same format and rationale as Step 5a's Session End procedure; see `${CLAUDE_PLUGIN_ROOT}/rules/mld-review.md`.
 

--- a/skills/harness-continue/SKILL.md
+++ b/skills/harness-continue/SKILL.md
@@ -407,7 +407,7 @@ For each classified item, append (or update) a row in `.harness/HARNESS_BACKLOG.
 - **revise**: it fired, but too noisely or too narrowly to trust as-is.
 - **remove**: it fired zero times this session, or every time it fired it was pure friction (no real defect behind it).
 
-Append a `retain` / `revise` / `remove` verdict with its reason as a row in `.harness/HARNESS_BACKLOG.md` for anything not simply `retain`. Removing a control that no longer earns its carrying cost is a healthy, expected outcome of this pass, not a failure to report defensively.
+Append a `retain` / `revise` / `remove` verdict with its reason as a row in `.harness/HARNESS_BACKLOG.md` for anything not simply `retain` -- put the verdict and its reason in `proposed owner` (e.g. `revise (too noisy; narrow the matcher)`), the same column a `gap` row's type goes in, since an ablation row isn't proposing a promotion destination. Removing a control that no longer earns its carrying cost is a healthy, expected outcome of this pass, not a failure to report defensively.
 
 **`.harness/HARNESS_BACKLOG.md`** (lead-owned; create it the first time either pass produces a candidate). One table:
 

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -6194,6 +6194,90 @@ else
 fi
 
 echo ""
+echo "== F015: promotion ladder + ablation pass =="
+
+HC_SKILL="$REPO_ROOT/skills/harness-continue/SKILL.md"
+CTX_RULE="$REPO_ROOT/rules/context-summary.md"
+
+# AC1: harness-continue contains both passes with the classification table,
+# and mentions HARNESS_BACKLOG.md (same grep-lint style as existing content
+# checks in this file, e.g. the F059/F061 checks just above).
+if grep -q "Promotion pass" "$HC_SKILL" && grep -q "Ablation pass" "$HC_SKILL" \
+  && grep -q "spawn-prompt tweak" "$HC_SKILL" && grep -q "not-yet" "$HC_SKILL"; then
+  pass "f015: harness-continue/SKILL.md has both the promotion and ablation passes with the ladder table"
+else
+  fail "f015: harness-continue/SKILL.md is missing the promotion pass, ablation pass, or ladder table"
+fi
+if grep -q "HARNESS_BACKLOG.md" "$HC_SKILL"; then
+  pass "f015: harness-continue/SKILL.md mentions HARNESS_BACKLOG.md (AC1)"
+else
+  fail "f015: harness-continue/SKILL.md does not mention HARNESS_BACKLOG.md"
+fi
+
+# AC2: rules/context-summary.md documents the disposition marker, with an example.
+if grep -q "disposition marker" "$CTX_RULE" && grep -q "promoted-to" "$CTX_RULE" \
+  && grep -q "backlog" "$CTX_RULE" && grep -q "watching" "$CTX_RULE"; then
+  pass "f015: rules/context-summary.md documents the disposition marker (promoted-to/backlog/watching)"
+else
+  fail "f015: rules/context-summary.md is missing the disposition marker documentation"
+fi
+if grep -q "^Example:" "$CTX_RULE"; then
+  pass "f015: rules/context-summary.md has a worked example of the disposition marker (AC2)"
+else
+  fail "f015: rules/context-summary.md is missing a worked example"
+fi
+
+# AC5: backlog table schema documents the 3 lifecycle columns and the score>=3 rule.
+if grep -q "| score | status | last_seen |" "$HC_SKILL"; then
+  pass "f015: the backlog table schema documents score/status/last_seen (AC5)"
+else
+  fail "f015: the backlog table schema is missing the score/status/last_seen columns"
+fi
+if grep -q "score >= 3" "$HC_SKILL"; then
+  pass "f015: the promotion threshold (score >= 3) is documented (AC5)"
+else
+  fail "f015: the score >= 3 promotion threshold is not documented"
+fi
+
+# AC6: retrospective text contains the decay/retire rule.
+if grep -q "60 days" "$HC_SKILL" && grep -q "retired" "$HC_SKILL"; then
+  pass "f015: the 60-day decay/retirement rule is documented (AC6)"
+else
+  fail "f015: the decay/retirement rule is missing"
+fi
+
+# AC7: the bounded-canon cap is stated EXACTLY once (a second copy would mean
+# the two could silently drift, defeating the point of a single hard cap).
+CANON_CAP_COUNT=$(grep -c "hard-capped at 15 lines\|hard cap.*15 lines\|15 lines total" "$HC_SKILL")
+if [ "$CANON_CAP_COUNT" -eq 1 ]; then
+  pass "f015: the bounded-canon 15-line cap is stated exactly once (AC7)"
+else
+  fail "f015: the bounded-canon cap should be stated exactly once, found $CANON_CAP_COUNT"
+fi
+
+# AC8: the gap entry type is documented with its promotion threshold (3+ similar gaps).
+if grep -q "gap.*type\|gap-type\|\`gap\`-type" "$HC_SKILL" && grep -q "[Tt]hree or more similar\|3+ similar" "$HC_SKILL"; then
+  pass "f015: the gap entry type is documented with its 3+ promotion threshold (AC8)"
+else
+  fail "f015: the gap entry type or its promotion threshold is missing"
+fi
+
+# AC4: no new always-on context -- the ladder/backlog machinery must live only
+# in the skill (loaded when harness-continue runs), never in a file that's
+# injected on every session start. templates/CLAUDE.md and the SessionStart
+# hook are the two always-on surfaces in this plugin.
+if grep -q "HARNESS_BACKLOG" "$REPO_ROOT/templates/CLAUDE.md" 2>/dev/null; then
+  fail "f015: templates/CLAUDE.md (always-on) should not reference the backlog machinery directly"
+else
+  pass "f015: templates/CLAUDE.md carries no new always-on reference to the backlog machinery (AC4)"
+fi
+if grep -q "HARNESS_BACKLOG" "$HOOKS_DIR/session-start.sh"; then
+  fail "f015: session-start.sh (always-on) should not reference the backlog machinery directly"
+else
+  pass "f015: session-start.sh carries no new always-on reference to the backlog machinery (AC4)"
+fi
+
+echo ""
 echo "== commit-gate.sh =="
 
 run_commit_gate() {

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -6288,7 +6288,7 @@ fi
 # the two could silently drift, defeating the point of a single hard cap).
 # grep -c counts matching LINES, not occurrences, so two mentions on the same
 # line would silently pass; grep -o extracts each match, giving a true count.
-CANON_CAP_COUNT=$(grep -o "15 lines\|15-line" "$HC_SKILL" | wc -l | tr -d ' ')
+CANON_CAP_COUNT=$(grep -oi "15 lines\|15-line\|fifteen lines" "$HC_SKILL" | wc -l | tr -d ' ')
 if [ "$CANON_CAP_COUNT" -eq 1 ]; then
   pass "f015: the bounded-canon 15-line cap is stated exactly once (AC7)"
 else

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -6199,14 +6199,48 @@ echo "== F015: promotion ladder + ablation pass =="
 HC_SKILL="$REPO_ROOT/skills/harness-continue/SKILL.md"
 CTX_RULE="$REPO_ROOT/rules/context-summary.md"
 
-# AC1: harness-continue contains both passes with the classification table,
-# and mentions HARNESS_BACKLOG.md (same grep-lint style as existing content
-# checks in this file, e.g. the F059/F061 checks just above).
-if grep -q "Promotion pass" "$HC_SKILL" && grep -q "Ablation pass" "$HC_SKILL" \
-  && grep -q "spawn-prompt tweak" "$HC_SKILL" && grep -q "not-yet" "$HC_SKILL"; then
-  pass "f015: harness-continue/SKILL.md has both the promotion and ablation passes with the ladder table"
+# AC1: harness-continue contains both passes with the FULL classification
+# table (all 7 rungs, one example each -- checking only 2 of 7 rung names
+# would let the middle five silently disappear), and mentions
+# HARNESS_BACKLOG.md (same grep-lint style as existing content checks in
+# this file, e.g. the F059/F061 checks just above).
+if grep -q "Promotion pass" "$HC_SKILL" && grep -q "Ablation pass" "$HC_SKILL"; then
+  pass "f015: harness-continue/SKILL.md has both the promotion and ablation passes"
 else
-  fail "f015: harness-continue/SKILL.md is missing the promotion pass, ablation pass, or ladder table"
+  fail "f015: harness-continue/SKILL.md is missing the promotion pass or the ablation pass"
+fi
+LADDER_ERRORS=$(python3 - "$HC_SKILL" <<'PYEOF'
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path).read()
+match = re.search(r"\| Rung \| What it means \| Example \|\n\|---\|---\|---\|\n(.*?)\n\n", text, re.DOTALL)
+if not match:
+    print("could not find the ladder table (header + separator + rows)")
+    sys.exit(0)
+rows = [r for r in match.group(1).splitlines() if r.strip()]
+expected_rungs = [
+    "spawn-prompt tweak", "rule file edit", "hook change", "schema field",
+    "agent definition", "plugin skill", "not-yet",
+]
+if len(rows) != 7:
+    print(f"expected 7 table rows (one per rung), found {len(rows)}")
+found_rungs = [r.split("|")[1].strip() for r in rows if r.count("|") >= 3]
+missing = [r for r in expected_rungs if r not in found_rungs]
+if missing:
+    print(f"missing rung(s) in the table: {missing}")
+# "one example per rung" -- each row's 3rd column (the Example cell) must be non-empty.
+for row in rows:
+    cells = row.split("|")
+    if len(cells) >= 4 and not cells[3].strip():
+        print(f"row has an empty Example cell: {row!r}")
+PYEOF
+)
+if [ -z "$LADDER_ERRORS" ]; then
+  pass "f015: the ladder table has all 7 rungs with one example each (AC1)"
+else
+  fail "f015: ladder table -- $LADDER_ERRORS"
 fi
 if grep -q "HARNESS_BACKLOG.md" "$HC_SKILL"; then
   pass "f015: harness-continue/SKILL.md mentions HARNESS_BACKLOG.md (AC1)"
@@ -6239,8 +6273,12 @@ else
   fail "f015: the score >= 3 promotion threshold is not documented"
 fi
 
-# AC6: retrospective text contains the decay/retire rule.
-if grep -q "60 days" "$HC_SKILL" && grep -q "retired" "$HC_SKILL"; then
+# AC6: retrospective text contains the decay/retire rule. Anchored to
+# last_seen + 60 days together (rather than "60 days" and "retired"
+# independently) so the check can't be satisfied by two unrelated mentions
+# elsewhere in the file (e.g. "no control was ever retired" in the intro
+# prose, or "retired" appearing in the status enum documentation).
+if grep -q "last_seen.*60 days\|60 days.*last_seen" "$HC_SKILL"; then
   pass "f015: the 60-day decay/retirement rule is documented (AC6)"
 else
   fail "f015: the decay/retirement rule is missing"
@@ -6248,7 +6286,9 @@ fi
 
 # AC7: the bounded-canon cap is stated EXACTLY once (a second copy would mean
 # the two could silently drift, defeating the point of a single hard cap).
-CANON_CAP_COUNT=$(grep -c "hard-capped at 15 lines\|hard cap.*15 lines\|15 lines total" "$HC_SKILL")
+# grep -c counts matching LINES, not occurrences, so two mentions on the same
+# line would silently pass; grep -o extracts each match, giving a true count.
+CANON_CAP_COUNT=$(grep -o "15 lines\|15-line" "$HC_SKILL" | wc -l | tr -d ' ')
 if [ "$CANON_CAP_COUNT" -eq 1 ]; then
   pass "f015: the bounded-canon 15-line cap is stated exactly once (AC7)"
 else


### PR DESCRIPTION
## Summary
- Add two mandatory passes to `harness-continue`'s Phase 5.5, after the existing Meta-Session/Meta-Patterns write-up: a **Promotion pass** (classify each Meta-Pattern entry to its smallest durable owner via a 7-rung ladder) and an **Ablation pass** (retain/revise/remove verdict on every control that fired this session).
- Both passes write to a new `.harness/HARNESS_BACKLOG.md` schema: `date | observation | proposed owner | evidence pointer | score | status | last_seen`. Promotion requires `score >= 3` from distinct sessions; a candidate decays to `retired` after 60 days stale; a promotion landing in always-loaded context is capped at one 15-line "Learned conventions" section; gap entries (work fitting no existing role/scope/skill) get a 3+ promotion threshold.
- `rules/context-summary.md` documents the new Meta-Patterns disposition marker (`promoted-to: X` | `backlog` | `watching`) with a worked example, so a pattern stops being restated verbatim once it has a place to live.
- Documentation/skill-content only — no code changed, no new always-on context (verified: `templates/CLAUDE.md` and `session-start.sh` carry nothing new).

## AC3: dry-run transcript
Simulated against a representative Meta-Pattern and control from this session's own history (this repo has no `.harness/HARNESS_BACKLOG.md` yet, so this is documented here rather than committed — that file is a per-project runtime artifact the skill creates when a real retrospective runs, not plugin distribution content):

**Promotion pass — one classified pattern:**
> Meta-Pattern: "Ground-truthing a reviewer's finding before fixing it caught real bugs every time it was tried this session."
> - **Rung: rule file edit** — a repeatable coordination discipline, not a one-off code fix; belongs in `rules/agent-teams-protocol.md`, not a hook (nothing to mechanically enforce) or a schema field (not data-shaped).
> - Backlog row: `2026-08-01 | Ground-truthing a reviewer's finding before fixing it caught real bugs every time it was tried | rule file edit -> rules/agent-teams-protocol.md | Meta-Session 2026-08-01 | 1 | candidate | 2026-08-01`
> - Meta-Patterns disposition: `(backlog)` — score 1, below the promotion threshold of 3.

**Ablation pass — one verdict:**
> Control: the `TeammateIdle` hook's repeated re-fire after a reviewer's work is delivered but before release.
> - **Verdict: revise** — fired far more than needed (6 times in one episode), real friction, but not zero-value; the underlying gap was real and its fix already landed as a documented lead-judgment rule (F059), so the hook itself needs no further code change.
> - Backlog row: `2026-08-01 | TeammateIdle re-fires repeatedly after a reviewer's work is delivered but before release | revise (addressed by F059's documented judgment rule, not a mechanism) | F059 | 3 | promoted | 2026-08-01`

## Testing
- New `test/run-tests.sh` section covers AC1 (both passes present, mentions `HARNESS_BACKLOG.md`), AC2 (disposition marker + example), AC4 (no new always-on context), AC5 (lifecycle columns + `score >= 3` rule), AC6 (60-day decay rule), AC7 (the bounded-canon cap stated exactly once — mutation-tested: duplicating the phrase flips the check from pass to fail), AC8 (gap entry type + threshold).
- Full suite: 1400/1400 assertions passing (`bash test/run-tests.sh`).

## Dependencies
Linear OVI-55 (incl. Amendment 1). No hard dependencies; P3.1 (corroborated MLD entries) hasn't shipped in this repo — documented as optional input, skipped gracefully when absent.