### PR TITLE
feat: optional dual-engine review (F018/OVI-66)

### DIFF
--- a/.harness/claude-progress.txt
+++ b/.harness/claude-progress.txt
@@ -648,3 +648,24 @@
   (discovered_via F013), per Ovidiu's standing instruction to keep working through
   everything from Linear without waiting for check-ins.
 - Blockers: none.
+
+## Session 31 - 2026-08-01 (F018/OVI-66: optional dual-engine review)
+- Feature: F018 - optional dual-engine review (Codex second reviewer + synthesizer rules)
+- Status: complete
+- Documentation/protocol-only (AC3: no new executable code paths). New "## Dual-Engine
+  Review" section in rules/agent-teams-protocol.md: optional harness.json
+  review.second_engine config, blind-parallel spawn rule, explicit skip-with-note when
+  the codex CLI is absent, the pinned `codex review --base <BASE_BRANCH>` invocation,
+  and the 4 synthesis rules (dedupe by defect, single-engine CRITICAL survives,
+  cross-engine agreement raises confidence, provenance via git show merge-base).
+  agents/reviewer.md gained a pointer to the synthesis rules and a blindness
+  instruction. README.md documents it in the Parallel work section.
+- Verified live 2026-08-01 on Codex CLI 0.145.0: confirmed the exact `codex review
+  --base` flag via --help and CLI auth/reachability via `codex doctor`, but did NOT
+  run a full review (avoiding unauthorized Codex subscription spend) -- the annotation
+  states precisely what was and wasn't verified.
+- Tests: 1421/1421 passing (full_test is the gate; +3 F018 assertions, mutation-tested).
+- Next: F019-F021 (three remaining Linear OVI-44 sub-issues) and F063/F064 (discovered
+  follow-ups), per Ovidiu's standing instruction to keep working through everything
+  from Linear without waiting for check-ins.
+- Blockers: none.

--- a/.harness/context_summary.md
+++ b/.harness/context_summary.md
@@ -4,14 +4,9 @@ Persistent record of architectural decisions, discovered patterns, gotchas, and 
 This file is referenced in CLAUDE.md and loaded every session.
 
 ## Active Context
