### PR TITLE
feat: add rules/debugging.md, four-phase root-cause process (F074/OVI-82)

### DIFF
--- a/.harness/features.json
+++ b/.harness/features.json
@@ -2110,6 +2110,28 @@
       "failure_reason": null,
       "discovered_via": "OVI-106 (Linear, investigated per Ovidiu's 2026-08-02 pickup instruction)",
       "spec": null
+    },
+    {
+      "id": "F074",
+      "description": "OVI-82: the harness has no documented systematic-debugging procedure. Moved out of Ovidiu's personal ~/.claude/CLAUDE.md as part of OVI-73 (the harness should own development discipline, not the global file). Verified 2026-07-25 against vv-harness/4.2.2/rules/: 'root cause' appears 0 times in code-quality.md, context-summary.md, and agent-teams-protocol.md, and only incidentally in task-completion.md. Fix: new rules/debugging.md with the four-phase process (root cause investigation, pattern analysis, hypothesis and testing, implementation rules) from the issue spec, wired into session-start.sh's rule-pointer block so it's surfaced at session start like the other 4 rule files. Includes the OVI-68 gotcha (a check that errors must report UNKNOWN, never PASS -- an empty/clean result is not a negative result until the command is known to have run).",
+      "priority": 74,
+      "status": "passing",
+      "scope": [
+        "rules/debugging.md",
+        "hooks/session-start.sh",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [],
+      "assigned_to": null,
+      "test_file": "test/run-tests.sh",
+      "coverage": "8 new suite assertions: the session-start.sh pointer is present when CLAUDE_PLUGIN_ROOT is set (1) and absent when unset (1, extending the existing y: suppression test); rules/debugging.md exists (1), states the root-cause-only rule (1), all 4 phase headers are present (4), and the OVI-68 gotcha text is included (1). Mutation-tested both mechanisms independently: removing the session-start.sh pointer line fails exactly its own assertion; renaming Phase 3's header fails exactly the Phase-3-present assertion. Full suite 1519/1519 both before and after restoring each mutation.",
+      "notes": "Measured the real char-budget impact before adding the pointer line, since PR #121's review flagged this repo's own live orientation as already thin on headroom against the platform's 10k cap (3,903/4000 chars measured then). Re-measured now: this repo's live orientation (its own real .harness/ state, not the test fixture) is 4,401 chars BEFORE this feature's change, already over the informal 4000 target -- a pre-existing condition from natural growth (73 features, long context_summary.md), not something this feature introduces at meaningful scale. This feature's own pointer line adds ~198 chars to that. The shipped regression test itself (which exercises a lean synthetic fixture, not this repo's live state) stays comfortably under budget at 1831/4000. The underlying platform-cap risk is OVI-105's still-open 'total output budget' task (tracked there, not duplicated here).",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": "OVI-82 (Linear, via OVI-73 handoff, investigated per Ovidiu's 2026-08-02 pickup instruction)",
+      "spec": null
     }
   ]
 }

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -246,6 +246,7 @@ if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
     "(read before editing context_summary.md)."
   echo "Completion checklist: $CLAUDE_PLUGIN_ROOT/rules/task-completion.md" \
     "(read before declaring work complete)."
+  echo "Debugging discipline: $CLAUDE_PLUGIN_ROOT/rules/debugging.md (read before debugging a failure)."
 fi
 echo "Run /harness-continue for the full interactive flow (mode choice, smoke test, team plan)."
 exit 0

--- a/rules/debugging.md
+++ b/rules/debugging.md
@@ -1,0 +1,38 @@
+# Systematic Debugging
+
+Find the root cause. NEVER fix a symptom or add a workaround.
+
+## Phase 1 — Root cause investigation (BEFORE attempting fixes)
+
+- Read error messages carefully; they often contain the exact solution
+- Reproduce consistently before investigating
+- Check recent changes: `git diff`, recent commits
+- For user-reported bugs: state the diagnosis and proposed fix in 2-3 sentences BEFORE
+  editing code ("I think the crash is X because Y, I'll fix it by Z"). Costs one message
+  and lets the human correct a wrong model early.
+- An empty or clean result is not a negative result until the command is known to have run.
+  A check that errors must report UNKNOWN, never PASS — a silently-missing tool or a query
+  that exits 0 without actually executing looks identical to a genuine clean result unless
+  you confirm the command ran.
+
+## Phase 2 — Pattern analysis
+
+- Find working examples in the same codebase
+- Compare against references; read the implementation completely
+- Identify differences between working and broken code
+- Understand dependencies
+
+## Phase 3 — Hypothesis and testing
+
+1. Form a single hypothesis; state it clearly
+2. Make the smallest possible change to test it
+3. Verify before continuing; if it did not work, form a new hypothesis
+4. Say "I don't understand X" rather than pretending to know
+
+## Phase 4 — Implementation rules
+
+- Always have the simplest possible failing test case
+- Never add multiple fixes at once
+- Never claim to implement a pattern without reading it completely
+- Test after each change
+- If the first fix does not work, STOP and re-analyse

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -166,6 +166,8 @@ assert_contains "$OUT" "rules/context-summary.md" \
   "o: orientation includes the context-summary pointer"
 assert_contains "$OUT" "rules/task-completion.md" \
   "o: orientation includes the task-completion pointer"
