### PR TITLE
release: v5.1.0 -- doctor commit-gate fixer, consolidated plugin-root warning, debugging.md, tdd.md

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vv-harness",
   "displayName": "VV Claude Code Harness",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "Multi-session continuity, parallel Agent Teams coordination, and mechanical quality enforcement for Claude Code.",
   "author": {
     "name": "oeftimie",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 Version history for the VV Claude Code Harness. The current version lives in `.claude-plugin/plugin.json`.
 
+### v5.1.0 (2026-08-02)
+
+**The additive follow-ups from the same external code review pass that shipped v5.0.1**
+(feedback_vivi.md), tracked as Linear issues OVI-104, OVI-82, and OVI-81. New capability,
+not bugfixes, per the v5.0.1 entry's own note about keeping the two kinds of change out
+of the same patch release.
+
+`harness-doctor --fix` couldn't restore a missing `commit-gate.sh` (OVI-104): the
+"upgrade available" finding had no `fix_id`, unlike its `harness_state.py` sibling. A new
+`copy_commit_gate` fixer closes the gap. Separately, four of `doctor.py`'s checks
+(commit-gate.sh presence, `features.json` cross-validation, `plugin_version` drift, the
+`.harness/mld/` non-injection guarantee) each silently returned no findings when
+`CLAUDE_PLUGIN_ROOT` was unset — individually correct, but four independent silent skips
+added up to a "healthy" report that verified less than it looked like it did. One
+consolidated finding now names all four. Dogfooding this fix on itself surfaced a related,
+already-shipped bug: `doctor --fix`'s `.gitignore` fixer could never add a newer required
+line (`.harness/features.json.lock`, from v5.0.1's OVI-107 fix) for any already-initialized
+project, because it early-returned on the presence of an older required line alone. Fixed
+alongside — the fixer now appends whichever required lines are missing.
+
+Two new rule files join the SessionStart orientation's rule-pointer block, both moved out
+of Ovidiu's personal `~/.claude/CLAUDE.md` per a separate handoff (OVI-73: "the harness
+should own development discipline, not the global file"). `rules/debugging.md` (OVI-82)
+is a four-phase systematic root-cause process. `rules/tdd.md` (OVI-81) is the 5-step TDD
+loop and coverage bar, including the finding that this exact discipline as always-on
+CLAUDE.md prose didn't measurably reduce `buggy_code` — the coverage gate and adversarial
+review did.
+
+**Tests**: `test/run-tests.sh` carries 1541 assertions, up from 1510 — every new check and
+fixer above is independently pinned and mutation-tested.
+
 ### v5.0.1 (2026-08-02)
 
 **Three correctness fixes from an external code review pass** (feedback_vivi.md, verified

--- a/README.md
+++ b/README.md
@@ -231,6 +231,16 @@ truncated to 200 chars with a pointer to the full text); and `/harness-continue`
 documented "smoke test" actually ran the full suite (both call sites now pass
 `smoke_test` explicitly).
 
+The same review's additive follow-ups shipped in v5.1.0: `harness-doctor --fix` can now
+restore a missing `commit-gate.sh` and repair a project's `.gitignore` on upgrade even
+when it already carries an older required line (the fixer previously early-returned on
+the first line's presence, making a newer required line permanently unreachable for any
+already-initialized project); doctor's report now names all four checks it silently
+skips when `CLAUDE_PLUGIN_ROOT` is unset, in one consolidated finding, instead of staying
+quiet about each one individually; and two new rule files, `rules/debugging.md` (a
+four-phase systematic root-cause process) and `rules/tdd.md` (the 5-step TDD loop and
+coverage bar), join the SessionStart rule-pointer block.
+
 ## Architecture
 
 ### Global (travels with you)
@@ -262,8 +272,10 @@ vv-harness/                                            # Plugin root
 │   ├── agent-teams-protocol.md                        # Agent Teams rules (harness projects only)
 │   ├── code-quality.md                                # Mechanical code quality limits
 │   ├── context-summary.md                             # context_summary.md template + update rules
+│   ├── debugging.md                                   # Four-phase systematic root-cause process
 │   ├── mld-review.md                                  # Cadence + disposition rules for .harness/mld/ entries
-│   └── task-completion.md                             # Completion checklist
+│   ├── task-completion.md                             # Completion checklist
+│   └── tdd.md                                         # 5-step TDD loop + coverage bar
 ├── schemas/
 │   ├── readiness-stamp.md                             # Stamp, hashing, HMAC, park/resolution contracts
 │   └── feature.schema.json                            # Canonical features.json envelope + feature object
@@ -468,8 +480,10 @@ claude
 | `rules/agent-teams-protocol.md` | Agent Teams coordination (harness projects only) |
 | `rules/code-quality.md` | Mechanical code quality limits |
 | `rules/context-summary.md` | `context_summary.md` template and update rules |
+| `rules/debugging.md` | Four-phase systematic root-cause debugging process |
 | `rules/mld-review.md` | Cadence and disposition rules for reviewing `.harness/mld/` entries |
 | `rules/task-completion.md` | Task completion checklist |
+| `rules/tdd.md` | 5-step TDD loop and coverage bar |
 | `templates/CLAUDE.md` | Core engineering standards template (manual copy to `~/.claude/`) |
 | `test/` | Fixture-based hook test suite, run in CI |
 | `evals/` | Proportionate behavioral evals: does an intervention change what the agent actually does, not just its terminology (semi-manual, not CI-wired) |


### PR DESCRIPTION
## Summary
- Version bump to 5.1.0, CHANGELOG entry, README pass (adds `rules/debugging.md` and `rules/tdd.md` to both places README lists rule files, plus a capabilities paragraph) covering the three fixes already merged individually: F073/OVI-104 (doctor commit-gate fixer + consolidated CLAUDE_PLUGIN_ROOT-unset warning, PR #123, plus a same-PR follow-up fix F077 for a related doctor --fix gitignore bug), F074/OVI-82 (`rules/debugging.md`, PR #125), F075/OVI-81 (`rules/tdd.md`, PR #126).
- Additive minor release -- no bugfixes bundled in, per v5.0.1's own note keeping the two kinds of change in separate releases.

## Test plan
- [x] Full suite: 1541/1541 assertions passed (up from 1510 pre-batch).
- [x] Secret scan on the diff: clean.