### PR TITLE
docs: sync recorded plugin_version to 5.1.0

### DIFF
--- a/.harness/harness.json
+++ b/.harness/harness.json
@@ -22,5 +22,5 @@
       "stamper": "ovidiu"
     }
   },
-  "plugin_version": "5.0.0"
+  "plugin_version": "5.1.0"
 }


### PR DESCRIPTION
## Summary
- `.harness/harness.json` still recorded `plugin_version: "5.0.0"` through this session's own v5.0.1 and v5.1.0 releases.
- Caught by running `harness-doctor` against this repo itself as a self-audit (`CLAUDE_PLUGIN_ROOT=$(pwd) python3 skills/harness-doctor/doctor.py .`), which reported the drift finding. Fixed via `doctor.py --fix`, which now reports `healthy`.

## Test plan
- [x] `doctor.py .` reports `healthy` after the fix.
- [x] Full suite: 1541/1541 assertions passed (unchanged, no logic touched).