+assert_contains "$OUT" "rules/debugging.md (read before debugging a failure)" \
+  "o (OVI-82): orientation includes the debugging pointer"
 
 # OVI-105: a feature description has no length cap in practice -- this
 # repo's own features.json has carried one past 13,000 chars. Exercise BOTH
@@ -240,6 +242,8 @@ assert_not_contains "$OUT" "<vv-harness plugin root>" \
   "y: no placeholder literal when CLAUDE_PLUGIN_ROOT is unset"
 assert_not_contains "$OUT" "rules/code-quality.md" \
   "y: no rule-pointer lines when CLAUDE_PLUGIN_ROOT is unset"
+assert_not_contains "$OUT" "rules/debugging.md" \
+  "y (OVI-82): the debugging pointer is also suppressed when CLAUDE_PLUGIN_ROOT is unset"
 assert_contains "$OUT" "## Harness orientation" \
   "y: orientation still prints when CLAUDE_PLUGIN_ROOT is unset"
 
@@ -9495,6 +9499,24 @@ if grep -q "own default target is \`full_test\`, not \`smoke_test\`" "$HC_SKILL_
 else
   fail "mnt (OVI-106): no inline note reconciling init.sh's full_test default with the smoke-test wording"
 fi
+
+echo ""
+echo "== OVI-82: rules/debugging.md exists with the required four-phase structure =="
+
+DEBUG_RULE="$REPO_ROOT/rules/debugging.md"
+if [ -f "$DEBUG_RULE" ]; then
+  pass "rd (OVI-82): rules/debugging.md exists"
+else
+  fail "rd (OVI-82): rules/debugging.md is missing"
+fi
+assert_contains "$(cat "$DEBUG_RULE" 2>/dev/null)" "NEVER fix a symptom or add a workaround" \
+  "rd (OVI-82): states the root-cause-only rule"
+for PHASE in "Phase 1" "Phase 2" "Phase 3" "Phase 4"; do
+  assert_contains "$(cat "$DEBUG_RULE" 2>/dev/null)" "$PHASE" \
+    "rd (OVI-82): $PHASE is present"
+done
+assert_contains "$(cat "$DEBUG_RULE" 2>/dev/null)" "is not a negative result until the command is known to have run" \
+  "rd (OVI-82): the empty-result-is-not-a-negative-result gotcha (OVI-68) is included"
 
 echo ""
 echo "== shell syntax =="


### PR DESCRIPTION
## Summary
- New `rules/debugging.md`: root-cause-only rule plus the four-phase process from OVI-82's spec (root cause investigation, pattern analysis, hypothesis and testing, implementation rules), including the OVI-68 gotcha (a check that errors must report UNKNOWN, never PASS).
- Wired into `hooks/session-start.sh`'s rule-pointer block alongside the other 4 rule files.
- Moved out of Ovidiu's personal `~/.claude/CLAUDE.md` per OVI-73 -- the harness should own development discipline, not the global file.

## Test plan
- [x] 8 new suite assertions: pointer present/absent (2), file exists + root-cause rule + all 4 phase headers + OVI-68 gotcha text (6).
- [x] Mutation-tested both mechanisms independently: removing the pointer line fails exactly its own assertion; renaming a phase header fails exactly that assertion.
- [x] Full suite: 1519/1519 assertions passed.
- [x] Measured the real char-budget impact before adding the pointer line (PR #121's review flagged this repo's live orientation as thin on headroom against the platform's 10k cap). This repo's live orientation is already at 4,401 chars *before* this change -- a pre-existing condition from natural growth, not introduced here (~198 chars added). The shipped regression test itself, which exercises a lean synthetic fixture, stays comfortably under budget at 1831/4000. The underlying platform-cap risk is OVI-105's still-open "total output budget" task, not duplicated here.
- [x] Secret scan on the diff: clean.