### PR TITLE
chore: release v5.0.0 - v5 upgrade epic complete (OVI-44)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vv-harness",
   "displayName": "VV Claude Code Harness",
-  "version": "4.2.2",
+  "version": "5.0.0",
   "description": "Multi-session continuity, parallel Agent Teams coordination, and mechanical quality enforcement for Claude Code.",
   "author": {
     "name": "oeftimie",

--- a/.harness/harness.json
+++ b/.harness/harness.json
@@ -22,5 +22,5 @@
       "stamper": "ovidiu"
     }
   },
-  "plugin_version": "4.2.2"
+  "plugin_version": "5.0.0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,124 @@
 
 Version history for the VV Claude Code Harness. The current version lives in `.claude-plugin/plugin.json`.
 
+### v5.0.0 (2026-08-02)
+
+**The v5 upgrade: absorbing harness-engineering's evidence and meta loops.** A comparative
+analysis against lopopolo/harness-engineering (CC BY 4.0) found vv-harness strong on
+mechanical enforcement and distribution but with three real gaps: feedback that never
+flowed back into the harness itself, proof that stopped at coverage percentage, and no
+maintenance loop against weekly platform drift. This release closes all three, adapting
+the applicable ideas rather than transplanting them (per HE's own doctrine), plus
+mechanisms from two further harnesses reconciled in wave 2: AlexCiortan/setlist (CC BY
+4.0) and nodera-studio/agent-os (MIT). 21 planned capabilities, tracked as Linear epic
+OVI-44.
+
+**Correctness first (P0).** Scope enforcement is now armed in the actual spawn path
+(`harness-continue`'s Phase 2 writes `.claude/teammate-scope.txt` on every teammate
+spawn; previously the only instruction to create it lived in prose nobody executed).
+Single-owner truth fixes: the version line, dates, and identity checks now agree with
+`plugin.json` and each other. The 5 per-project hook templates gained real test coverage
+(previously excluded from both `bash -n` and the fixture suite) and were then hardened
+against roughly 30 parsing and evasion edge cases found by adversarial dogfooding —
+quoting, redirects, ANSI-C escapes, compound commands, flag-taking short options, and
+more, all in `enforce-scope.sh.template` and `commit-gate.sh.template`.
+
+**One concept, one owner (P1).** `schemas/feature.schema.json` is now the single
+canonical definition of the `features.json` envelope and the feature object, enforced by
+a stdlib-only validator (`scripts/validate-features.py`, no `jsonschema` dependency) wired
+into the test suite and into `harness-doctor`. A shared `harness_state.py` module
+replaces per-hook reimplementations of `features.json` parsing across
+`verify-task-quality.sh` and `check-remaining-tasks.sh`.
+
+**Authority and proof (P2).** Lead-only ownership of `.harness/` state files
+(`features.json`, `context_summary.md`, `claude-progress.txt`) is now mechanically
+enforced, not just documented — `enforce-scope.sh` blocks a teammate write to any of the
+three regardless of its assigned scope, with a best-effort Bash-write backstop for the
+same three plus scope boundaries generally. Features gained claim-matched proof: a
+`proof` object (claim, evidence type, artifact, what the evidence did NOT establish),
+per-feature `coverage_target` overrides for claim types unit coverage measures poorly,
+and a `delivered` closure field for PR-shipped projects. The readiness stamp's HMAC key
+now resolves from a three-source chain (macOS Keychain, a mode-600 key file, or an
+explicitly-discouraged env var) instead of Keychain only, so the spec gate's signing
+recipe is exercised on Linux CI for the first time.
+
+**Feedback becomes infrastructure (P3).** `.harness/mld/` gives the harness a builder-only
+telemetry channel (Mistakes/Learnings/Desires) with a hard, tested non-injection
+guarantee: `session-start.sh` never reads it, on any SessionStart source. The Phase 5.5
+retrospective gained a promotion pass (classify each observed pattern to its smallest
+durable owner: spawn-prompt tweak, rule edit, hook change, schema field, agent
+definition, or plugin skill) and an ablation pass (retain/revise/remove controls that
+fired zero times or produced only friction), with candidate lifecycle tracking
+(score, status, decay) recorded in `HARNESS_BACKLOG.md`.
+
+**Continuous maintenance (P4).** `docs/maintenance-runbook.md` is the loop that watches
+for platform drift on Claude Code's experimental Agent Teams surface: a weekly CI probe,
+a monthly live-agent probe checklist, and durable state in `MAINTENANCE_LOG.md` where a
+quiet no-op run is a successful run, not a skipped one. Every documented workaround now
+carries an explicit retirement condition. A new optional `worker` block in
+`harness.json` records the CLI version and model bindings an epoch's operational metrics
+belong to, with a requalification checklist (`docs/requalification.md`) triggered on a
+version-delta jump — including a mandatory subtraction pass, since a worker upgrade can
+absorb scaffolding a harness project no longer needs.
+
+**Meta and distribution (P5).** A new root `AGENTS.md` (plus nested guides under
+`skills/` and `test/`) gives non-Claude agents (Codex, Cursor) a real map of this repo,
+with `CLAUDE.md` reduced to a one-line import and a small Claude-specific overlay. The
+new `harness-improve` skill runs HE's improve-one-harnessed-job loop: record a job
+contract, observe the baseline, make one intervention, verify at the claim boundary a
+guardrail actually prevents. `evals/` documents the eval method (decision-first,
+one-intervention, fresh-sessions) and ships the first behavioral eval, an orientation-
+recovery A/B.
+
+**Two new health-check and safety mechanisms (wave 2).** `skills/harness-doctor/` is a
+report-first, idempotent instance health check with an optional `--fix` upgrade mode —
+it replaces the five-step manual upgrade INSTALL.md used to document, and now also
+tracks `plugin_version` drift between a project's recorded sync point and the currently
+installed plugin, bootstrapping or refreshing that field on `--fix`. `scripts/stamp.sh`
+is the deterministic file emitter behind `/harness-init`: "never hand-write what a stamp
+can emit; never stamp what a decision shapes" — every framework-fixed file (hooks
+byte-verbatim, settings templated, `plugin_version` read directly from the plugin's own
+manifest) comes from the stamp, with new-mode collision pre-flight and upgrade-mode
+byte-identical-only overwrites. A new commit-content gate (`commit-gate.sh`) denies
+compound stage-and-commit forms and staged secret-shaped content before they land.
+
+**Two new review mechanisms.** `agents/conformance-tester.md` derives behavior tests
+from a feature's verified spec alone — it never reads the implementation diff, the
+implementer's completion message, or the implementer's own tests, closing the
+reward-hacking surface where a single context that writes both code and tests can
+satisfy a bug with a test that matches the bug. An optional dual-engine review
+(`review.second_engine` in `harness.json`) runs a second, independently-run reviewer
+(e.g. Codex) blind to the first, with explicit synthesis rules: dedupe by defect not
+line, a single-engine CRITICAL survives, cross-engine agreement raises confidence,
+provenance checked against `git show <merge-base>:<file>` before labeling a finding NEW
+vs. PRE-EXISTING.
+
+**The TeammateIdle identity correction.** This release also corrects a claim shipped
+since v4.1.0: the `TeammateIdle` hook payload does carry the teammate's `teammate_name`
+(and deprecated `team_name`) — it was never true that the hook has no way to know which
+teammate is idling. The original claim traced to a documentation fetch that truncated
+before reaching the relevant section of a long reference page and silently answered from
+the wrong table; a raw fetch of the same page corrected it. The hook still doesn't act on
+`teammate_name` — that remains a deliberate design decision (`rules/agent-teams-protocol.md`),
+not a platform limitation: the field is caller-chosen free text with no enforced naming
+contract, and a wrong automated guess (silently suppressing a nudge for a teammate that
+legitimately has more work) is worse than the current bounded, visible cost of one extra
+decline per stale nudge. The correct remedy — the lead releasing a role-limited or
+scoped-one-shot teammate promptly once its work is delivered — already existed as a rule
+and simply needed to be followed, not mechanized around.
+
+**Dogfooding found the rest.** This repo ran its own harness on itself for the entire
+upgrade (`/harness-init` on vv-claude-harness, per the epic's self-execution protocol).
+Beyond the 21 planned issues, that surfaced and fixed 48 further defects — mostly the
+scope-enforcement hardening pass above, plus a `harness-doctor` check that a
+`passing`/`in-progress` feature's `test_file` actually exists, a mutation-testing gap in
+`fixes.py`'s settings-wiring drift check, and the TeammateIdle-idle-nudge scope gaps this
+entry already covers. Full per-defect detail lives in this repo's own `.harness/features.json`,
+not restated here at that granularity.
+
+**Tests**: `test/run-tests.sh` carries 1489 assertions covering every mechanism above
+plus the hardening pass, each mutation-tested against the specific defect it guards.
+
 ### v4.2.2 (2026-07-04)
 
 **A go-ahead is durable.** In practice, sessions governed by the template's "present a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ retrospective gained a promotion pass (classify each observed pattern to its sma
 durable owner: spawn-prompt tweak, rule edit, hook change, schema field, agent
 definition, or plugin skill) and an ablation pass (retain/revise/remove controls that
 fired zero times or produced only friction), with candidate lifecycle tracking
