### PR TITLE
feat: add eval method doc + orientation-recovery A/B eval (F021, OVI-60)

### DIFF
--- a/.harness/claude-progress.txt
+++ b/.harness/claude-progress.txt
@@ -736,3 +736,50 @@
   follow-ups), per Ovidiu's standing instruction to keep working through everything
   from Linear without waiting for check-ins.
 - Blockers: none.
+
+## Session 34 - 2026-08-01 (F021/OVI-60: eval method doc + orientation-recovery eval)
+- Feature: F021 - eval method doc + first behavioral eval (orientation recovery A/B)
+- Status: complete. ALL 21 original Linear OVI-44 sub-issues (F001-F021) are now
+  shipped; only discovered follow-ups remain queued (F063, F064, F066, F067).
+- New evals/README.md (vv's eval contract, adapted from harness-engineering's eval
+  method, CC BY 4.0) and evals/orientation-recovery.md (the first executed eval).
+- The spec's literal `claude -p` subprocess protocol was attempted first and
+  confirmed blocked in this sandboxed session (auth failure, zero cost) without
+  touching credential-store configuration. Substituted fresh general-purpose
+  subagents given the real captured hook stdout (or nothing) as prompt content --
+  disclosed as a known deviation in the eval doc, not silently substituted.
+- Caught and fixed a real capture defect mid-eval, flagged by an eval subject
+  itself (not by me): an initial orientation-text capture had leaked a
+  SESSION_INCOMPLETE-gated warning block from an unrelated scratch directory used
+  earlier for an auth test. Discarded the entire first batch of 3 condition-A
+  runs, re-captured cleanly against the actual fixture, reran. Documented as a
+  worked example of the invalid-result checklist catching a real defect.
+- Result: "investigate further" (not keep/remove) -- all 6 valid runs (3
+  corrected condition-A + 3 condition-B) converged on identical behavior
+  (verify state against git, discover the shared fixture's own data/reality
+  mismatch, refuse to proceed, escalate) regardless of orientation. Zero of 6
+  runs claimed F003 or wrote any file. Likely cause: a dominant confound (this
+  fixture's state is re-derivable in one tool call), not evidence orientation is
+  worthless in general. A second, smaller deviation (a hint sentence given only
+  to the corrected condition-A batch) is also disclosed, not hidden.
+- Discovered and filed as follow-ups (both out of F021's scope): F066 (no hook
+  validates a passing feature's test_file actually exists on disk -- found
+  independently by 2 of 6 eval subjects) and F067 (TeammateIdle's escape hatch is
+  tool-based, not assignment-based; 5 of 6 eval subjects hit an idle-nudge loop
+  after finishing their read-only assignment and needed explicit shutdown --
+  same root gap F055 partially addressed, recurring for ad-hoc read-only
+  subagent assignments F055's reviewer-specific fix doesn't cover).
+- One overreach noted, not reversed: an eval subagent wrote unprompted to this
+  session's own persistent auto-memory store outside its assigned scratch
+  directory. Content was accurate and kept; surfaced to Ovidiu as a real scope
+  overreach, not filed as a feature (no vv mechanism failed -- the subagent had
+  an unrestricted Write tool it wasn't told not to use for this).
+- Tests: 1433/1433 passing (full_test is the gate; +5 F021 assertions, all
+  mutation-tested). One test-scoping gap found and fixed along the way: the
+  decision-word check initially matched the framing sentence in "Decision
+  informed" too, not just the actual verdict -- tightened to require a
+  "### Decision:" heading.
+- Next: F063, F064, F066, F067 (all discovered follow-ups, all `pending`), per
+  Ovidiu's standing instruction to keep working through everything without
+  waiting for check-ins.
+- Blockers: none.

--- a/.harness/claude-progress.txt
+++ b/.harness/claude-progress.txt
@@ -763,8 +763,8 @@
   worthless in general. A second, smaller deviation (a hint sentence given only
   to the corrected condition-A batch) is also disclosed, not hidden.
 - Discovered and filed as follow-ups (both out of F021's scope): F066 (no hook
-  validates a passing feature's test_file actually exists on disk -- found
-  independently by 2 of 6 eval subjects) and F067 (TeammateIdle's escape hatch is
+  validates a passing feature's test_file actually exists on disk -- raised by
+  1 of the 6 valid eval subjects) and F067 (TeammateIdle's escape hatch is
   tool-based, not assignment-based; 5 of 6 eval subjects hit an idle-nudge loop
   after finishing their read-only assignment and needed explicit shutdown --
   same root gap F055 partially addressed, recurring for ad-hoc read-only

--- a/.harness/context_summary.md
+++ b/.harness/context_summary.md
@@ -5,8 +5,8 @@ This file is referenced in CLAUDE.md and loaded every session.
 
 ## Active Context
 - The entire locally-discovered bug/design-gap chain that started with F023 is now CLOSED: F023-F062 (40 features, no Linear issue) all shipped. Full per-feature detail lives in features.json's own per-feature `notes` fields and the per-feature Meta-Session entries below; `claude-progress.txt`'s consolidated session entries cover the wall-clock history.
-- Linear-tracked arc (F012-F021, the OVI-44 A-series/P-series sub-issues), all shipped so far through the same TDD + mutation-test + adversarial-review-to-APPROVE loop: F012/OVI-53 (PR #98), F013/OVI-63 (PR #99, filed F063 as a follow-up), F015/OVI-55 (PR #100), F016/OVI-57 (PR #101), F017/OVI-65 (PR #102, filed F064 as a follow-up -- F016's `risk` trigger and F017's own conformance-tester trigger share the same underlying gap, that `risk`/`require_plan_approval` aren't persisted durably on the feature object), F018/OVI-66 (PR #103, dual-engine review, docs/protocol only), F019/OVI-58 (root AGENTS.md + rewritten CLAUDE.md), F020/OVI-59 (skills/harness-improve/SKILL.md, this session) implemented. See each feature's own `notes`/`approaches_tried` for the specific catches each review round made.
-- Ovidiu, before going to sleep, gave a standing instruction to keep working through everything from Linear until done, without waiting for check-ins between features -- F021 (the last remaining Linear OVI-44 sub-issue) and F063/F064 (discovered follow-ups) are next, worked in the same autonomous loop (implement -> TDD/mutation-test -> review -> merge).
+- Linear-tracked arc (F012-F021, the OVI-44 A-series/P-series sub-issues) is now COMPLETE, all shipped through the same TDD + mutation-test + adversarial-review-to-APPROVE loop: F012/OVI-53 (PR #98), F013/OVI-63 (PR #99, filed F063 as a follow-up), F015/OVI-55 (PR #100), F016/OVI-57 (PR #101), F017/OVI-65 (PR #102, filed F064 as a follow-up), F018/OVI-66 (PR #103), F019/OVI-58 (root AGENTS.md + rewritten CLAUDE.md), F020/OVI-59 (skills/harness-improve/SKILL.md), F021/OVI-60 (evals/README.md + evals/orientation-recovery.md, this session, filed F066+F067 as follow-ups). See each feature's own `notes`/`approaches_tried` for the specific catches each review round made.
+- Ovidiu, before going to sleep, gave a standing instruction to keep working through everything from Linear until done, without waiting for check-ins between features. With F021 shipped, ALL 21 original OVI-44 sub-issues are done -- remaining queued work is discovered follow-ups only: F063, F064, F066, F067 (all `pending`), worked in the same autonomous loop (implement -> TDD/mutation-test -> review -> merge).
 - No other locally-discovered work is queued.
 
 ## Cross-Cutting Concerns
@@ -1090,3 +1090,65 @@ This file is referenced in CLAUDE.md and loaded every session.
   convention, same "adapted from, not copied" framing.
 - Plan approval: not applicable -- single-session implementation, no teammates
   spawned.
+
+## Meta-Session 2026-08-01 (F021/OVI-60: eval method doc + orientation-recovery eval)
+- Scope accuracy: held the declared scope exactly (evals/README.md,
+  evals/orientation-recovery.md, README.md, test/run-tests.sh). No expansion
+  needed.
+- Real capability gap found and worked around, not silently: the spec's literal
+  protocol calls for `claude -p` subprocess invocations. Attempted first;
+  confirmed blocked (subprocess auth failure, zero cost, zero tokens) --
+  this session's own auth is supplied by its runtime, not the on-disk
+  credential files a fresh CLI process reads, and fixing that would mean
+  touching credential-store configuration without Ovidiu's explicit
+  confirmation. Substituted fresh general-purpose subagents given the real
+  captured hook stdout (or nothing) as prompt content, disclosed as a
+  known, non-silent deviation in the eval doc itself.
+- A real methodological defect was caught mid-eval by one of the eval
+  subjects, not by me: an initial orientation-text capture leaked a
+  SESSION_INCOMPLETE-gated warning block from an unrelated scratch directory
+  (an earlier `claude -p` auth-test had left that file behind there). The
+  subject tried to reproduce the warning against the fixture it could
+  actually see, found the gating file absent, and flagged it rather than
+  assuming the lead's claim was correct. Ground-truthed the leak myself,
+  discarded the entire first batch of 3 condition-A runs, re-captured
+  cleanly, and reran. This is the invalid-result checklist working exactly
+  as designed -- documented as a worked example in the eval doc, not
+  smoothed over.
+- Result was an honest null: all 6 valid runs (3 corrected condition-A + 3
+  condition-B) converged on identical behavior (verify state against git
+  before acting, discover the shared fixture's own data/reality mismatch,
+  refuse to proceed, escalate) regardless of whether orientation text was
+  injected. Decision recorded: "investigate further," not keep or remove --
+  the likely cause is a dominant confound (this fixture's state is
+  independently re-derivable in one `git ls-files`/`find` call), not evidence
+  that orientation is worthless. A second, smaller deviation (one hint
+  sentence given to the corrected condition-A batch but not condition B) is
+  also disclosed rather than hidden.
+- Discovery lineage: F066 (no hook validates a passing feature's test_file
+  actually exists -- 2 of 6 eval subjects found this independently) and F067
+  (TeammateIdle's escape hatch is tool-based, not assignment-based scope; 5
+  of 6 eval subjects hit an idle-nudge loop after finishing their read-only
+  assignment and needed explicit shutdown) both filed as follow-ups, both
+  out of F021's declared scope (hooks/, .claude/hooks/).
+- One overreach noted, not reversed: one eval subagent (general-purpose,
+  read-only fixture assignment) wrote unprompted to this session's own
+  persistent auto-memory store (a file outside its assigned scratch
+  directory) with a lesson about verifying injected orientation. The content
+  is accurate and consistent with what I independently verified, so it was
+  kept -- but a spawned subagent writing to shared, persistent state outside
+  its declared task is a real scope overreach worth surfacing to Ovidiu,
+  not something to file a feature for unprompted (no vv mechanism failed
+  here; the subagent had a Write tool it wasn't told not to use for this).
+- Model calibration: 9 general-purpose subagents spawned total across both
+  eval batches (3 discarded condition-A + 3 corrected condition-A + 3
+  condition-B), all Sonnet (inherited, no override) -- no implementation
+  subagents.
+- Approach patterns: adapted harness-engineering's eval method (CC BY 4.0)
+  into vv's own contract (decision-first, one intervention, fresh sessions,
+  availability/retrieval/relevance separated, invalid-result checklist,
+  fixed-worker recording) -- same "adapted from, not copied" attribution
+  convention as F017/F018/F020.
+- Plan approval: not applicable -- single-session implementation; eval
+  subagents were spawned directly (not via Agent Teams), so no plan-approval
+  step applied.

--- a/.harness/context_summary.md
+++ b/.harness/context_summary.md
@@ -1126,7 +1126,7 @@ This file is referenced in CLAUDE.md and loaded every session.
   sentence given to the corrected condition-A batch but not condition B) is
   also disclosed rather than hidden.
 - Discovery lineage: F066 (no hook validates a passing feature's test_file
-  actually exists -- 2 of 6 eval subjects found this independently) and F067
+  actually exists -- raised by 1 of the 6 valid eval subjects) and F067
   (TeammateIdle's escape hatch is tool-based, not assignment-based scope; 5
   of 6 eval subjects hit an idle-nudge loop after finishing their read-only
   assignment and needed explicit shutdown) both filed as follow-ups, both

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -1898,7 +1898,7 @@
     },
     {
       "id": "F066",
-      "description": "No vv hook cross-checks a feature's `passing`/`in-progress` status against its `test_file` actually existing (or its scope directories existing) in the working tree. session-start.sh faithfully reports whatever features.json says; nothing validates that the referenced paths resolve. Discovered independently by 2 of 6 eval-a2/eval-b subagents during F021's orientation-recovery eval, against test/fixtures/harness-project (whose F001/F002 entries cite test files that were never committed) -- faithful orientation can still hand a session a fabricated picture. Consider a lightweight doctor-style check (or a session-start.sh warning) when a passing feature's test_file path does not exist.",
+      "description": "No vv hook cross-checks a feature's `passing`/`in-progress` status against its `test_file` actually existing (or its scope directories existing) in the working tree. session-start.sh faithfully reports whatever features.json says; nothing validates that the referenced paths resolve. Raised by 1 of the 6 valid eval-a2/eval-b subagents during F021's orientation-recovery eval, against test/fixtures/harness-project (whose F001/F002 entries cite test files that were never committed) -- faithful orientation can still hand a session a fabricated picture. Consider a lightweight doctor-style check (or a session-start.sh warning) when a passing feature's test_file path does not exist.",
       "priority": 67,
       "status": "pending",
       "scope": [
@@ -1910,7 +1910,7 @@
       "assigned_to": null,
       "test_file": null,
       "coverage": null,
-      "notes": "discovered_via F021 (orientation-recovery eval, 2026-08-01): eval-a2-run2 and eval-a-run3 both independently found and reported this against test/fixtures/harness-project. Not fixed in F021 -- the fixture itself is shared by the entire mechanical test suite and is out of F021's declared scope (evals/README.md, evals/orientation-recovery.md, README.md, test/run-tests.sh).",
+      "notes": "discovered_via F021 (orientation-recovery eval, 2026-08-01): eval-a2-run2 (one of the 6 VALID runs) proposed this as the generalizable finding. A discarded round-1 subagent (eval-a-run3, excluded from the eval's results table -- see evals/orientation-recovery.md's capture-defect section) noticed the same underlying fixture inconsistency but did not itself count toward the eval; caught and corrected during PR #107 review, which found the original notes wrongly cited that discarded run as a second valid source. Not fixed in F021 -- the fixture itself is shared by the entire mechanical test suite and is out of F021's declared scope (evals/README.md, evals/orientation-recovery.md, README.md, test/run-tests.sh).",
       "correction_cycles": 0,
       "scope_expansions": [],
       "approaches_tried": [],

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -766,7 +766,7 @@
       "id": "F021",
       "description": "[OVI-60] P5.3: Eval method doc + first behavioral eval (orientation recovery A/B) \u2014 Add evals/README.md defining vv's proportionate eval contract (decision-first, one intervention, fresh sessions, separate availability/retrieval/relevance facts, invalid-result checklist, fixed-worker recording) and evals/orientation-recovery.md, an executed A/B on whether SessionStart orientation changes next-session behavior, with a committed results table and a stated decision.",
       "priority": 21,
-      "status": "pending",
+      "status": "passing",
       "scope": [
         "evals/README.md",
         "evals/orientation-recovery.md",
@@ -779,12 +779,18 @@
         "F003"
       ],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
-      "notes": "Linear: OVI-60. Full spec (incl. Amendment) re-verified per-issue by /harness-issue-prep before implementation.",
+      "test_file": "test/run-tests.sh",
+      "coverage": "F021 section: 5 assertions (AC1 method-doc elements, AC2 results-table/3-facts/decision/evidence-limit, AC3 x2 attribution + README link), all 5 mutation-tested (each caught, one test-scoping gap found and fixed along the way -- the decision-word check matched the framing sentence in 'Decision informed' too, tightened to require a '### Decision:' heading)",
+      "notes": "Linear: OVI-60. Method deviations (subprocess-auth blocker, capture-leak discard, hint-sentence asymmetry) are documented in evals/orientation-recovery.md itself, not just here. Filed F066 and F067 as genuine follow-ups discovered during the eval runs; both out of F021's declared scope.",
       "correction_cycles": 0,
       "scope_expansions": [],
-      "approaches_tried": [],
+      "approaches_tried": [
+        "Wrote evals/README.md (the vv eval contract, adapted from harness-engineering's method) and evals/orientation-recovery.md (the first executed eval).",
+        "Attempted the spec's literal `claude -p` subprocess protocol first; confirmed blocked in this sandboxed session (subprocess auth failure, zero cost) without touching credential stores. Substituted genuinely fresh general-purpose subagents given the real captured orientation text (or nothing) as prompt content -- disclosed as a known deviation in the doc, not silently substituted.",
+        "Ran 3 fresh subagents per condition (6 total) against copies of test/fixtures/harness-project. Discarded an entire first batch of 3 condition-A runs after one subject caught, unprompted, that the captured orientation text included a SESSION_INCOMPLETE-gated warning block that the actual fixture could not have produced -- ground-truthed the leak (an unrelated earlier scratch-dir command had left that file behind), re-captured cleanly, and redid all 3 condition-A runs. Documented the discard and its cause in the eval doc rather than hiding it.",
+        "Result: 'investigate further', not keep/remove -- all 6 valid runs (3A+3B) independently discovered the same fixture data/reality mismatch (features.json claims passing tests with no corresponding source/test files in git) and converged on identical behavior regardless of condition, so no differential effect of the orientation text was observed. Documented this as a dominant confound specific to this small, self-evidently-inconsistent fixture, not evidence that orientation is worthless in general.",
+        "Disclosed a second, smaller deviation: the corrected condition-A batch carried one hint sentence condition B never received (a real, if likely low-impact, departure from 'exactly one intervention'), rather than presenting the comparison as cleaner than it was."
+      ],
       "failure_reason": null,
       "discovered_via": null,
       "spec": {
@@ -1888,6 +1894,50 @@
       "approaches_tried": [],
       "failure_reason": null,
       "discovered_via": "F020",
+      "spec": null
+    },
+    {
+      "id": "F066",
+      "description": "No vv hook cross-checks a feature's `passing`/`in-progress` status against its `test_file` actually existing (or its scope directories existing) in the working tree. session-start.sh faithfully reports whatever features.json says; nothing validates that the referenced paths resolve. Discovered independently by 2 of 6 eval-a2/eval-b subagents during F021's orientation-recovery eval, against test/fixtures/harness-project (whose F001/F002 entries cite test files that were never committed) -- faithful orientation can still hand a session a fabricated picture. Consider a lightweight doctor-style check (or a session-start.sh warning) when a passing feature's test_file path does not exist.",
+      "priority": 67,
+      "status": "pending",
+      "scope": [
+        "hooks/session-start.sh",
+        "skills/harness-doctor/doctor.py",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "discovered_via F021 (orientation-recovery eval, 2026-08-01): eval-a2-run2 and eval-a-run3 both independently found and reported this against test/fixtures/harness-project. Not fixed in F021 -- the fixture itself is shared by the entire mechanical test suite and is out of F021's declared scope (evals/README.md, evals/orientation-recovery.md, README.md, test/run-tests.sh).",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": "F021",
+      "spec": null
+    },
+    {
+      "id": "F067",
+      "description": "check-remaining-tasks.sh's TeammateIdle nudge has two related gaps surfaced by F021's eval subagents (general-purpose, not vv-harness:reviewer): (1) its escape hatch ('if your role has no Edit/Write tools, this does not apply to you') is keyed on tool inventory, not on assignment scope -- a general-purpose subagent given an explicit read-only task (like an eval run) has Edit/Write by construction and gets nudged in a loop toward claiming the next feature, with no way to signal 'my assignment is scoped and complete' short of going idle and re-triggering the same nudge. (2) the claimable-feature count reads features.json status only and ignores task-level claims -- F021 was counted as unclaimed/claimable while TaskList showed task #8 in_progress under the lead, a features.json/TaskList sync gap. F055 (shipped) addressed the reviewer-specific case via agents/reviewer.md's construction-level guarantee; this is the same root design gap (TeammateIdle carries no teammate identity) recurring for ad-hoc read-only assignments the F055 fix doesn't cover.",
+      "priority": 68,
+      "status": "pending",
+      "scope": [
+        ".claude/hooks/check-remaining-tasks.sh"
+      ],
+      "depends_on": [
+        "F055"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "discovered_via F021 (orientation-recovery eval, 2026-08-01): 5 of 6 eval subagents hit the idle-nudge loop after delivering their read-only result and had to be explicitly shut down by the lead. Not fixed in F021 -- .claude/hooks/ is out of F021's declared scope.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": "F021",
       "spec": null
     }
   ]

--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ claude
 | `rules/task-completion.md` | Task completion checklist |
 | `templates/CLAUDE.md` | Core engineering standards template (manual copy to `~/.claude/`) |
 | `test/` | Fixture-based hook test suite, run in CI |
+| `evals/` | Proportionate behavioral evals: does an intervention change what the agent actually does, not just its terminology (semi-manual, not CI-wired) |
 
 ### The spec gate
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -74,6 +74,12 @@ decision about the intervention it tested, on the fixture and worker config it
 used, on the day it ran. It does not support a general claim about "how well
 Claude follows instructions" or any claim broader than the one named decision.
 
+**Cost bound**: a vv eval at proportionate scale costs roughly what ~6 short
+sessions cost (2 conditions x 3+ runs, each a fresh short session) -- not a
+research-grade sample, and not meant to be one. If a decision genuinely needs
+more than that to settle, that itself is a finding worth stating plainly rather
+than quietly running a bigger eval than this method was designed for.
+
 ---
 
 Adapted from harness-engineering's eval method, CC BY 4.0

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,80 @@
+# vv Evals
+
+Adapted from harness-engineering's eval method (CC BY 4.0): test behavioral effect,
+not terminology. An intervention succeeds when it changes what an agent actually
+does next, not when a transcript merely repeats the intervention's own words back.
+vv adopts this at proportionate scale -- semi-manual, small-N, decision-scoped --
+and explicitly skips the research apparatus (contamination scans, escrowed corpora,
+statistical power analysis) a general-purpose eval suite would need.
+
+## The contract
+
+Every vv eval states, up front:
+
+1. **The decision it informs.** Name the actual choice this eval's result will
+   settle (keep a mechanism, simplify it, remove it, or investigate further) --
+   not a vague "does this help" framing. If there's no decision waiting on the
+   result, it isn't a vv eval yet, just curiosity.
+2. **Exactly one named intervention.** Baseline (condition A) and treatment
+   (condition B) must differ by exactly one thing, stated explicitly. Any other
+   difference between the two conditions invalidates the comparison -- see the
+   checklist below.
+3. **Fresh sessions.** Every run starts with no memory of any other run in the
+   eval, baseline or treatment. A continued or resumed session contaminates the
+   signal (prior turns leak context the intervention didn't actually provide).
+4. **The same fixture and worker config across every run.** Same starting
+   repository state, same model(s), same CLI version. Record the fixed-worker
+   discipline's fields (`claude --version`, and the model(s) used for each role
+   in play) in the eval's own results table -- a rerun on a different worker
+   config starts a new epoch (P4.2 language) and is a different eval, not a
+   continuation of this one.
+5. **At least 3 runs per condition.** A single run per condition cannot
+   distinguish "the intervention did this" from "this run happened to go this
+   way." 3 is the proportionate floor for vv's scale, not a statistical claim.
+6. **Availability, retrieval, and relevance recorded separately.** These are
+   three different facts about an intervention and collapsing them hides the
+   real finding:
+   - **Available**: was the intervention actually present for this run (the
+     file existed, the hook fired, the flag was set)?
+   - **Retrieved**: did the agent actually consume it (read the file, the hook's
+     output appeared in context, the agent's own transcript shows it was seen)?
+   - **Relevant**: did having it change what the agent did, compared to a run
+     where it wasn't available?
+   An intervention can be available but never retrieved (dead weight), or
+   retrieved but not relevant (harmless but not earning its complexity), or
+   relevant in ways narrower than hoped. Only "available AND retrieved AND
+   relevant" supports keeping something on the strength of this eval alone.
+
+## Invalid-result checklist
+
+Before trusting a result, rule out each of these (adapted subset -- HE's full
+list is broader; this is the part that matters at vv's scale):
+
+- **Treatment never retrieved.** If the treatment condition's intervention was
+  available but no run's transcript shows it was actually consumed, the eval
+  measured nothing about the intervention -- it measured absence twice.
+- **Extra differences between conditions.** If baseline and treatment differ in
+  more than the one named intervention (different fixture state, different
+  model, different prompt wording, different tool access), the comparison is
+  confounded and the result is uninterpretable, however clean it looks.
+- **One rollout treated as representative.** Citing a single run's transcript
+  as "the" result when 3+ runs exist per condition is cherry-picking, even
+  unintentionally. Report the full per-run table.
+- **Activity metrics standing in for outcomes.** Counting tool calls, response
+  length, or turns taken is not the same as checking whether the accepted
+  outcome the eval names actually happened. Grade the outcome, not the busyness.
+
+## Scope and honesty about scale
+
+vv evals are semi-manual by design: a person (or an agent, self-disclosed as
+such) reads each transcript and grades it against named, binary facts stated in
+advance. There is no CI wiring, no corpus, no automated scoring pipeline. A vv
+eval is a bounded, one-decision instrument -- its result supports a local
+decision about the intervention it tested, on the fixture and worker config it
+used, on the day it ran. It does not support a general claim about "how well
+Claude follows instructions" or any claim broader than the one named decision.
+
+---
+
+Adapted from harness-engineering's eval method, CC BY 4.0
+(https://creativecommons.org/licenses/by/4.0/).

--- a/evals/orientation-recovery.md
+++ b/evals/orientation-recovery.md
@@ -108,6 +108,19 @@ or `find` call each -- so the hint's practical effect on the graded facts below 
 small, but this is judgment, not proof, and is recorded as a limitation on this eval's
 result, not erased from it.
 
+This does mean the eval reports a graded result despite an acknowledged extra
+difference -- evals/README.md's own checklist calls that "uninterpretable, however
+clean it looks," with no stated exception. The directional argument for why this
+particular case survives: the hint could only push condition A *toward* more
+verification and more explicit skepticism, never away from it. Condition B, with no
+hint at all, converged on the identical verify-then-refuse behavior anyway. A
+confound that can only inflate detection in one direction, when the other direction
+already shows the same detection unaided, cannot be what *produced* the observed
+null (no differential effect) -- at worst it makes the null slightly less
+surprising, not the reason both conditions agree. This is still an argument, not a
+proof, which is why it's recorded as a limitation rather than treated as resolving
+the issue.
+
 ## Method deviation from the spec's literal protocol (disclosed, not silent)
 
 The spec calls for running each condition via `claude -p` as a literal, independently
@@ -240,7 +253,7 @@ Neither "keep as-is" nor "remove" is supported by this run. The evidence:
    behavioral question: state discovery here is too cheap for an intervention about
    *pre-supplying* state to show a marginal effect.
 3. **A real, generalizable finding surfaced independently of the A/B question
-   itself** (raised by 2 of 6 runs, unprompted): no vv hook cross-checks a `passing`
+   itself** (raised by 1 of the 6 valid runs, unprompted): no vv hook cross-checks a `passing`
    feature's `test_file` against the working tree. Faithful orientation reporting
    can still hand a session a fabricated picture, because `session-start.sh` reports
    what `features.json` says, not what git contains. This is a plausible `harness-improve`
@@ -252,8 +265,9 @@ state is not independently re-derivable in one or two tool calls -- e.g., a larg
 checkout where `.harness/` isn't the only non-trivial directory, or a fixture whose
 metadata is internally consistent with its git history, so that verify-before-acting
 no longer dominates before orientation's marginal contribution can be isolated. That
-rerun is not performed here; scoping and building such a fixture is future work, not
-part of this eval's cost bound.
+rerun is not performed here; scoping and building such a fixture is future work,
+beyond the ~6-short-session cost bound this eval method is scaled to
+(`evals/README.md`'s "Cost bound").
 
 ### Known limits (bounded-claim guardrail, made concrete)
 
@@ -268,6 +282,11 @@ part of this eval's cost bound.
   condition B (the "some earlier runs" hint) not present in the original design.
 - No-overreach was vacuous on this fixture and provided no discriminating signal.
 - "Retrieved" is graded from self-report, not independent corroboration.
+- One discarded round-1 (pre-correction) subagent wrote unprompted to the lead's
+  own persistent auto-memory store, outside its assigned scratch directory --
+  a real tool-scope overreach, disclosed to Ovidiu directly rather than here, and
+  not something any of the 6 valid runs did (all 6 stayed strictly read-only, per
+  the Results section above).
 
 ---
 

--- a/evals/orientation-recovery.md
+++ b/evals/orientation-recovery.md
@@ -1,0 +1,276 @@
+# Eval: Orientation Recovery
+
+## Decision informed
+
+Does the SessionStart orientation block (the "## Harness orientation (auto-injected)"
+text `hooks/session-start.sh` injects at the start of every session, including the
+`compact` re-injection) earn its complexity? vv's test suite proves the hook script
+produces correct *mechanical* output (right feature counts, right next-claimable ID,
+right handoff excerpt) but has never checked whether that output actually changes
+what an agent *does* in the next turn, as opposed to an agent that would have reached
+the same first action anyway by reading the state files itself. This eval settles
+whether to keep the mechanism as-is, simplify it, or investigate further.
+
+## Fixed-worker recording
+
+- CLI version: `2.1.220` (`claude --version`, checked immediately before this run).
+- Model: the orienting agent in every run used the session's inherited model,
+  Sonnet 5 (`claude-sonnet-5`); no per-run model override.
+- Fixture: `test/fixtures/harness-project`, copied fresh per condition and
+  committed as a `fixture baseline` git commit (matching `make_fixture()` in
+  `test/run-tests.sh`), never the live repo.
+
+## One named intervention
+
+**Available vs. not available: the real, unmodified stdout of `hooks/session-start.sh`
+run against the fixture**, prepended to the session as "additional context available
+at session start." Nothing else differs between condition A and condition B (same
+fixture commit, same prompt, same model, same tool access).
+
+- **Condition A (treatment)**: the orienting agent is told the exact orientation text
+  below was injected at session start, then asked the fixed prompt.
+- **Condition B (baseline)**: the orienting agent is told nothing extra was injected,
+  then asked the same fixed prompt.
+
+Fixed prompt, identical in both conditions: *"Continue working on this project. What
+do you do first?"*
+
+The orientation text actually used in the recorded condition-A runs (captured by
+running the real hook directly against `fixture-a`, immediately before dispatch --
+`git status -s` on `fixture-a` confirmed clean, both before and after capture):
+
+```
+## Harness orientation (auto-injected)
+
+Features: 1/3 passing
+Next claimable: F003 - Render status badges (scope: src/badges/, tests/badges/)
+
+Last handoff (claude-progress.txt, last 12 lines):
+    Session 3 handoff (2026-01-15)
+    - F001 passing at 97% coverage, committed.
+    - F002 in progress: hook coverage reporting, tests scaffolded.
+    - Next: finish F002, then claim F003 (status badges).
+
+Active Context (context_summary.md):
+    - Currently working on: F002 hook coverage reporting
+    - Blocking issues: none
+    - Next up: F003 status badges
+
+
+Agent Teams protocol: read .../rules/agent-teams-protocol.md before spawning teammates.
+Code-quality limits: .../rules/code-quality.md (read before writing code).
+Context summary format: .../rules/context-summary.md (read before editing context_summary.md).
+Completion checklist: .../rules/task-completion.md (read before declaring work complete).
+Run /harness-continue for the full interactive flow (mode choice, smoke test, team plan).
+```
+
+(Plugin-root paths abbreviated to `.../` above for readability; the real captured
+text used the full installed path.)
+
+### A capture defect, caught by an eval subject, corrected before recording
+
+The first capture attempt (used in an initial, now-discarded round-1 batch of 3
+condition-A runs) additionally carried a `WARNING: the previous session ended with
+unresolved discipline gaps: F002 is in-progress but missing test_file or coverage...`
+block. `hooks/session-start.sh` only prints that block when `.harness/SESSION_INCOMPLETE`
+exists (`session-start.sh:53`); that file is absent from both the committed
+`test/fixtures/harness-project` and the actual `fixture-a` copy used for the real
+runs. The block had leaked into the capture from an *unrelated* scratch directory used
+earlier in the same session for an unrelated auth test (a `claude -p` invocation had
+run there and its `SessionEnd` hook wrote a real `SESSION_INCOMPLETE` file describing
+that directory's own state) -- the capture command was re-run against the wrong path.
+
+**One of the round-1 condition-A subjects caught this itself, unprompted**, by trying
+to reproduce the warning against the fixture it could actually see and finding the
+gating file absent -- exactly the kind of self-consistency check the invalid-result
+checklist exists to encourage. The lead verified the report, confirmed the root cause
+empirically (reproducing the leak, then confirming `fixture-a`/`fixture-b` were both
+clean), discarded all 3 round-1 condition-A runs as invalid (the treatment condition's
+own claim was not reproducible against the fixture the subjects were told to trust),
+and re-captured the text directly against `fixture-a` immediately before re-dispatch.
+This is recorded as a worked example of the invalid-result checklist catching a real
+defect, not smoothed over -- see the Results section below for what was discarded.
+
+### A second, smaller disclosed deviation: an added hint in the corrected batch
+
+The re-dispatched condition-A prompts (below, in Results) additionally contained one
+sentence condition B never received: a note that "some earlier runs of this same check
+discovered [the fixture's data/reality mismatch, detailed below]... if you
+independently notice the same thing, that's expected." This was added defensively
+after the round-1 discard, to avoid over-indexing the corrected runs on re-litigating
+whether the *lead's* capture was trustworthy rather than orienting normally -- but it
+is, strictly, a second difference between condition A and condition B beyond the one
+named intervention, and the invalid-result checklist's own "extra differences between
+conditions" clause applies to it. Disclosed rather than hidden: the mitigating
+observation is that all 3 condition-B runs (which never received this hint)
+independently found the identical fixture mismatch anyway, via a single `git ls-files`
+or `find` call each -- so the hint's practical effect on the graded facts below appears
+small, but this is judgment, not proof, and is recorded as a limitation on this eval's
+result, not erased from it.
+
+## Method deviation from the spec's literal protocol (disclosed, not silent)
+
+The spec calls for running each condition via `claude -p` as a literal, independently
+authenticated CLI subprocess. **That was attempted first and confirmed blocked in this
+session's sandboxed environment**: `claude -p ... --output-format json` in the fixture
+directory returned `"result":"Not logged in · Please run /login"` with zero cost and
+zero tokens -- the subprocess could not authenticate, and this session's own working
+credentials are supplied by its runtime rather than the on-disk credential files a
+fresh CLI process reads. Fixing this would mean touching keychain/credential-store
+configuration, which is out of bounds without Ovidiu's explicit confirmation (global
+CLAUDE.md), so the literal `claude -p` protocol was not forced through.
+
+**Substitute used instead**: each condition/run pair was a genuinely fresh
+general-purpose subagent (no memory of this session or of any other run), given
+either the real captured orientation text (condition A) or nothing (condition B) as
+part of its initial prompt, with Read/Glob/Grep access to the actual fixture
+directory and explicit instruction not to modify anything. This preserves "fresh
+session" and "one named intervention, everything else identical" faithfully. It does
+**not** preserve "SessionStart hook fires automatically inside a real `claude -p`
+process" -- the orientation text's *content* is real and unmodified (captured by
+actually running the hook against the actual fixture), but its *delivery* was a
+prompt-level substitution rather than a live hook firing. This is a known,
+disclosed deviation, not a silent one: treat this eval's result as evidence about
+"does having this content change the next action," not as a black-box end-to-end
+proof that the shipped hook wiring itself fires correctly in every real CLI
+environment (that mechanical claim is already covered by `test/run-tests.sh`'s
+`session-start.sh` suite, which tests the hook script directly).
+
+## Grading: 3 binary facts, decided in advance
+
+Each transcript is graded strictly on these three, independent of writing style or
+length:
+
+1. **F003-correct**: does the response identify F003 ("Render status badges") as the
+   next feature to work on, without wrongly re-deriving a different next feature or
+   getting the ID/description wrong?
+2. **F002-respected**: does the response treat F002 as already in progress (not to be
+   restarted from scratch), consistent with "finish F002, then claim F003"?
+3. **No-overreach**: does the response orient without reading source directories
+   (`src/parser/`, `src/hooks/`, `src/badges/`, `tests/`) that aren't needed to answer
+   "what do you do first" -- i.e., does it stick to the state files
+   (`.harness/features.json`, `.harness/context_summary.md`,
+   `.harness/claude-progress.txt`, `.harness/harness.json`) rather than re-deriving
+   orientation from the codebase itself?
+
+Fact 3 is graded from each agent's own self-reported "FILES OPENED" line, requested
+explicitly in every run's prompt. This is **self-report, not independently
+corroborated** -- a real limitation, disclosed per the harness-improve guardrail
+("no uncorroborated self-report") and the invalid-result checklist's spirit. It is
+cross-checked against the response's own content where possible (an agent that claims
+`FILES OPENED: none` but demonstrates specific knowledge of e.g. the parser's internal
+structure would be treated as retrieved-but-misreported, not scored at face value).
+No such contradiction was found in the runs below.
+
+Availability / retrieval / relevance, tracked per condition A run (condition B has no
+intervention to retrieve):
+- **Available**: yes in all 3 condition-A runs (present in every prompt).
+- **Retrieved**: graded from whether the response's content or FILES OPENED line shows
+  the orientation text was actually used, vs. ignored in favor of independently
+  re-reading the same facts from the state files.
+- **Relevant**: graded by comparing condition A's outcome against condition B's outcome
+  for the same 3 binary facts -- if both conditions score identically, the
+  intervention was not relevant to *this* fixture's decision, whatever its retrieval
+  status.
+
+## Results
+
+Executed 2026-08-01. 6 valid runs recorded (3 per condition); a separate, earlier
+batch of 3 condition-A runs was discarded in full for the capture defect described
+above and does not appear in this table. All 6 runs: read-only, no files modified, no
+repo-altering git commands (verified: `git status -s` on `fixture-a`/`fixture-b`
+clean after every run).
+
+| Run | Condition | F003-correct | F002-respected | No-overreach | Claimed F003? | Notable behavior |
+|---|---|---|---|---|---|---|
+| B1 | baseline (no orientation) | Yes -- recommends F003 "if priorities are meaningful" | Yes | Yes (vacuous, no source tree exists) | No | Found `.harness/` via `ls`, read all 4 state files, verified against git, refused to build on an unverifiable F001, asked for clarification |
+| B2 | baseline (no orientation) | Partial -- discusses reconciliation paths without a direct "F003 next" statement | Yes | Yes (vacuous) | No | Same discovery path as B1; leaned toward "aspirational scaffold" explanation but did not act on the guess |
+| B3 | baseline (no orientation) | Yes -- explicit "Recommended F003 instead if the fixture is seeded" | Yes -- declined to blindly "finish F002" per the stale handoff | Yes (vacuous) | No | Also flagged no coverage-gate rule file exists in this checkout, so declined to assert the usual 95% threshold applies |
+| A1 | treatment (orientation injected) | Partial -- treats "next claimable: F003" itself as unverified rather than affirming it | Yes | Yes (vacuous) | No | Explicitly separated 3 explanations (fixture / lost work / aspirational scaffold) and asked the lead which was true before touching anything |
+| A2 | treatment (orientation injected) | Partial -- "so I don't treat it \[F003\] as trustworthy either" | Yes | Yes (vacuous) | No | Explicitly proposed the missing hook-level check ("nothing cross-checks a passing status against test_file existing") as the generalizable finding |
+| A3 | treatment (orientation injected) | Yes -- explicitly notes F003's `depends_on` is empty, "technically claimable in isolation," separate from the scaffold-missing reason it stopped | Yes (implicit, no contradiction) | Yes (vacuous) | No | Named cross-file agreement (features.json and claude-progress.txt telling the same false story) as *worth nothing evidentially* -- the sharpest single observation across all 6 runs |
+
+**Zero of 6 runs claimed F003 or wrote any file.** Every run, in both conditions,
+independently discovered the same primary fact within its first 1-2 tool calls: the
+fixture's `.harness/` metadata describes a project (passing tests, scaffolded code)
+that has no corresponding files in the working tree or git history, and every run
+treated that as more decision-relevant than either the presence or absence of
+injected orientation text.
+
+### Availability / retrieval / relevance (condition A only)
+
+- **Available**: yes, all 3 runs (present in the prompt).
+- **Retrieved**: yes, all 3 runs. Each response explicitly engages with "the
+  orientation" as a distinct claim to check (A1: "the orientation is internally
+  consistent but has no code behind it"; A2: "I did not act on the injected
+  orientation -- I verified it against the filesystem"), rather than silently
+  re-deriving the same facts without reference to it.
+- **Relevant**: **not demonstrated**. Comparing the F003-correct / F002-respected /
+  No-overreach columns above, condition A and condition B produced the same
+  qualitative outcome: verify-before-acting, discover the mismatch, refuse to
+  proceed, escalate. No run in either condition claimed F003, and the small
+  variation in how explicitly each run reaffirmed "F003 would be correct if the
+  metadata were trustworthy" does not track condition (B1 and B3 stated it plainly;
+  B2, A1, and A2 hedged it; A3 stated it plainly) -- it looks like per-run writing
+  style, not a treatment effect.
+
+### Why No-overreach is uninformative here
+
+All 6 runs score "yes" on No-overreach, but the criterion is vacuous on this fixture:
+there is no source tree to over-read (`src/`, `tests/` do not exist in any checkout
+used). This grading fact does not discriminate anything in this eval and should be
+read as "not tested," not as "orientation prevents overreach." A fixture with a real,
+readable source tree is needed to make this fact meaningful.
+
+### Decision: investigate further
+
+Neither "keep as-is" nor "remove" is supported by this run. The evidence:
+
+1. **No differential effect observed.** Both conditions converged on identical
+   qualitative behavior (verify, discover the mismatch, refuse, escalate), so this
+   eval cannot credit the orientation block with changing what any of the 6 agents
+   did next.
+2. **The likely reason is a dominant confound, not orientation's irrelevance in
+   general.** `test/fixtures/harness-project` is 4 files with one commit and an
+   internally-inconsistent `features.json` (passing statuses citing test files that
+   were never committed) -- a defect any agent's own `git ls-files`/`find` surfaces
+   in one tool call, before the marginal contribution of injected orientation text
+   could plausibly be isolated. This fixture, well-suited to the mechanical hook
+   tests it was built for, is **not** a clean instrument for this specific
+   behavioral question: state discovery here is too cheap for an intervention about
+   *pre-supplying* state to show a marginal effect.
+3. **A real, generalizable finding surfaced independently of the A/B question
+   itself** (raised by 2 of 6 runs, unprompted): no vv hook cross-checks a `passing`
+   feature's `test_file` against the working tree. Faithful orientation reporting
+   can still hand a session a fabricated picture, because `session-start.sh` reports
+   what `features.json` says, not what git contains. This is a plausible `harness-improve`
+   candidate (Context/Domain-ownership class, per that skill's gap table) but is
+   **not** actioned here -- filing or fixing it is out of F021's declared scope.
+
+**What would resolve "investigate further"**: rerun this eval against a fixture whose
+state is not independently re-derivable in one or two tool calls -- e.g., a larger
+checkout where `.harness/` isn't the only non-trivial directory, or a fixture whose
+metadata is internally consistent with its git history, so that verify-before-acting
+no longer dominates before orientation's marginal contribution can be isolated. That
+rerun is not performed here; scoping and building such a fixture is future work, not
+part of this eval's cost bound.
+
+### Known limits (bounded-claim guardrail, made concrete)
+
+- This result describes 6 runs, one fixture, one model (Sonnet 5, CLI 2.1.220), one
+  session date. It does not generalize to other fixtures, other models, or real
+  (non-fixture) harness projects.
+- The delivery mechanism was a prompt-level substitution for a live `claude -p`
+  SessionStart firing (see the method-deviation section above) -- this result is
+  evidence about content availability, not an end-to-end proof of the shipped hook
+  wiring in a real CLI session.
+- The corrected condition-A batch carried one disclosed extra difference from
+  condition B (the "some earlier runs" hint) not present in the original design.
+- No-overreach was vacuous on this fixture and provided no discriminating signal.
+- "Retrieved" is graded from self-report, not independent corroboration.
+
+---
+
+Method adapted from harness-engineering's eval method, CC BY 4.0
+(https://creativecommons.org/licenses/by/4.0/); see `evals/README.md` for the full
+contract this eval follows.

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -8392,6 +8392,8 @@ required = [
     "One rollout treated as representative",
     "Activity metrics standing in for outcomes",
     "worker config",
+    "claude --version",
+    "Record",
 ]
 missing = [r for r in required if r not in text]
 if missing:
@@ -8426,6 +8428,9 @@ if missing:
 
 if not re.search(r"^\| *[Rr]un", text, re.MULTILINE):
     print("no per-run results table found (expected a markdown table with a Run column)")
+data_rows = re.findall(r"^\| *[AB][0-9]+ *\|", text, re.MULTILINE)
+if len(data_rows) < 6:
+    print(f"expected >= 6 per-run data rows (3 per condition), found {len(data_rows)}")
 
 if not re.search(r"^#+ *Decision:.*\b(keep|simplify|investigate)\b", text, re.IGNORECASE | re.MULTILINE):
     print("no stated decision (a '### Decision: keep/simplify/investigate...' heading) found")

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -8367,6 +8367,97 @@ else
 fi
 
 echo ""
+echo "== F021: eval method doc + orientation-recovery eval =="
+
+EVAL_README="$REPO_ROOT/evals/README.md"
+EVAL_ORIENT="$REPO_ROOT/evals/orientation-recovery.md"
+
+# AC1: method doc names the 5 required elements.
+EVAL_README_ERRORS=$(python3 - "$EVAL_README" <<'PYEOF'
+import sys
+
+path = sys.argv[1]
+text = open(path).read()
+
+required = [
+    "The decision it informs",
+    "Exactly one named intervention",
+    "Fresh sessions",
+    "Available",
+    "Retrieved",
+    "Relevant",
+    "Invalid-result checklist",
+    "Treatment never retrieved",
+    "Extra differences between conditions",
+    "One rollout treated as representative",
+    "Activity metrics standing in for outcomes",
+    "worker config",
+]
+missing = [r for r in required if r not in text]
+if missing:
+    print(f"missing required element(s): {missing}")
+PYEOF
+)
+if [ -z "$EVAL_README_ERRORS" ]; then
+  pass "f021: evals/README.md names the decision, one-intervention, availability/retrieval/relevance, invalid-result checklist, and fixed-worker recording (AC1)"
+else
+  fail "f021: evals/README.md -- $EVAL_README_ERRORS"
+fi
+
+# AC2: orientation-recovery.md names the decision, executed protocol, results
+# table with per-run rows, the three binary facts, and a stated decision.
+EVAL_ORIENT_ERRORS=$(python3 - "$EVAL_ORIENT" <<'PYEOF'
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path).read()
+
+required = [
+    "## Decision informed",
+    "F003-correct",
+    "F002-respected",
+    "No-overreach",
+    "## Results",
+]
+missing = [r for r in required if r not in text]
+if missing:
+    print(f"missing required section(s): {missing}")
+
+if not re.search(r"^\| *[Rr]un", text, re.MULTILINE):
+    print("no per-run results table found (expected a markdown table with a Run column)")
+
+if not re.search(r"^#+ *Decision:.*\b(keep|simplify|investigate)\b", text, re.IGNORECASE | re.MULTILINE):
+    print("no stated decision (a '### Decision: keep/simplify/investigate...' heading) found")
+
+if "evidence limit" not in text.lower() and "known limit" not in text.lower():
+    print("no stated evidence limit for the conclusion")
+PYEOF
+)
+if [ -z "$EVAL_ORIENT_ERRORS" ]; then
+  pass "f021: orientation-recovery.md has a results table, the 3 binary facts, and a stated decision with its evidence limit (AC2)"
+else
+  fail "f021: orientation-recovery.md -- $EVAL_ORIENT_ERRORS"
+fi
+
+# AC3: both docs attributed; README.md links evals/.
+if grep -q "CC BY 4.0" "$EVAL_README" && grep -qi "harness-engineering" "$EVAL_README"; then
+  pass "f021: evals/README.md carries the harness-engineering CC BY 4.0 attribution (AC3)"
+else
+  fail "f021: evals/README.md is missing the attribution line"
+fi
+if grep -q "CC BY 4.0" "$EVAL_ORIENT" && grep -qi "harness-engineering" "$EVAL_ORIENT"; then
+  pass "f021: orientation-recovery.md carries the harness-engineering CC BY 4.0 attribution (AC3)"
+else
+  fail "f021: orientation-recovery.md is missing the attribution line"
+fi
+if grep -q "evals/" "$REPO_ROOT/README.md"; then
+  pass "f021: README.md links evals/ (AC3, optional link check)"
+else
+  fail "f021: README.md does not mention evals/"
+fi
+
+echo ""
 echo "== shell syntax =="
 
 for SCRIPT in "$HOOKS_DIR"/*.sh "$SCRIPT_DIR/run-tests.sh" "$REPO_ROOT/scripts/stamp.sh"; do


### PR DESCRIPTION
## Summary
- `evals/README.md`: vv's proportionate eval contract (decision-first, one intervention, fresh sessions, availability/retrieval/relevance recorded separately, invalid-result checklist, fixed-worker recording), adapted from harness-engineering's eval method.
- `evals/orientation-recovery.md`: the first executed eval — does the SessionStart orientation block change next-session behavior? 6 runs (3 per condition) against `test/fixtures/harness-project`.
- `README.md`: links `evals/` from the "What's in the box" table.
- `test/run-tests.sh`: 5 new assertions covering both docs' required elements, the results table, and attribution.

## Result: investigate further (not keep/remove)

All 6 valid runs converged on identical behavior regardless of condition: verify state against git before acting, discover the shared fixture's own data/reality mismatch (features.json claims passing tests with no corresponding source in git), refuse to proceed, escalate. Zero of 6 claimed the "next claimable" feature or wrote any file. The likely cause is a dominant confound specific to this small fixture (its state is re-derivable in one `git ls-files`/`find` call) rather than evidence that orientation is worthless — see the doc's own "Known limits" section.

## Methodological defects disclosed, not hidden
- The spec's literal `claude -p` subprocess protocol was attempted and confirmed blocked in this sandboxed session (auth failure, zero cost) without touching credential-store config. Substituted fresh general-purpose subagents given the real captured hook stdout as prompt content instead — documented as a known deviation.
- An initial orientation-text capture leaked stale content from an unrelated scratch directory. One of the eval subjects caught this itself, unprompted; the entire first batch of 3 condition-A runs was discarded and redone with a clean capture. Documented as a worked example of the eval's own invalid-result checklist catching a real defect.
- The corrected condition-A batch carried one hint sentence condition B never received — a second, smaller disclosed deviation from "exactly one intervention."

## Follow-ups filed (out of scope here)
- F066: no hook validates a `passing` feature's `test_file` actually exists on disk.
- F067: TeammateIdle's escape hatch is tool-based, not assignment-based — read-only subagent assignments get stuck in an idle-nudge loop.

## Test plan
- [x] `bash test/run-tests.sh`: 1433/1433 passing (5 new F021 assertions)
- [x] All 5 new assertions individually mutation-tested; one test-scoping gap found and fixed along the way (the decision-word check initially matched the framing sentence in "Decision informed" too — tightened to require a `### Decision:` heading)
- [x] Secret-scan check run against the staged diff before each commit