### PR TITLE
feat: author-blind conformance tester (F017/OVI-65)

### DIFF
--- a/.harness/claude-progress.txt
+++ b/.harness/claude-progress.txt
@@ -626,3 +626,25 @@
   (discovered_via F013), per Ovidiu's standing instruction to keep working through
   everything from Linear without waiting for check-ins.
 - Blockers: none.
+
+## Session 30 - 2026-08-01 (F017/OVI-65: author-blind conformance tester)
+- Feature: F017 - author-blind conformance tester (anti-reward-hacking gate)
+- Status: complete
+- New agents/conformance-tester.md (vv-harness:conformance-tester, sonnet, tools
+  Read/Grep/Glob/Write/Bash): derives behavior tests from a feature's verified
+  description and acceptance criteria alone, hard-forbidden from reading the
+  implementation diff, completion message, or implementer-authored tests. Reports
+  PASS/FAIL/NOT-TESTABLE per criterion; never fixes source itself.
+- Wired as an optional harness-continue Phase 4 step (3.5): spawns before marking a
+  feature passing when spec.verdict is PASS AND (risk elevated OR
+  require_plan_approval), recording proof.evidence_type conformance on success,
+  routing any FAIL back as a finding.
+- AC3 (schema accepts evidence_type "conformance") was already satisfied -- F010/OVI-52
+  added it to both enums proactively; confirmed via git blame before assuming a schema
+  change was needed.
+- Tests: 1417/1417 passing (full_test is the gate; +6 F017 assertions, 2
+  mutation-tested).
+- Next: F018-F021 (four remaining Linear OVI-44 sub-issues) and F063
+  (discovered_via F013), per Ovidiu's standing instruction to keep working through
+  everything from Linear without waiting for check-ins.
+- Blockers: none.

--- a/.harness/context_summary.md
+++ b/.harness/context_summary.md
@@ -7,11 +7,12 @@ This file is referenced in CLAUDE.md and loaded every session.
 - The entire locally-discovered bug/design-gap chain that started with F023 is now CLOSED: F023-F062 (40 features, no Linear issue) all shipped, each through the standard TDD + mutation-test + adversarial-review-to-APPROVE loop. Full per-feature detail lives in features.json's own per-feature `notes` fields and the per-feature Meta-Session entries below; `claude-progress.txt`'s consolidated session entries cover the wall-clock history.
 - Freshest arc (F055-F062, prior session, see Meta-Session 2026-07-31 below): the LEAD_OWNED protection family (harness.json, teammate-scope.txt, .harness/mld/) plus TeammateIdle/shutdown coordination fixes (F055, F059) plus one pure-research feature that resolved to documentation instead of code (F061).
 - **Correction, 2026-07-31**: the long-repeated "F012/F013 blocked awaiting Ovidiu's answers" claim (carried across many session handoffs since session 11) was stale, not current. `features.json`'s own `spec` field showed `verdict: "PASS"` for both, sha256(description) matched the stored hash exactly (no drift), and direct Linear queries (`get_issue`, `list_comments`) on OVI-53 and OVI-63 showed zero open-question comment threads. Ovidiu confirmed to proceed once this was surfaced. Lesson: a claim repeated across many handoffs with no fresh evidence is a signal to re-verify, not to re-relay.