-(score, status, decay) recorded in `HARNESS_BACKLOG.md`.
+(score, status, decay) recorded in `.harness/HARNESS_BACKLOG.md`.
 
 **Continuous maintenance (P4).** `docs/maintenance-runbook.md` is the loop that watches
 for platform drift on Claude Code's experimental Agent Teams surface: a weekly CI probe,
@@ -118,7 +118,8 @@ entry already covers. Full per-defect detail lives in this repo's own `.harness/
 not restated here at that granularity.
 
 **Tests**: `test/run-tests.sh` carries 1489 assertions covering every mechanism above
-plus the hardening pass, each mutation-tested against the specific defect it guards.
+plus the hardening pass, with each non-trivial check mutation-tested against the
+specific defect it guards.
 
 ### v4.2.2 (2026-07-04)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VV Claude Code Harness
 
-A harness system for Claude Code that solves multi-session continuity, parallel agent coordination, and automated quality enforcement. Built on Anthropic's research for long-running tasks, evolved through four major versions into a native Claude Code plugin built on the platform's Agent Teams primitives.
+A harness system for Claude Code that solves multi-session continuity, parallel agent coordination, and automated quality enforcement. Built on Anthropic's research for long-running tasks, evolved through five major versions into a native Claude Code plugin built on the platform's Agent Teams primitives.
 
 See [CHANGELOG.md](./CHANGELOG.md) for the current version and history.
 