-- The entire locally-discovered bug/design-gap chain that started with F023 is now CLOSED: F023-F062 (40 features, no Linear issue) all shipped, each through the standard TDD + mutation-test + adversarial-review-to-APPROVE loop. Full per-feature detail lives in features.json's own per-feature `notes` fields and the per-feature Meta-Session entries below; `claude-progress.txt`'s consolidated session entries cover the wall-clock history.
-- Freshest arc (F055-F062, prior session, see Meta-Session 2026-07-31 below): the LEAD_OWNED protection family (harness.json, teammate-scope.txt, .harness/mld/) plus TeammateIdle/shutdown coordination fixes (F055, F059) plus one pure-research feature that resolved to documentation instead of code (F061).
-- **Correction, 2026-07-31**: the long-repeated "F012/F013 blocked awaiting Ovidiu's answers" claim (carried across many session handoffs since session 11) was stale, not current. `features.json`'s own `spec` field showed `verdict: "PASS"` for both, sha256(description) matched the stored hash exactly (no drift), and direct Linear queries (`get_issue`, `list_comments`) on OVI-53 and OVI-63 showed zero open-question comment threads. Ovidiu confirmed to proceed once this was surfaced. Lesson: a claim repeated across many handoffs with no fresh evidence is a signal to re-verify, not to re-relay.
-- F012/OVI-53 (portable readiness-stamp signing) shipped, merged to main (PR #98). See F012's own `notes` for the `prep.kick_command` spec-conformance catch.
-- F013/OVI-63 (mechanical stamp for /harness-init) shipped, merged to main (PR #99). Filed F063 (discovered_via F013, harness-doctor/fixes.py wiring drift, pre-existing and out of scope) as a follow-up.
-- F015/OVI-55 (promotion ladder + ablation pass in Phase 5.5) shipped, merged to main (PR #100).
-- F016/OVI-57 (worker epoch record + requalification checklist) shipped, merged to main (PR #101, 2 review rounds -- round 1 caught the feature was inert: spec item 1 said the worker block is "written by /harness-init" but no code path ever wrote it, fixed by adding the write step outside the declared scope list and recording a scope_expansion).
-- F017/OVI-65 (author-blind conformance tester) implemented. New agents/conformance-tester.md (sonnet): derives behavior tests from a feature's verified description alone, hard-forbidden from reading the implementation diff/completion message/implementer tests. Wired as an optional harness-continue Phase 4 step for spec-verified + elevated-risk features. AC3 (schema evidence_type "conformance") was already satisfied by F010's proactive addition -- confirmed via git blame before assuming a schema change was needed. Full detail in F017's own `notes`/`approaches_tried`.
+- The entire locally-discovered bug/design-gap chain that started with F023 is now CLOSED: F023-F062 (40 features, no Linear issue) all shipped. Full per-feature detail lives in features.json's own per-feature `notes` fields and the per-feature Meta-Session entries below; `claude-progress.txt`'s consolidated session entries cover the wall-clock history.
+- Linear-tracked arc (F012-F021, the OVI-44 A-series/P-series sub-issues), all shipped so far through the same TDD + mutation-test + adversarial-review-to-APPROVE loop: F012/OVI-53 (PR #98), F013/OVI-63 (PR #99, filed F063 as a follow-up), F015/OVI-55 (PR #100), F016/OVI-57 (PR #101), F017/OVI-65 (PR #102, filed F064 as a follow-up -- F016's `risk` trigger and F017's own conformance-tester trigger share the same underlying gap, that `risk`/`require_plan_approval` aren't persisted durably on the feature object), F018/OVI-66 (dual-engine review, docs/protocol only) implemented this session. See each feature's own `notes`/`approaches_tried` for the specific catches each review round made.
+- F019-F021 (three remaining Linear OVI-44 sub-issues) and F063/F064 (discovered follow-ups) are next, worked in the same autonomous loop.
 - Ovidiu, before going to sleep, gave a standing instruction to keep working through everything from Linear until done, without waiting for check-ins between features -- F018-F021 (four remaining Linear OVI-44 sub-issues) and F063 (discovered_via F013) are next, worked in the same autonomous loop (implement -> TDD/mutation-test -> review -> merge).
 - No other locally-discovered work is queued.
 
@@ -1001,5 +996,25 @@ This file is referenced in CLAUDE.md and loaded every session.
 - Approach patterns: mutation-tested both new lint checks (the frontmatter
   tools-set check, the blindness-rule presence check) against targeted
   defects; both caught their mutation on the first attempt.
+- Plan approval: not applicable -- single-session implementation, no
+  teammates spawned.
+
+## Meta-Session 2026-08-01 (F018/OVI-66: optional dual-engine review)
+- Scope accuracy: held the declared scope exactly (rules/agent-teams-protocol.md,
+  agents/reviewer.md, README.md, test/run-tests.sh); zero scope_expansions.
+- Grounded a "verified live" annotation in genuine, minimal live verification
+  rather than either fabricating it or skipping it: checked `codex --help` and
+  `codex review --help` to confirm the exact pinned flag exists, and `codex
+  doctor` to confirm auth/reachability -- but deliberately did NOT run a full
+  `codex review` against a real diff, since that would spend Ovidiu's Codex
+  subscription usage without an explicit go-ahead for that specific action.
+  The annotation states precisely what was verified (command existence + auth)
+  versus what wasn't (a completed review's actual output), rather than letting
+  "verified live" imply more than it means.
+- Model calibration: single-session, no sub-agents spawned for implementation.
+- Discovery lineage: none -- F018 was a pre-existing Linear-tracked feature
+  (OVI-66), not discovered mid-work.
+- Approach patterns: mutation-tested the section-scoped synthesis-rules check
+  by deleting one of the four rules; caught correctly on the first attempt.
 - Plan approval: not applicable -- single-session implementation, no
   teammates spawned.

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -658,7 +658,7 @@
       "id": "F018",
       "description": "[OVI-66] A2: Optional dual-engine review (Codex second reviewer + synthesizer rules) \u2014 Add an optional harness.json review block enabling a blind second-engine (Codex CLI) review run in parallel with the Claude reviewer, with explicit skip-with-note when the CLI is absent, plus synthesizer rules (dedupe by defect, single-engine CRITICAL survives, cross-engine agreement raises confidence, provenance verified via git show merge-base). Document in the protocol and README.",
       "priority": 18,
-      "status": "pending",
+      "status": "passing",
       "scope": [
         "rules/agent-teams-protocol.md",
         "agents/reviewer.md",
@@ -667,12 +667,15 @@
       ],
       "depends_on": [],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
-      "notes": "Linear: OVI-66. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "test_file": "test/run-tests.sh (F018 section)",
+      "coverage": "n/a (shell/python fixture suite, no coverage tool; docs+protocol lint only, no new executable code path per AC3)",
+      "notes": "Linear: OVI-66. Documentation/protocol-only feature (AC3: \"no new executable code paths in the plugin\"). New \"## Dual-Engine Review\" section in rules/agent-teams-protocol.md: optional harness.json review.second_engine config, blind-parallel spawn rule, explicit skip-with-note when the codex CLI is absent, the pinned `codex review --base <BASE_BRANCH>` invocation, and the 4 synthesis rules (dedupe by defect, single-engine CRITICAL survives, cross-engine agreement raises confidence, provenance via git show merge-base). agents/reviewer.md gained a pointer to the same synthesis rules and an explicit blindness instruction. README.md documents it in the Parallel work section. Verified live 2026-08-01 on Codex CLI 0.145.0: confirmed `codex review --base <BRANCH>` is the exact real flag (via `codex review --help`) and the CLI is authenticated/reachable (via `codex doctor`) -- deliberately did NOT run a full end-to-end review to avoid spending the user's Codex subscription usage without explicit authorization; the annotation says exactly what was verified (command existence + auth) vs. not (a completed review's output shape), and says to re-verify a full run the first time this path actually triggers.",
       "correction_cycles": 0,
       "scope_expansions": [],
-      "approaches_tried": [],
+      "approaches_tried": [
+        "Checked codex CLI availability and its actual --help output before writing the pinned invocation, rather than guessing plausible flag names -- found a literal `codex review --base <BRANCH>` subcommand, and confirmed via `codex doctor` the CLI is authenticated and reachable, without spending a real review's worth of API/subscription usage on an unauthorized test run.",
+        "Mutation-tested the main section-scoped check by deleting one of the 4 synthesis rules; caught correctly."
+      ],
       "failure_reason": null,
       "discovered_via": null,
       "spec": {

--- a/README.md
+++ b/README.md
@@ -306,6 +306,17 @@ Use Agent Teams when two or more independent features are ready. The lead operat
 
 The `TaskCompleted` hook mechanically enforces passing tests before any task can be marked complete. The `TeammateIdle` hook prompts (but doesn't force) idle teammates to pick up the next pending feature.
 
+**Optional dual-engine review (F018/OVI-66)**: configure `.harness/harness.json`'s
+`review.second_engine: "codex"` to have the lead run a Codex CLI review in parallel
+with — and blind to — the Claude reviewer's own review. Absent the config, or absent
+the `codex` CLI on `PATH`, behavior is unchanged (single-engine review); a missing CLI
+skips with an explicit note rather than silently. Synthesis rules for combining both
+engines' findings (dedupe by defect, a single-engine CRITICAL always survives,
+cross-engine agreement raises confidence, provenance verified via `git show`) live in
+`rules/agent-teams-protocol.md`'s Dual-Engine Review section. The second engine costs
+Codex-subscription usage, not Claude tokens; the two engines disagree often on style,
+so only correctness/security findings get the cross-engine consensus treatment.
+
 ### When NOT to use
 
 * **Don't use Agent Teams** for features touching fewer than 3 files each — sequential single-session mode is cheaper. The Opus lead runs for the entire session regardless of teammate count; coordination overhead adds up.

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -21,7 +21,7 @@ Review for:
 - Coverage >= 95% on touched code (the harness gate)
 
 Constraints:
-- Bash is for running the test suite and `git diff` only — never for mutating the tree.
+- Bash is for running the test suite and read-only git inspection (`git diff`, `git show`) only — never for mutating the tree.
 - You cannot edit files by construction (no Edit/Write); do not attempt fixes yourself.
 - Report each finding to the lead via SendMessage with file:line, severity
   (critical / major / minor), and a concrete fix.

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -3,9 +3,9 @@ name: reviewer
 description: >-
   Harness Agent Teams review teammate. Senior review of completed features for
   correctness, scope adherence, test quality, and the 95% coverage gate. Cannot edit
-  files by construction (no Edit/Write tools); Bash is limited to test runs and git diff
-  by instruction. Reports findings to the lead via SendMessage. Spawn via the
-  harness-continue team workflow.
+  files by construction (no Edit/Write tools); Bash is limited to test runs and
+  read-only git inspection (git diff, git show) by instruction. Reports findings to
+  the lead via SendMessage. Spawn via the harness-continue team workflow.
 model: opus
 effort: high
 tools: Read, Grep, Glob, Bash

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -51,3 +51,13 @@ to you even though they are not in the tools list above (platform behavior). Whe
 as a plain subagent (fallback mode), SendMessage and TaskUpdate do not exist — report the
 same content in your final message instead, and treat spawn-prompt instructions that
 reference them accordingly.
+
+Dual-engine review (optional, F018/OVI-66): if the project's `.harness/harness.json` has
+a `review.second_engine` configured, the lead may also be running a Codex CLI review in
+parallel with yours. You review BLIND to it regardless — do not seek out or read any
+Codex output before delivering your own findings, the same way the Codex run is blind to
+yours. If the lead asks you to help synthesize both engines' findings into one list, apply
+the four synthesis rules in `${CLAUDE_PLUGIN_ROOT}/rules/agent-teams-protocol.md`'s Dual-Engine
+Review section (dedupe by defect not line, a single-engine CRITICAL survives, cross-engine
+agreement raises confidence, provenance checked via `git show <merge-base>:<file>` before
+labeling NEW vs. PRE-EXISTING) rather than just merging the two lists naively.

--- a/rules/agent-teams-protocol.md
+++ b/rules/agent-teams-protocol.md
@@ -231,7 +231,8 @@ Absent -- the current default -- means single-engine behavior, zero change.
 CLI review as a background Bash step over the feature branch diff, BLIND to the Claude
 reviewer's output: spawn the Claude reviewer teammate and start the Codex background
 step before reading either's result, so neither engine's findings can influence the
-other's.
+other's. **Worktree-fallback mode**: same flow -- the diff reviewed is the worktree
+branch's diff, not the lead's own working tree.
 
 Pinned invocation:
 ```bash
@@ -258,8 +259,8 @@ fixes):
    defect at slightly different line numbers (e.g. the function signature vs. its
    first call site) are ONE finding, not two.
 2. **A single-engine CRITICAL survives synthesis.** Cross-engine agreement is a
-   confidence signal, not a filter -- a defect only one engine caught is not
-   downgraded or dropped for lacking a second opinion, if its severity is CRITICAL.
+   confidence signal, not a filter -- a CRITICAL-severity defect only one engine
+   caught is never downgraded or dropped for lacking a second opinion.
 3. **Cross-engine agreement raises confidence, it doesn't gate inclusion.** When both
    engines independently flag the same defect, label it higher-confidence in the
    synthesized list; a single-engine finding is still included, just not labeled with
@@ -271,7 +272,7 @@ fixes):
 
 **Cost**: the second engine is Codex-subscription cost, not Claude tokens -- it adds
 no Sonnet/Opus spend to the session's own cost accounting in `## Cost Considerations`
-above.
+below.
 
 **Honest limits**: two engines disagree often on style; only correctness and security
 findings get the cross-engine consensus treatment above. A style disagreement between

--- a/rules/agent-teams-protocol.md
+++ b/rules/agent-teams-protocol.md
@@ -210,6 +210,79 @@ promptly rather than waiting for Phase 5 -- distinguishing the two cases is a ju
 call for the lead, not something the `TeammateIdle` hook can do on its own (it has no
 teammate identity to key off, confirmed during F055).
 
+## Dual-Engine Review (optional, F018/OVI-66)
+
+Source: agent-os's review doctrine (nodera-studio, MIT) -- "independent engines for
+recall, one synthesizer for precision." vv's reviewer is a single Opus agent reading
+the diff; a second, independently-run engine catches single-model blind spots at the
+cost of configuration, not a new dependency.
+
+**Config**: an optional `review` block in `.harness/harness.json`:
+```json
+{
+  "review": {
+    "second_engine": "codex"
+  }
+}
+```
+Absent -- the current default -- means single-engine behavior, zero change.
+
+**When the block is present AND `command -v codex` succeeds**, the lead runs the Codex
+CLI review as a background Bash step over the feature branch diff, BLIND to the Claude
+reviewer's output: spawn the Claude reviewer teammate and start the Codex background
+step before reading either's result, so neither engine's findings can influence the
+other's.
+
+Pinned invocation:
+```bash
+codex review --base <BASE_BRANCH>
+```
+`verified live 2026-08-01 on Codex CLI 0.145.0`: `codex review --help` confirms this
+exact flag (`--base <BRANCH>`, "Review changes against the given base branch") exists
+and matches this use case, and `codex doctor` confirmed the CLI is authenticated
+(ChatGPT auth) and its endpoint reachable. A full end-to-end review run was NOT
+executed as part of this verification (avoiding an unrequested spend against the
+user's Codex subscription) -- the command's existence, exact flag spelling, and the
+CLI's auth/reachability are what's verified live, not a completed review's output
+shape. Re-verify a full run the first time this path actually triggers.
+
+**If the CLI is absent or errors**, skip WITH an explicit line in the review summary:
+`"second engine unavailable: single-engine review"` -- never silently. A silent skip
+would let a config that looks like it's getting dual coverage quietly degrade to
+single-engine without anyone noticing.
+
+**Synthesis rules** (apply when both engines produced output; these govern how the
+lead or the Claude reviewer combines the two lists into what actually routes to
+fixes):
+1. **Dedupe by defect, not by file:line.** Two engines describing the same underlying
+   defect at slightly different line numbers (e.g. the function signature vs. its
+   first call site) are ONE finding, not two.
+2. **A single-engine CRITICAL survives synthesis.** Cross-engine agreement is a
+   confidence signal, not a filter -- a defect only one engine caught is not
+   downgraded or dropped for lacking a second opinion, if its severity is CRITICAL.
+3. **Cross-engine agreement raises confidence, it doesn't gate inclusion.** When both
+   engines independently flag the same defect, label it higher-confidence in the
+   synthesized list; a single-engine finding is still included, just not labeled with
+   that boost.
+4. **Provenance is verified, not guessed.** Before labeling a finding NEW vs.
+   PRE-EXISTING, check `git show <merge-base>:<file>` for the flagged region rather
+   than assuming from the diff alone -- a line that looks new in the diff view can be
+   an unmodified line inside a larger hunk.
+
+**Cost**: the second engine is Codex-subscription cost, not Claude tokens -- it adds
+no Sonnet/Opus spend to the session's own cost accounting in `## Cost Considerations`
+above.
+
+**Honest limits**: two engines disagree often on style; only correctness and security
+findings get the cross-engine consensus treatment above. A style disagreement between
+engines is not evidence either engine is wrong -- don't synthesize style findings the
+same way as correctness/security ones.
+
+**Out of scope**: a third engine (CodeRabbit, Gemini, etc.); Codex as an implementer
+(vv orchestrates Claude teams only, by design); automatically applying fixes from the
+synthesized findings list -- synthesis produces a routed list, a human or a teammate
+still does the fix.
+
 ## Teammate Responsibilities
 
 Each teammate is a focused implementer. It:

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -8174,6 +8174,79 @@ else
 fi
 
 echo ""
+echo "== F018: dual-engine review =="
+
+PROTOCOL_MD_F018="$REPO_ROOT/rules/agent-teams-protocol.md"
+DUAL_ENGINE_ERRORS=$(python3 - "$PROTOCOL_MD_F018" <<'PYEOF'
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path).read()
+match = re.search(r"## Dual-Engine Review.*?(?=\n## )", text, re.DOTALL)
+if not match:
+    print("could not find the Dual-Engine Review section")
+    sys.exit(0)
+section = match.group(0)
+
+# AC1: both conditions (no config, no CLI) are made explicit as producing
+# unchanged/single-engine behavior.
+if "zero change" not in section:
+    print("section does not state the no-config case is zero change")
+if "second engine unavailable: single-engine review" not in section:
+    print("section does not state the exact skip-with-note message")
+
+# AC2: blind-parallel rule, skip-with-note rule (checked above), the four
+# synthesis rules, and the pinned invocation with its verified-live annotation.
+if "BLIND to" not in section and "blind" not in section.lower():
+    print("section does not state the blind-parallel rule")
+if "codex review --base" not in section:
+    print("section does not pin the codex review --base invocation")
+if "verified live" not in section:
+    print("section does not carry a verified-live annotation")
+synthesis_markers = [
+    "Dedupe by defect",
+    "single-engine CRITICAL survives",
+    "Cross-engine agreement raises confidence",
+    "Provenance is verified",
+]
+missing = [m for m in synthesis_markers if m not in section]
+if missing:
+    print(f"section is missing synthesis rule(s): {missing}")
+
+# Spec item 4: cost note and honest limits.
+if "Codex-subscription cost" not in section:
+    print("section is missing the cost note (Codex-subscription cost, not Claude tokens)")
+if "disagree often on style" not in section:
+    print("section is missing the honest-limits note")
+
+# Spec item 5: attribution.
+if "agent-os" not in section or "nodera-studio" not in section or "MIT" not in section:
+    print("section is missing the attribution line")
+PYEOF
+)
+if [ -z "$DUAL_ENGINE_ERRORS" ]; then
+  pass "f018: rules/agent-teams-protocol.md's Dual-Engine Review section covers AC1/AC2 and spec items 4-5"
+else
+  fail "f018: Dual-Engine Review section -- $DUAL_ENGINE_ERRORS"
+fi
+
+# AC3: documented in README's team workflow section.
+if grep -q "F018/OVI-66" "$REPO_ROOT/README.md" && grep -q "review.second_engine" "$REPO_ROOT/README.md"; then
+  pass "f018: README.md documents dual-engine review in the team workflow section (AC3)"
+else
+  fail "f018: README.md does not document dual-engine review"
+fi
+
+# Spec item 3: synthesis rules are also referenced from the reviewer agent's own
+# instructions ("added to the reviewer/lead instructions").
+if grep -q "F018/OVI-66" "$REPO_ROOT/agents/reviewer.md" && grep -qi "synthesis rules" "$REPO_ROOT/agents/reviewer.md"; then
+  pass "f018: agents/reviewer.md references the dual-engine synthesis rules"
+else
+  fail "f018: agents/reviewer.md does not reference the dual-engine synthesis rules"
+fi
+
+echo ""
 echo "== shell syntax =="
 
 for SCRIPT in "$HOOKS_DIR"/*.sh "$SCRIPT_DIR/run-tests.sh" "$REPO_ROOT/scripts/stamp.sh"; do

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -8198,12 +8198,22 @@ if "second engine unavailable: single-engine review" not in section:
 
 # AC2: blind-parallel rule, skip-with-note rule (checked above), the four
 # synthesis rules, and the pinned invocation with its verified-live annotation.
-if "BLIND to" not in section and "blind" not in section.lower():
-    print("section does not state the blind-parallel rule")
+# Checking the word "blind" alone is a no-op: this same section separately says
+# a second engine "catches single-model blind spots", so a bare substring check
+# can never fail even with the actual blind-parallel sequencing rule deleted
+# (confirmed by PR #103 round 1 review: deleting the whole rule left this
+# passing). Assert the concrete sequencing instruction and the CLI gate instead.
+if "before reading either's result" not in section:
+    print("section does not state the blind-parallel sequencing rule")
+if "command -v codex" not in section:
+    print("section does not state the command -v codex gate")
 if "codex review --base" not in section:
     print("section does not pin the codex review --base invocation")
 if "verified live" not in section:
     print("section does not carry a verified-live annotation")
+if "was NOT" not in section or "Re-verify" not in section:
+    print("verified-live annotation is missing its own honesty caveat "
+          "(what was NOT verified, and the re-verify trigger)")
 synthesis_markers = [
     "Dedupe by defect",
     "single-engine CRITICAL survives",


### PR DESCRIPTION
## Summary
- New "## Dual-Engine Review" section in `rules/agent-teams-protocol.md`. Source: agent-os's review doctrine (nodera-studio, MIT) — independent engines for recall, one synthesizer for precision. Documentation/protocol only, per AC3 ("no new executable code paths in the plugin").
- Optional `harness.json` `review.second_engine: "codex"` config; absent means unchanged single-engine behavior.
- When configured and `command -v codex` succeeds: run the Codex CLI review as a background Bash step, blind to the Claude reviewer's output.
- Pinned invocation: `codex review --base <BASE_BRANCH>`. **Verified live 2026-08-01 on Codex CLI 0.145.0** — confirmed the exact flag via `codex review --help` and CLI auth/reachability via `codex doctor`, but deliberately did not run a full review (avoiding unauthorized spend against the user's Codex subscription). The annotation states precisely what was and wasn't verified.
- CLI absent or errors → skip WITH an explicit summary line ("second engine unavailable: single-engine review"), never silently.
- Four synthesis rules: dedupe by defect not file:line; a single-engine CRITICAL always survives; cross-engine agreement raises confidence without gating inclusion; provenance verified via `git show <merge-base>:<file>`.
- Cost note (Codex-subscription usage, not Claude tokens) and honest limits (only correctness/security findings get cross-engine consensus treatment).
- `agents/reviewer.md`: a pointer to the same synthesis rules plus an explicit blindness instruction. `README.md`: documented in the Parallel work (Agent Teams) section.

## Testing
- New `test/run-tests.sh` F018 section, section-scoped (not whole-file) so a check can't be satisfied by content living outside the actual Dual-Engine Review section — covers AC1, AC2, AC3, plus the `reviewer.md` cross-reference.
- Mutation-tested by deleting one synthesis rule; caught correctly.
- Full suite: 1421/1421 assertions passing (`bash test/run-tests.sh`).

## Dependencies
Linear OVI-66. No hard dependencies.