-- F012/OVI-53 (portable readiness-stamp signing) shipped, merged to main (PR #98). Notable catch: the actual Linear spec text (fetched via `get_issue`, not the terse local `features.json` description mirror) specified a flat, presence-gated `prep.kick_command` -- the first implementation pass had nested it as `prep.runner.kick_command` with a leftover `enabled` flag, caught only by re-checking against the real spec source before committing. Full detail in F012's own `notes`/`approaches_tried`.
-- F013/OVI-63 (mechanical stamp for /harness-init) shipped, merged to main (PR #99, 2 review rounds -- round 1 caught a real JSON-injection/crash bug via unescaped project_name substitution, fixed with json.dumps-based escaping). Full detail in F013's own `notes`/`approaches_tried`. Filed F063 (discovered_via F013, harness-doctor/fixes.py wiring drift, pre-existing and out of scope) as a follow-up.
-- F015/OVI-55 (promotion ladder + ablation pass in Phase 5.5) shipped, merged to main (PR #100, 2 review rounds -- round 1 caught a real markdown fence-nesting regression in rules/context-summary.md that escaped headings and orphaned trailing prose into a broken code block, verified with pandoc). Full detail in F015's own `notes`/`approaches_tried`.
-- F016/OVI-57 (worker epoch record + requalification checklist) implemented. New `harness_worker_block` sub-schema in schemas/feature.schema.json for harness.json's optional worker block; harness-continue Step 2.6 (defensive `claude --version` check, delta>=10 requalification prompt, silent-skip when unavailable); new docs/requalification.md checklist (4-candidate subtraction pass, inherit-vs-pinned per role, verified-live annotations); rules/agent-teams-protocol.md's Model Selection table reframed as the single bindings table; CLAUDE_CODE_SUBAGENT_MODEL footgun warning added to templates/CLAUDE.md. Full detail in F016's own `notes`/`approaches_tried`.
-- Ovidiu, before going to sleep, gave a standing instruction to keep working through everything from Linear until done, without waiting for check-ins between features -- F017-F021 (five remaining Linear OVI-44 sub-issues) and F063 (discovered_via F013) are next, worked in the same autonomous loop (implement -> TDD/mutation-test -> review -> merge).
+- F012/OVI-53 (portable readiness-stamp signing) shipped, merged to main (PR #98). See F012's own `notes` for the `prep.kick_command` spec-conformance catch.
+- F013/OVI-63 (mechanical stamp for /harness-init) shipped, merged to main (PR #99). Filed F063 (discovered_via F013, harness-doctor/fixes.py wiring drift, pre-existing and out of scope) as a follow-up.
+- F015/OVI-55 (promotion ladder + ablation pass in Phase 5.5) shipped, merged to main (PR #100).
+- F016/OVI-57 (worker epoch record + requalification checklist) shipped, merged to main (PR #101, 2 review rounds -- round 1 caught the feature was inert: spec item 1 said the worker block is "written by /harness-init" but no code path ever wrote it, fixed by adding the write step outside the declared scope list and recording a scope_expansion).
+- F017/OVI-65 (author-blind conformance tester) implemented. New agents/conformance-tester.md (sonnet): derives behavior tests from a feature's verified description alone, hard-forbidden from reading the implementation diff/completion message/implementer tests. Wired as an optional harness-continue Phase 4 step for spec-verified + elevated-risk features. AC3 (schema evidence_type "conformance") was already satisfied by F010's proactive addition -- confirmed via git blame before assuming a schema change was needed. Full detail in F017's own `notes`/`approaches_tried`.
+- Ovidiu, before going to sleep, gave a standing instruction to keep working through everything from Linear until done, without waiting for check-ins between features -- F018-F021 (four remaining Linear OVI-44 sub-issues) and F063 (discovered_via F013) are next, worked in the same autonomous loop (implement -> TDD/mutation-test -> review -> merge).
 - No other locally-discovered work is queued.
 
 ## Cross-Cutting Concerns
@@ -978,5 +979,27 @@ This file is referenced in CLAUDE.md and loaded every session.
   mutation meant a weak check, then redone with a heredoc to get a
   trustworthy result. A reminder that a mutation test's own tooling
   needs the same skepticism as the code it's testing.
+- Plan approval: not applicable -- single-session implementation, no
+  teammates spawned.
+
+## Meta-Session 2026-08-01 (F017/OVI-65: author-blind conformance tester)
+- Scope accuracy: held the declared scope exactly (agents/conformance-tester.md,
+  skills/harness-continue/SKILL.md, schemas/feature.schema.json,
+  test/run-tests.sh); zero scope_expansions -- schemas/feature.schema.json
+  was in scope but needed no edit (see below).
+- Verified-before-assuming: checked git history for the evidence_type enum
+  before touching schemas/feature.schema.json, and found F010/OVI-52 had
+  already added "conformance" to both the qa_binding and proof.evidence_type
+  enums proactively when it shipped. Confirmed AC3 was already satisfied
+  rather than making a redundant edit to an already-correct schema (which
+  could have introduced a real conflict, e.g. a duplicate enum entry, if
+  done carelessly).
+- Model calibration: single-session, no sub-agents spawned for
+  implementation.
+- Discovery lineage: none -- F017 was a pre-existing Linear-tracked
+  feature (OVI-65), not discovered mid-work.
+- Approach patterns: mutation-tested both new lint checks (the frontmatter
+  tools-set check, the blindness-rule presence check) against targeted
+  defects; both caught their mutation on the first attempt.
 - Plan approval: not applicable -- single-session implementation, no
   teammates spawned.

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -642,7 +642,7 @@
       ],
       "approaches_tried": [
         "Checked git history for the evidence_type enum before assuming a schema change was needed -- found F010 had already added \"conformance\" to both enums proactively, avoiding a redundant/conflicting edit to an already-correct schema.",
-        "Mutation-tested both new lint checks (the AC1 tools-set check and the AC2 blindness-rule check) against targeted defects; both caught their mutation."
+        "Mutation-tested both new lint checks (the AC1 tools-set check and the round-1 AC2 blindness-rule check) against targeted defects; both caught their mutation at the time -- but round-1's AC2 mutation was too narrow (it only tried weakening the rule's wording, not deleting the whole section), and PR #102 review round 1 found the check still passed with the ENTIRE blindness-rule section deleted, since it grepped the whole file including the agent's own frontmatter description. Rewrote round 2 to scope the check to the blindness-rule section specifically (body only, frontmatter stripped); re-verified against the exact section-deletion mutation."
       ],
       "failure_reason": null,
       "discovered_via": null,

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -622,7 +622,7 @@
       "id": "F017",
       "description": "[OVI-65] A1: Author-blind conformance tester (anti-reward-hacking gate) \u2014 Add agents/conformance-tester.md (vv-harness:conformance-tester), an agent that derives behavior tests from the verified feature description alone, forbidden from reading the implementation diff, completion message, or implementer tests, writes conformance tests, and reports PASS/FAIL/NOT-TESTABLE per criterion. Wire an optional harness-continue Phase 4 spawn for elevated-risk features recording evidence_type conformance.",
       "priority": 17,
-      "status": "pending",
+      "status": "passing",
       "scope": [
         "agents/conformance-tester.md",
         "skills/harness-continue/SKILL.md",
@@ -633,12 +633,15 @@
         "F010"
       ],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
-      "notes": "Linear: OVI-65. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "test_file": "test/run-tests.sh (F017 section)",
+      "coverage": "n/a (shell/python fixture suite, no coverage tool)",
+      "notes": "Linear: OVI-65. New agents/conformance-tester.md (vv-harness:conformance-tester, sonnet, tools Read/Grep/Glob/Write/Bash): derives behavior tests from a feature's verified description + acceptance criteria alone, hard-forbidden from reading the implementation diff, completion message, or implementer-authored tests. Reports PASS/FAIL/NOT-TESTABLE per criterion; never fixes source itself. Wired as an optional harness-continue Phase 4 step (3.5): spawns before marking a feature passing when spec.verdict is PASS AND (risk elevated OR require_plan_approval), recording proof.evidence_type conformance on success, routing any FAIL back as a finding rather than marking passing. AC3 (schema accepts evidence_type \"conformance\") was ALREADY satisfied -- F010/OVI-52 added it to both the qa_binding and proof.evidence_type enums proactively when it shipped, confirmed via git blame and the pre-existing \"fsv: accepts qa_binding value conformance\" test; no schema change needed here despite schemas/feature.schema.json being in the declared scope list.",
       "correction_cycles": 0,
       "scope_expansions": [],
-      "approaches_tried": [],
+      "approaches_tried": [
+        "Checked git history for the evidence_type enum before assuming a schema change was needed -- found F010 had already added \"conformance\" to both enums proactively, avoiding a redundant/conflicting edit to an already-correct schema.",
+        "Mutation-tested both new lint checks (the AC1 tools-set check and the AC2 blindness-rule check) against targeted defects; both caught their mutation."
+      ],
       "failure_reason": null,
       "discovered_via": null,
       "spec": {

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -1,7 +1,7 @@
 {
   "project": "vv-claude-harness",
   "created": "2026-07-22",
-  "total_features": 63,
+  "total_features": 64,
   "passing": 53,
   "features": [
     {
@@ -637,7 +637,9 @@
       "coverage": "n/a (shell/python fixture suite, no coverage tool)",
       "notes": "Linear: OVI-65. New agents/conformance-tester.md (vv-harness:conformance-tester, sonnet, tools Read/Grep/Glob/Write/Bash): derives behavior tests from a feature's verified description + acceptance criteria alone, hard-forbidden from reading the implementation diff, completion message, or implementer-authored tests. Reports PASS/FAIL/NOT-TESTABLE per criterion; never fixes source itself. Wired as an optional harness-continue Phase 4 step (3.5): spawns before marking a feature passing when spec.verdict is PASS AND (risk elevated OR require_plan_approval), recording proof.evidence_type conformance on success, routing any FAIL back as a finding rather than marking passing. AC3 (schema accepts evidence_type \"conformance\") was ALREADY satisfied -- F010/OVI-52 added it to both the qa_binding and proof.evidence_type enums proactively when it shipped, confirmed via git blame and the pre-existing \"fsv: accepts qa_binding value conformance\" test; no schema change needed here despite schemas/feature.schema.json being in the declared scope list.",
       "correction_cycles": 0,
-      "scope_expansions": [],
+      "scope_expansions": [
+        "README.md (outside the declared scope list) was edited during review round 1 to add conformance-tester to the agent roster (tree diagram + layout table) -- a regression this PR itself caused by shipping a 7th agent without updating either place that enumerates all six pre-existing ones."
+      ],
       "approaches_tried": [
         "Checked git history for the evidence_type enum before assuming a schema change was needed -- found F010 had already added \"conformance\" to both enums proactively, avoiding a redundant/conflicting edit to an already-correct schema.",
         "Mutation-tested both new lint checks (the AC1 tools-set check and the AC2 blindness-rule check) against targeted defects; both caught their mutation."
@@ -1826,6 +1828,31 @@
       "approaches_tried": [],
       "failure_reason": null,
       "discovered_via": "F013",
+      "spec": null
+    },
+    {
+      "id": "F064",
+      "description": "F017/OVI-65's harness-continue Phase 4 step 3.5 gates the conformance-tester spawn on a feature's risk being \"elevated\", but risk is not persisted anywhere on the local features.json feature object -- it exists only transiently in a Linear readiness-stamp comment (remote mode, and only if prep.stamp is configured) or in the lead's own in-session Phase 1 notes, neither of which survives compaction or is checkable without a live Linear lookup. Persist `risk` (and ideally `require_plan_approval`, the step's other trigger condition, which has the same problem) as a durable field on the feature object in schemas/feature.schema.json, written back by harness-issue-prep at stamp time (mirroring what already goes into the Linear comment) and/or by the lead at Phase 1 team-design time, so step 3.5's trigger condition becomes a genuine features.json lookup instead of \"whatever the lead remembers or can still find in Linear.\"",
+      "priority": 65,
+      "status": "pending",
+      "scope": [
+        "schemas/feature.schema.json",
+        "skills/harness-issue-prep/SKILL.md",
+        "skills/harness-continue/SKILL.md",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F017"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Discovered during PR #102 (F017/OVI-65) round-1 review: step 3.5's trigger condition references a field that does not durably exist. Documented as a known limitation in step 3.5's own text rather than fixed there, since persisting risk properly means changes to harness-issue-prep (writing it back locally at stamp time), which was never in F017's declared scope.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": "F017",
       "spec": null
     }
   ]

--- a/README.md
+++ b/README.md
@@ -201,7 +201,8 @@ vv-harness/                                            # Plugin root
 │   ├── researcher.md                                  # Sonnet, retrieval-only (Write for findings file)
 │   ├── reviewer.md                                    # Opus, high effort, no Edit/Write tools
 │   ├── spec-verification.md                           # Opus, read-only spec gate (SV-01..SV-06)
-│   └── reverification-guard.md                        # Sonnet, read-only re-verify of human revisions
+│   ├── reverification-guard.md                        # Sonnet, read-only re-verify of human revisions
+│   └── conformance-tester.md                          # Sonnet, author-blind behavior tests from spec alone
 ├── hooks/
 │   ├── session-start.sh                               # Orientation, spec-drift warning, compaction recovery
 │   ├── session-end.sh                                 # Session discipline audit
@@ -388,7 +389,7 @@ claude
 | `skills/harness-continue/` | Session continuation with team spawn prompts and the subagent fallback |
 | `skills/harness-issue-prep/` | Verify and normalize a spec (Linear issue, pasted text, or a feature), then mark it ready for implementation |
 | `skills/harness-issue-debug/` | Open a failed feature or a runner-parked Linear issue in a live repair session |
-| `agents/` | Declarative teammate definitions (feature-implementer, layer-implementer, researcher, reviewer, spec-verification, reverification-guard) |
+| `agents/` | Declarative teammate definitions (feature-implementer, layer-implementer, researcher, reviewer, spec-verification, reverification-guard, conformance-tester) |
 | `schemas/` | Data contracts published for external consumers (readiness stamp, park/resolution formats) |
 | `hooks/` | Plugin continuity hooks: session-start, session-end, statusline |
 | `rules/agent-teams-protocol.md` | Agent Teams coordination (harness projects only) |

--- a/agents/conformance-tester.md
+++ b/agents/conformance-tester.md
@@ -1,0 +1,63 @@
+---
+name: conformance-tester
+description: >-
+  Author-blind behavior-test writer (F017/OVI-65). Derives conformance tests from a
+  feature's verified description and acceptance criteria alone -- never from the
+  implementation diff, the implementer's completion message, or any test file the
+  implementer wrote. Adapted from agent-os's conformance-test-writer pattern
+  (nodera-studio, MIT): a single context that writes both the code and its tests can
+  satisfy a bug with a test that matches the bug. Spawn optionally from
+  harness-continue's Phase 4 for features with a verified spec and elevated risk or
+  require_plan_approval. Reports PASS/FAIL/NOT-TESTABLE per acceptance criterion to
+  the lead; never fixes source itself.
+model: sonnet
+tools: Read, Grep, Glob, Write, Bash
+---
+
+You write author-blind conformance tests. Your spawn prompt names the feature's
+verified `description` (including its acceptance criteria), its `scope`, and the
+project's test conventions.
+
+## The blindness rule
+
+You MUST NOT read, and were not given:
+- The implementation diff or any source file changed by this feature.
+- The implementer's completion message or report.
+- Any test file the implementer authored (the lead names it in your spawn prompt as a
+  do-not-read; do not open it even if you encounter its path incidentally).
+
+If any of these appear in your context by accident (a stray file reference, a
+tool result that leaks implementer content), stop and tell the lead rather than
+using it — a conformance test written with knowledge of the implementation is not a
+conformance test, it is the same reward-hacking surface this agent exists to close.
+Derive every test from the verified feature description and acceptance criteria
+alone. You may read the project's existing test conventions (naming, framework,
+directory layout) to write idiomatic tests, but never the implementer's own tests for
+THIS feature.
+
+## What you produce
+
+Write behavior tests under the project's test tree in a `conformance/` subpath (or the
+stack's own suffix convention for a distinctly-purposed test file, e.g.
+`*.conformance.test.ts`) — one test per acceptance criterion where it is testable at
+all from black-box behavior alone.
+
+Run them via `.harness/init.sh full_test`. Report to the lead, per acceptance
+criterion:
+- **PASS**: the criterion holds against the observed behavior.
+- **FAIL**: the criterion does not hold — a finding for the lead, routed back for a
+  fix. You do not fix it yourself.
+- **NOT-TESTABLE**: with a concrete reason (e.g. requires UI automation this project
+  doesn't have, describes an internal implementation detail rather than an observable
+  behavior). Honest partial coverage beats a fabricated pass.
+
+## Constraints
+
+- You cannot fix source. Bash is for running the test suite only, by instruction —
+  never for touching implementation files. Route every FAIL to the lead as a finding;
+  do not attempt a fix yourself even if it looks trivial.
+- Do not write to any file outside the `conformance/` test path (or stack-equivalent)
+  named in your spawn prompt.
+- Report your PASS/FAIL/NOT-TESTABLE table to the lead via SendMessage when spawned as
+  an Agent Teams teammate; as a plain subagent (fallback mode), return the same table
+  as your final message instead.

--- a/rules/agent-teams-protocol.md
+++ b/rules/agent-teams-protocol.md
@@ -552,6 +552,7 @@ Model mixing reduces per-implementer token cost by roughly 5x (Sonnet vs Opus). 
 - For two features that each touch fewer than 3 files, sequential single-session is cheaper
 - The more independent the features, the better the parallelism payoff (less SendMessage overhead)
 - Reviewer teammates on Opus are worth the cost for features touching 10+ files; skip them for smaller scopes
+- The author-blind conformance tester (F017/OVI-65) costs one Sonnet pass per elevated-risk or plan-approval-gated feature it's spawned for -- it's opt-in per feature (Phase 4 step 3.5 in `harness-continue`), not a per-session fixed cost, so it doesn't change the break-even math above for teams that never trigger it.
 
 Don't optimize for cost at the expense of quality. The point of model mixing is to put reasoning power where it matters most (lead decisions, code review) and use efficient models for well-scoped, well-defined implementation work.
 

--- a/skills/harness-continue/SKILL.md
+++ b/skills/harness-continue/SKILL.md
@@ -389,6 +389,38 @@ When all teammates complete:
    - Identify conflicting changes via `git diff`
    - Revert cleanly rather than attempting broken merges
    - Record conflict resolution in `context_summary.md`
+3.5. **Author-blind conformance check (optional, F017/OVI-65)**: for a feature whose
+   `spec.verdict` is `"PASS"` AND (its stamp/prep `risk` is `"elevated"`, OR its
+   teammate had `require_plan_approval: true`), spawn the conformance tester BEFORE
+   marking the feature passing. Adapted from agent-os's `conformance-test-writer`
+   pattern (nodera-studio, MIT): a single context that writes both the code and its
+   tests can satisfy a bug with a test that matches the bug — this step derives tests
+   from the verified spec alone, never from the implementation.
+
+   ```
+   Agent({
+     description: "Author-blind conformance test for F0NN",
+     subagent_type: "vv-harness:conformance-tester",
+     model: "sonnet",
+     prompt: "[the feature's verified description, including its numbered acceptance
+               criteria, exactly as it appears in features.json; the feature's scope;
+               the project's test conventions (framework, directory layout, naming).
+               Do NOT read: [implementer's test_file path], the implementation diff,
+               or the implementer's completion message.]"
+   })
+   ```
+
+   Route the result:
+   - All PASS (or PASS plus honest NOT-TESTABLE criteria): proceed to mark the feature
+     passing; record `proof.evidence_type: "conformance"` on the feature, with the
+     conformance test file(s) as `artifact` and any NOT-TESTABLE criteria named in
+     `not_established`.
+   - Any FAIL: do NOT mark the feature passing. The FAIL is a finding routed back for
+     a fix (to the implementer, or fixed directly by the lead), same as any other
+     pre-passing defect — the conformance tester never fixes source itself.
+
+   **Single-session mode**: this step is available but manual — run it only if the
+   user asks for it; it is not a default part of the single-session TDD loop.
 4. Update `.harness/features.json` for each completed feature (status, test_file, coverage, clear assigned_to)
 5. Append decisions and patterns to `.harness/context_summary.md`
 

--- a/skills/harness-continue/SKILL.md
+++ b/skills/harness-continue/SKILL.md
@@ -390,12 +390,27 @@ When all teammates complete:
    - Revert cleanly rather than attempting broken merges
    - Record conflict resolution in `context_summary.md`
 3.5. **Author-blind conformance check (optional, F017/OVI-65)**: for a feature whose
-   `spec.verdict` is `"PASS"` AND (its stamp/prep `risk` is `"elevated"`, OR its
-   teammate had `require_plan_approval: true`), spawn the conformance tester BEFORE
-   marking the feature passing. Adapted from agent-os's `conformance-test-writer`
-   pattern (nodera-studio, MIT): a single context that writes both the code and its
-   tests can satisfy a bug with a test that matches the bug — this step derives tests
-   from the verified spec alone, never from the implementation.
+   `spec.verdict` is `"PASS"` AND EITHER of the following holds, spawn the conformance
+   tester BEFORE marking the feature passing:
+   - Its Linear readiness stamp (if one was minted; `${CLAUDE_PLUGIN_ROOT}/schemas/readiness-stamp.md`)
+     recorded `risk: "elevated"`. `risk` is NOT itself persisted on the local feature
+     object today, so check the stamp comment directly (or the Phase 1 team-design
+     notes, if the lead recorded the risk classification there) rather than expecting
+     a `features.json` field to hold it.
+   - The lead set `require_plan_approval: true` for this feature's teammate during
+     Phase 1. This is a live decision the lead makes in-session, not a field read back
+     from `features.json` — if Phase 1 happened in an earlier, now-compacted context
+     and the decision isn't in current context, treat this condition as unknown rather
+     than assuming false.
+
+   (Neither condition is a durable, machine-checkable field on the feature object
+   today; persisting `risk` on `features.json` so this trigger doesn't depend on the
+   lead's own memory or a live Linear lookup is a natural follow-up, not done here.)
+
+   Adapted from agent-os's `conformance-test-writer` pattern (nodera-studio, MIT): a
+   single context that writes both the code and its tests can satisfy a bug with a
+   test that matches the bug — this step derives tests from the verified spec alone,
+   never from the implementation.
 
    ```
    Agent({

--- a/skills/harness-continue/SKILL.md
+++ b/skills/harness-continue/SKILL.md
@@ -401,7 +401,10 @@ When all teammates complete:
      Phase 1. This is a live decision the lead makes in-session, not a field read back
      from `features.json` — if Phase 1 happened in an earlier, now-compacted context
      and the decision isn't in current context, treat this condition as unknown rather
-     than assuming false.
+     than assuming false. Since this whole step is optional, don't spawn the
+     conformance tester on an unknown condition alone — mention the ambiguity to the
+     user (e.g. "this feature may have needed plan approval, but I don't have that
+     decision in context; run a conformance check anyway?") and let them decide.
 
    (Neither condition is a durable, machine-checkable field on the feature object
    today; persisting `risk` on `features.json` so this trigger doesn't depend on the

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -8019,6 +8019,79 @@ else
 fi
 
 echo ""
+echo "== F017: author-blind conformance tester =="
+
+CONFORMANCE_AGENT="$REPO_ROOT/agents/conformance-tester.md"
+
+# AC2: the blindness rule is present verbatim-strength, and the forbidden-inputs
+# list explicitly names the diff, the completion message, and implementer tests.
+if grep -q "MUST NOT read" "$CONFORMANCE_AGENT" \
+  && grep -qi "implementation diff" "$CONFORMANCE_AGENT" \
+  && grep -qi "completion message" "$CONFORMANCE_AGENT" \
+  && grep -qi "implementer authored\|implementer's own tests\|implementer wrote" "$CONFORMANCE_AGENT"; then
+  pass "f017: conformance-tester.md's blindness rule is stated verbatim-strength with the forbidden-inputs list (AC2)"
+else
+  fail "f017: conformance-tester.md is missing the blindness rule or its forbidden-inputs list"
+fi
+
+# AC1 (frontmatter specifics not already covered by the generic agent lint above):
+# right tools (Write for test files, Bash for running the suite only, no Edit),
+# and the model is sonnet per spec item 1.
+CONFORMANCE_FM_ERRORS=$(python3 - "$CONFORMANCE_AGENT" <<'PYEOF'
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path).read()
+fm = text.split("---")[1]
+
+if not re.search(r"^model:\s*sonnet\s*$", fm, re.MULTILINE):
+    print("model should be sonnet")
+
+tools_match = re.search(r"^tools:\s*(.+)$", fm, re.MULTILINE)
+if not tools_match:
+    print("no tools: line found")
+else:
+    tools = {t.strip() for t in tools_match.group(1).split(",")}
+    expected = {"Read", "Grep", "Glob", "Write", "Bash"}
+    if tools != expected:
+        print(f"tools should be exactly {sorted(expected)}, got {sorted(tools)}")
+PYEOF
+)
+if [ -z "$CONFORMANCE_FM_ERRORS" ]; then
+  pass "f017: conformance-tester.md has model sonnet and the exact expected tool set (AC1)"
+else
+  fail "f017: conformance-tester.md frontmatter -- $CONFORMANCE_FM_ERRORS"
+fi
+
+# Spec item 4: one attribution line.
+if grep -qi "agent-os" "$CONFORMANCE_AGENT" && grep -qi "nodera-studio" "$CONFORMANCE_AGENT" \
+  && grep -qi "MIT" "$CONFORMANCE_AGENT"; then
+  pass "f017: conformance-tester.md attributes the agent-os pattern (nodera-studio, MIT)"
+else
+  fail "f017: conformance-tester.md is missing the attribution line"
+fi
+
+# AC4: harness-continue documents the trigger conditions and the spawn prompt template.
+HC_SKILL_F017="$REPO_ROOT/skills/harness-continue/SKILL.md"
+if grep -q "vv-harness:conformance-tester" "$HC_SKILL_F017" \
+  && grep -q "elevated" "$HC_SKILL_F017" && grep -q "require_plan_approval: true" "$HC_SKILL_F017"; then
+  pass "f017: harness-continue/SKILL.md documents the conformance-tester trigger conditions (AC4)"
+else
+  fail "f017: harness-continue/SKILL.md is missing the conformance-tester trigger conditions"
+fi
+if grep -q 'subagent_type: "vv-harness:conformance-tester"' "$HC_SKILL_F017"; then
+  pass "f017: harness-continue/SKILL.md has the conformance-tester spawn prompt template (AC4)"
+else
+  fail "f017: harness-continue/SKILL.md is missing the conformance-tester spawn prompt template"
+fi
+if grep -qi 'evidence_type.*"conformance"\|evidence_type: "conformance"' "$HC_SKILL_F017"; then
+  pass "f017: harness-continue/SKILL.md documents recording proof.evidence_type conformance"
+else
+  fail "f017: harness-continue/SKILL.md does not document recording proof.evidence_type conformance"
+fi
+
+echo ""
 echo "== shell syntax =="
 
 for SCRIPT in "$HOOKS_DIR"/*.sh "$SCRIPT_DIR/run-tests.sh" "$REPO_ROOT/scripts/stamp.sh"; do

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -8103,12 +8103,32 @@ else
   fail "f017: conformance-tester.md is missing the attribution line"
 fi
 
-# Edge case/NFR: token cost is documented (one sonnet pass per elevated feature).
-if grep -q "F017/OVI-65" "$REPO_ROOT/rules/agent-teams-protocol.md" \
-  && grep -q "one Sonnet pass" "$REPO_ROOT/rules/agent-teams-protocol.md"; then
+# Edge case/NFR: token cost is documented (one sonnet pass per elevated feature),
+# anchored to the actual Cost Considerations section rather than anywhere in the
+# file -- the assertion message claims a specific section, so the check should too
+# (PR #102 round 2 review: relocating the line elsewhere in the file still passed
+# a whole-file grep).
+COST_SECTION_ERRORS=$(python3 - "$REPO_ROOT/rules/agent-teams-protocol.md" <<'PYEOF'
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path).read()
+match = re.search(r"## Cost Considerations\n(.*?)(?=\n## )", text, re.DOTALL)
+if not match:
+    print("could not find the Cost Considerations section")
+    sys.exit(0)
+section = match.group(1)
+if "F017/OVI-65" not in section:
+    print("Cost Considerations section does not mention F017/OVI-65")
+if "one Sonnet pass" not in section:
+    print("Cost Considerations section does not mention the one-Sonnet-pass cost")
+PYEOF
+)
+if [ -z "$COST_SECTION_ERRORS" ]; then
   pass "f017: the token cost NFR is documented in rules/agent-teams-protocol.md's Cost Considerations"
 else
-  fail "f017: the token cost NFR is not documented"
+  fail "f017: token cost NFR -- $COST_SECTION_ERRORS"
 fi
 
 # AC4: harness-continue documents the trigger conditions and the spawn prompt

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -8024,14 +8024,45 @@ echo "== F017: author-blind conformance tester =="
 CONFORMANCE_AGENT="$REPO_ROOT/agents/conformance-tester.md"
 
 # AC2: the blindness rule is present verbatim-strength, and the forbidden-inputs
-# list explicitly names the diff, the completion message, and implementer tests.
-if grep -q "MUST NOT read" "$CONFORMANCE_AGENT" \
-  && grep -qi "implementation diff" "$CONFORMANCE_AGENT" \
-  && grep -qi "completion message" "$CONFORMANCE_AGENT" \
-  && grep -qi "implementer authored\|implementer's own tests\|implementer wrote" "$CONFORMANCE_AGENT"; then
-  pass "f017: conformance-tester.md's blindness rule is stated verbatim-strength with the forbidden-inputs list (AC2)"
+# list explicitly names the diff, the completion message, and implementer tests --
+# scoped to the INSTRUCTION BODY (frontmatter stripped) and specifically within the
+# blindness-rule section itself, not just anywhere in the file. A naive whole-file
+# grep would still pass with the entire rule deleted, since the frontmatter
+# `description:` field independently mentions these same words as agent-selection
+# metadata (caught in PR #102 round 1 review, reproduced live: deleting the whole
+# "## The blindness rule" section and replacing it with unrelated text left a
+# whole-file grep passing).
+BLINDNESS_ERRORS=$(python3 - "$CONFORMANCE_AGENT" <<'PYEOF'
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path).read()
+parts = text.split("---", 2)
+if len(parts) < 3:
+    print("could not split frontmatter from body")
+    sys.exit(0)
+body = parts[2]
+
+section_match = re.search(r"## The blindness rule\n(.*?)(?=\n## )", body, re.DOTALL)
+if not section_match:
+    print("no '## The blindness rule' section found in the instruction body")
+    sys.exit(0)
+section = section_match.group(1)
+
+if "MUST NOT read" not in section:
+    print("blindness-rule section does not state MUST NOT read")
+for phrase in ("implementation diff", "completion message"):
+    if phrase.lower() not in section.lower():
+        print(f"blindness-rule section is missing: {phrase!r}")
+if not re.search(r"implementer authored|implementer's own tests|implementer wrote", section, re.IGNORECASE):
+    print("blindness-rule section does not name implementer-authored tests as forbidden")
+PYEOF
+)
+if [ -z "$BLINDNESS_ERRORS" ]; then
+  pass "f017: conformance-tester.md's blindness-rule SECTION states the rule and forbidden-inputs list (AC2)"
 else
-  fail "f017: conformance-tester.md is missing the blindness rule or its forbidden-inputs list"
+  fail "f017: blindness rule -- $BLINDNESS_ERRORS"
 fi
 
 # AC1 (frontmatter specifics not already covered by the generic agent lint above):
@@ -8072,13 +8103,44 @@ else
   fail "f017: conformance-tester.md is missing the attribution line"
 fi
 
-# AC4: harness-continue documents the trigger conditions and the spawn prompt template.
-HC_SKILL_F017="$REPO_ROOT/skills/harness-continue/SKILL.md"
-if grep -q "vv-harness:conformance-tester" "$HC_SKILL_F017" \
-  && grep -q "elevated" "$HC_SKILL_F017" && grep -q "require_plan_approval: true" "$HC_SKILL_F017"; then
-  pass "f017: harness-continue/SKILL.md documents the conformance-tester trigger conditions (AC4)"
+# Edge case/NFR: token cost is documented (one sonnet pass per elevated feature).
+if grep -q "F017/OVI-65" "$REPO_ROOT/rules/agent-teams-protocol.md" \
+  && grep -q "one Sonnet pass" "$REPO_ROOT/rules/agent-teams-protocol.md"; then
+  pass "f017: the token cost NFR is documented in rules/agent-teams-protocol.md's Cost Considerations"
 else
-  fail "f017: harness-continue/SKILL.md is missing the conformance-tester trigger conditions"
+  fail "f017: the token cost NFR is not documented"
+fi
+
+# AC4: harness-continue documents the trigger conditions and the spawn prompt
+# template -- anchored to the step 3.5 block itself, not the whole file. A whole-file
+# grep for "require_plan_approval: true" would pass even with that clause removed
+# from step 3.5, since the identical string already exists in an unrelated Phase 1
+# bullet elsewhere in this file (caught in PR #102 round 1 review, reproduced live).
+HC_SKILL_F017="$REPO_ROOT/skills/harness-continue/SKILL.md"
+STEP_3_5_ERRORS=$(python3 - "$HC_SKILL_F017" <<'PYEOF'
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path).read()
+match = re.search(r"3\.5\. \*\*Author-blind conformance check.*?(?=\n4\. )", text, re.DOTALL)
+if not match:
+    print("could not find the step 3.5 block")
+    sys.exit(0)
+step = match.group(0)
+
+if "vv-harness:conformance-tester" not in step:
+    print("step 3.5 does not name vv-harness:conformance-tester")
+if "elevated" not in step:
+    print("step 3.5 does not mention elevated risk")
+if "require_plan_approval: true" not in step:
+    print("step 3.5 does not mention require_plan_approval: true")
+PYEOF
+)
+if [ -z "$STEP_3_5_ERRORS" ]; then
+  pass "f017: harness-continue/SKILL.md's step 3.5 documents the conformance-tester trigger conditions (AC4)"
+else
+  fail "f017: step 3.5 trigger conditions -- $STEP_3_5_ERRORS"
 fi
 if grep -q 'subagent_type: "vv-harness:conformance-tester"' "$HC_SKILL_F017"; then
   pass "f017: harness-continue/SKILL.md has the conformance-tester spawn prompt template (AC4)"


### PR DESCRIPTION
## Summary
- New `agents/conformance-tester.md` (`vv-harness:conformance-tester`, sonnet, tools `Read, Grep, Glob, Write, Bash`): derives behavior tests from a feature's verified description and acceptance criteria alone. Hard forbidden from reading the implementation diff, the implementer's completion message, or any implementer-authored test file. Writes tests under a `conformance/` subpath, runs them via `.harness/init.sh full_test`, reports PASS/FAIL/NOT-TESTABLE per criterion. Never fixes source itself — a FAIL is a finding routed to the lead. Adapted from agent-os's `conformance-test-writer` pattern (nodera-studio, MIT).
- `harness-continue` Phase 4 gains an optional step (3.5): for a feature with `spec.verdict` `PASS` and either elevated risk or `require_plan_approval`, spawn the conformance tester before marking the feature passing. All-PASS (or PASS plus honest NOT-TESTABLE) records `proof.evidence_type: "conformance"`; any FAIL blocks marking passing. Single-session mode: available but manual.
- AC3 (schema accepts `evidence_type: "conformance"`) needed no change — F010/OVI-52 had already added it to both the `qa_binding` and `proof.evidence_type` enums proactively when it shipped; confirmed via `git blame` and the pre-existing `fsv: accepts qa_binding value 'conformance'` test before assuming an edit was needed.

## Testing
- New `test/run-tests.sh` section covers AC1 (frontmatter model/tools beyond what the generic agent lint already checks automatically), AC2 (the blindness rule and its forbidden-inputs list — mutation-tested), the attribution line, and AC4 (the trigger conditions and spawn prompt template are documented in `harness-continue`).
- Full suite: 1417/1417 assertions passing (`bash test/run-tests.sh`).

## Dependencies
Linear OVI-65. Depends on F010 (already merged, proof/qa_binding schema).