@@ -51,7 +51,7 @@ Three reasons:
 * **Transparency**: When an agent goes off the rails, you can open `task_plan.md` and see exactly what it thinks it's doing. You can't really debug a vector database when an agent starts hallucinating. Files are inspectable, editable, and version-controlled.
 * **Structure**: Anthropic specifically chose JSON for their features file because, [as they noted](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents), "the model is less likely to inappropriately change or overwrite JSON files compared to Markdown files." Structured formats create implicit contracts. The agent knows that `passes: false` means work remains. It knows not to delete entries. The file format itself enforces discipline.
 
-## The evolution: v2.0 to v4.2
+## The evolution: v2.0 to v5.0
 
 ### v2.0: The foundation (January 2026)
 
@@ -183,6 +183,39 @@ memorizing names. No alias for the old names: replace, don't deprecate. v4.2.1 f
 spec-gate content to reference the schema via `${CLAUDE_PLUGIN_ROOT}` so plugin-internal
 paths resolve for installed users, not just inside this repo.
 
+### v5.0: The evidence and meta loops (August 2026)
+
+A comparative analysis against lopopolo/harness-engineering (CC BY 4.0) — a methodology
+corpus rather than an execution harness — found vv-harness strong on mechanical
+enforcement and distribution but missing three things: feedback that never flowed back
+into the harness itself, proof that stopped at coverage percentage, and no maintenance
+loop against weekly platform drift. v5.0 closes all three, adapting the applicable ideas
+rather than copying file layouts or policies, plus mechanisms reconciled from two
+further harnesses: AlexCiortan/setlist (CC BY 4.0) and nodera-studio/agent-os (MIT).
+
+New capabilities: `harness-doctor` (a report-first health check with a `--fix` upgrade
+mode, now including plugin-version drift detection); `scripts/stamp.sh` (a deterministic
+file emitter behind `/harness-init` — never hand-write what a stamp can emit); a
+commit-content gate denying compound stage-and-commit forms and staged secret-shaped
+content; `.harness/mld/` builder-only telemetry with a hard, tested non-injection
+guarantee; a promotion-and-ablation pass in the Phase 5.5 retrospective that routes
+observed patterns to their smallest durable owner instead of letting them evaporate in
+prose; a platform-drift maintenance loop (`docs/maintenance-runbook.md`) with weekly CI
+probes and explicit retirement conditions on every documented workaround; a `worker`
+epoch record with a requalification checklist (including a mandatory subtraction pass);
+an author-blind conformance tester that derives tests from a verified spec alone, never
+the implementation diff; an optional dual-engine review; and a root `AGENTS.md` routing
+layer for non-Claude agents working on this repo. Full detail in the
+[v5.0.0 changelog entry](./CHANGELOG.md).
+
+Dogfooding the upgrade on this repo's own harness surfaced 48 further defects beyond the
+21 planned — mostly hardening `enforce-scope.sh`/`commit-gate.sh` against parsing and
+evasion edge cases, plus a `harness-doctor` check that a feature's claimed `test_file`
+actually exists. That process also caught and corrected a claim shipped since v4.1.0: the
+`TeammateIdle` hook payload does carry a teammate's name — the original "no teammate
+identity" claim traced to a documentation fetch that silently answered from the wrong
+section of a long reference page.
+
 ## Architecture
 
 ### Global (travels with you)
@@ -218,6 +251,9 @@ vv-harness/                                            # Plugin root
 ├── schemas/
 │   ├── readiness-stamp.md                             # Stamp, hashing, HMAC, park/resolution contracts
 │   └── feature.schema.json                            # Canonical features.json envelope + feature object
+├── scripts/
+│   ├── stamp.sh                                       # Deterministic file emitter for /harness-init (+ upgrade mode)
+│   └── validate-features.py                           # Stdlib features.json validator, run by harness-doctor
 └── templates/
     └── CLAUDE.md                                      # Core standards template (manual copy to ~/.claude/)
 ```
@@ -233,14 +269,17 @@ project-root/
 │   └── hooks/
 │       ├── verify-task-quality.sh                     # TaskCompleted enforcement
 │       ├── check-remaining-tasks.sh                   # TeammateIdle prompted reassignment
-│       ├── enforce-scope.sh                           # PreToolUse scope enforcement
+│       ├── enforce-scope.sh                           # PreToolUse scope enforcement (incl. lead-owned state)
 │       ├── verify-git-identity.sh                     # PreToolUse git identity verification
+│       ├── commit-gate.sh                             # PreToolUse commit-content gate (secret scan)
+│       ├── harness_state.py                           # Shared features.json read/write module
 │       └── statusline.sh                              # Project copy of the plugin status line
 └── .harness/
-    ├── harness.json                                   # Config + git identity + team structure
+    ├── harness.json                                   # Config, git identity, team structure, plugin_version
     ├── features.json                                  # Feature tracking (with scope, dependencies)
     ├── context_summary.md                             # Decisions, patterns, gotchas, active context
     ├── claude-progress.txt                            # Session-boundary handoff
+    ├── mld/                                           # Optional: builder-only Mistakes/Learnings/Desires
     ├── SESSION_INCOMPLETE                             # Discipline gaps from last session (gitignored)
     └── init.sh                                        # Build/test script
 ```
@@ -407,6 +446,8 @@ claude
 | `skills/harness-improve/` | Observation-first improvement loop: record a job contract, observe the baseline, one intervention, verify at the claim boundary |
 | `agents/` | Declarative teammate definitions (feature-implementer, layer-implementer, researcher, reviewer, spec-verification, reverification-guard, conformance-tester) |
 | `schemas/` | Data contracts published for external consumers (readiness stamp, park/resolution formats) |
+| `scripts/stamp.sh` | Deterministic file emitter for `/harness-init`, new + upgrade mode |
+| `scripts/validate-features.py` | Stdlib `features.json` validator, run by harness-doctor and CI |
 | `hooks/` | Plugin continuity hooks: session-start, session-end, statusline |
 | `rules/agent-teams-protocol.md` | Agent Teams coordination (harness projects only) |
 | `rules/code-quality.md` | Mechanical code quality limits |

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ vv-harness/                                            # Plugin root
 │   ├── agent-teams-protocol.md                        # Agent Teams rules (harness projects only)
 │   ├── code-quality.md                                # Mechanical code quality limits
 │   ├── context-summary.md                             # context_summary.md template + update rules
+│   ├── mld-review.md                                  # Cadence + disposition rules for .harness/mld/ entries
 │   └── task-completion.md                             # Completion checklist
 ├── schemas/
 │   ├── readiness-stamp.md                             # Stamp, hashing, HMAC, park/resolution contracts
@@ -452,6 +453,7 @@ claude
 | `rules/agent-teams-protocol.md` | Agent Teams coordination (harness projects only) |
 | `rules/code-quality.md` | Mechanical code quality limits |
 | `rules/context-summary.md` | `context_summary.md` template and update rules |
+| `rules/mld-review.md` | Cadence and disposition rules for reviewing `.harness/mld/` entries |
 | `rules/task-completion.md` | Task completion checklist |
 | `templates/CLAUDE.md` | Core engineering standards template (manual copy to `~/.claude/`) |
 | `test/` | Fixture-based hook test suite, run in CI |


### PR DESCRIPTION
## Summary
- Bumps `plugin.json` to 5.0.0, completing Linear epic OVI-44 (the v5 upgrade: all 21 planned capabilities across P0-P5, plus wave-2 mechanisms from setlist/agent-os).
- Adds the v5.0.0 CHANGELOG entry summarizing every capability shipped, the ~30-defect scope-enforcement hardening pass, and the TeammateIdle identity correction — grouped by theme rather than itemized (69 features shipped this epic; per-defect detail lives in `features.json`).
- Updates README's evolution narrative, Global/Per-project architecture trees, and component table to reflect what's actually shipped (scripts/stamp.sh, harness_state.py, commit-gate.sh, mld/, plugin_version).
- Dogfoods this repo's own `.harness/harness.json` plugin_version to 5.0.0 via `doctor --fix` (not hand-edited).

## Test plan
- [x] Full suite: 1489/1489 passing (docs + version bump only, no code changes)
- [x] Verified no unfounded numeric claims in the CHANGELOG (dropped an unverifiable "grew from ~500 to 1489" comparison after the historical baseline test run proved unreliable)
- [x] Confirmed README never restates "Current version" (single-owner rule, existing test)
