### PR TITLE
fix: doctor's plugin-root-unset finding only names the mld check when mld/ exists (F080)

### DIFF
--- a/.harness/features.json
+++ b/.harness/features.json
@@ -2225,6 +2225,29 @@
       "failure_reason": null,
       "discovered_via": "OVI-81 (Linear, via OVI-73 handoff, investigated per Ovidiu's 2026-08-02 pickup instruction)",
       "spec": null
+    },
+    {
+      "id": "F080",
+      "description": "PR #123 (F073/OVI-104) round-1 review nit N3, deferred at merge as a 'not a defect... harmless' minor over-report, picked up now per Ovidiu's 'work until blocked' instruction: check_plugin_root_unset's consolidated finding unconditionally listed 'the .harness/mld/ non-injection guarantee' among the checks skipped due to CLAUDE_PLUGIN_ROOT being unset, even for the common case of a project with no .harness/mld/ directory at all -- check_mld_non_injection already no-ops on a missing mld/ dir BEFORE it even looks at plugin_root, so that check was never going to run regardless of the unset variable. Fix: check_plugin_root_unset now takes project_dir too and only includes the mld line when .harness/mld/ actually exists, so the count (and the message) accurately reflects what CLAUDE_PLUGIN_ROOT specifically caused to be skipped.",
+      "priority": 79,
+      "status": "passing",
+      "scope": [
+        "skills/harness-doctor/doctor.py",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F073"
+      ],
+      "assigned_to": null,
+      "test_file": "test/run-tests.sh",
+      "coverage": "Net +2 assertions (1 existing assertion changed from a positive mld-phrase check to a negative one on the no-mld fixture, plus 2 new assertions on a second fixture WITH .harness/mld/ present, confirming the count rises to 4 and the mld phrase appears in that case). Mutation-tested: reverting to the old unconditional-inclusion behavior fails exactly the 2 assertions that depend on the mld line being conditional (the '3 checks' count on the no-mld fixture, and the negative 'does not contain the mld phrase' assertion on that same fixture), nothing else. Full suite 1543/1543 both before and after restoring the mutation.",
+      "notes": "Reviewer's own framing at the time was 'harmless... not a defect', so this was correctly left unfixed at F073's merge rather than blocking it. Small enough and cheap enough to fold in now that other higher-priority work is clear.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": "F073 (review-pr123-f073, nit N3, deferred at merge; picked up 2026-08-03 per Ovidiu's 'work until blocked' instruction)",
+      "spec": null
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -235,8 +235,8 @@ The same review's additive follow-ups shipped in v5.1.0: `harness-doctor --fix` 
 restore a missing `commit-gate.sh` and repair a project's `.gitignore` on upgrade even
 when it already carries an older required line (the fixer previously early-returned on
 the first line's presence, making a newer required line permanently unreachable for any
-already-initialized project); doctor's report now names all four checks it silently
-skips when `CLAUDE_PLUGIN_ROOT` is unset, in one consolidated finding, instead of staying
+already-initialized project); doctor's report now names the checks it silently skips
+when `CLAUDE_PLUGIN_ROOT` is unset, in one consolidated finding, instead of staying
 quiet about each one individually; and two new rule files, `rules/debugging.md` (a
 four-phase systematic root-cause process) and `rules/tdd.md` (the 5-step TDD loop and
 coverage bar), join the SessionStart rule-pointer block.

--- a/skills/harness-doctor/doctor.py
+++ b/skills/harness-doctor/doctor.py
@@ -415,14 +415,15 @@ def check_mld_non_injection(project_dir, plugin_root):
 
 # OVI-104: commit-gate.sh presence (_check_optional_v5_hooks), features.json
 # cross-validation (_run_features_validator via check_harness_state_files),
-# plugin_version drift (check_version_drift), and the .harness/mld/
-# non-injection guarantee (check_mld_non_injection) all silently return no
-# findings when plugin_root is falsy -- each one individually correct (none
-# can compare against a plugin it can't locate), but four independent silent
-# skips add up to a "healthy" report that quietly verified less than it
-# looks like it did. One consolidated Finding here, instead of teaching each
-# of the four to also self-report, keeps the skip visible without repeating
-# the same "set CLAUDE_PLUGIN_ROOT" advice four times.
+# plugin_version drift (check_version_drift), and -- when applicable, see
+# MLD_CHECK_NAME below -- the .harness/mld/ non-injection guarantee
+# (check_mld_non_injection) all silently return no findings when plugin_root
+# is falsy -- each one individually correct (none can compare against a
+# plugin it can't locate), but several independent silent skips add up to a
+# "healthy" report that quietly verified less than it looks like it did. One
+# consolidated Finding here, instead of teaching each check to also
+# self-report, keeps the skip visible without repeating the same "set
+# CLAUDE_PLUGIN_ROOT" advice once per check.
 PLUGIN_ROOT_GATED_CHECKS = (
     "commit-gate.sh presence",
     "features.json cross-validation against the plugin's validator",

--- a/skills/harness-doctor/doctor.py
+++ b/skills/harness-doctor/doctor.py
@@ -427,17 +427,27 @@ PLUGIN_ROOT_GATED_CHECKS = (
     "commit-gate.sh presence",
     "features.json cross-validation against the plugin's validator",
     "plugin_version drift",
-    "the .harness/mld/ non-injection guarantee",
 )
 
+# The mld non-injection guarantee is only listed above when it's actually
+# applicable (round-1 review of PR #123): check_mld_non_injection already
+# no-ops when .harness/mld/ doesn't exist, before it even looks at
+# plugin_root -- for the common case of a project with no mld/ directory,
+# that check was never going to run regardless of CLAUDE_PLUGIN_ROOT, so
+# blaming the unset variable for it would overstate what's actually skipped.
+MLD_CHECK_NAME = "the .harness/mld/ non-injection guarantee"
 
-def check_plugin_root_unset(plugin_root):
+
+def check_plugin_root_unset(project_dir, plugin_root):
     if plugin_root:
         return []
-    checks = ", ".join(PLUGIN_ROOT_GATED_CHECKS)
+    checks = list(PLUGIN_ROOT_GATED_CHECKS)
+    if os.path.isdir(os.path.join(project_dir, ".harness", "mld")):
+        checks.append(MLD_CHECK_NAME)
+    joined = ", ".join(checks)
     return [Finding(
-        f"CLAUDE_PLUGIN_ROOT is not set -- {len(PLUGIN_ROOT_GATED_CHECKS)} checks could not "
-        f"run and were silently skipped: {checks}",
+        f"CLAUDE_PLUGIN_ROOT is not set -- {len(checks)} checks could not "
+        f"run and were silently skipped: {joined}",
         "set CLAUDE_PLUGIN_ROOT to the plugin's install directory and re-run doctor for a "
         "complete report (Claude Code sets it automatically when the plugin is active; a "
         "manual or CI invocation of doctor.py must set it explicitly)",
@@ -454,7 +464,7 @@ def run_checks(project_dir, plugin_root):
     findings.extend(check_feature_test_files(project_dir))
     findings.extend(check_version_drift(project_dir, plugin_root))
     findings.extend(check_mld_non_injection(project_dir, plugin_root))
-    findings.extend(check_plugin_root_unset(plugin_root))
+    findings.extend(check_plugin_root_unset(project_dir, plugin_root))
     return findings
 
 

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -6140,16 +6140,22 @@ OUT=$(env -u CLAUDE_PLUGIN_ROOT python3 "$DOCTOR_PY" "$DIR_DOC_MLD_NOROOT")
 assert_not_contains "$OUT" "non-injection guarantee broken" \
   "hd: .harness/mld/ present with no CLAUDE_PLUGIN_ROOT set produces no mld-specific finding"
 
-# F073/OVI-104: CLAUDE_PLUGIN_ROOT unset silently skipped 4 checks (commit-gate
-# presence, features.json cross-validation, plugin_version drift, mld
-# non-injection) with zero indication to the user. One consolidated Finding
-# now covers all 4 in a single message, instead of either 4 separate
-# skip-warnings or the prior silence.
+# F073/OVI-104: CLAUDE_PLUGIN_ROOT unset silently skipped several checks
+# (commit-gate presence, features.json cross-validation, plugin_version drift,
+# and -- only when applicable -- mld non-injection) with zero indication to
+# the user. One consolidated Finding now covers them in a single message,
+# instead of either N separate skip-warnings or the prior silence.
+#
+# This fixture has no .harness/mld/ directory (round-1 review of PR #123,
+# N3): check_mld_non_injection already no-ops on a missing mld/ dir before it
+# even looks at plugin_root, so that check was never going to run regardless
+# of CLAUDE_PLUGIN_ROOT -- the consolidated finding must not claim it was
+# skipped BECAUSE of the unset variable when it wouldn't have run anyway.
 DIR_DOC_NOROOT="$WORK/doctor-plugin-root-unset"
 make_healthy_doctor_fixture "$DIR_DOC_NOROOT"
 OUT=$(env -u CLAUDE_PLUGIN_ROOT python3 "$DOCTOR_PY" "$DIR_DOC_NOROOT")
 assert_contains "$OUT" \
-  "CLAUDE_PLUGIN_ROOT is not set -- 4 checks could not run and were silently skipped" \
+  "CLAUDE_PLUGIN_ROOT is not set -- 3 checks could not run and were silently skipped" \
   "hd: CLAUDE_PLUGIN_ROOT unset produces one consolidated finding (F073/OVI-104)"
 assert_contains "$OUT" "commit-gate.sh presence" \
   "hd: consolidated finding names commit-gate.sh presence"
@@ -6157,8 +6163,8 @@ assert_contains "$OUT" "features.json cross-validation" \
   "hd: consolidated finding names features.json cross-validation"
 assert_contains "$OUT" "plugin_version drift" \
   "hd: consolidated finding names plugin_version drift"
-assert_contains "$OUT" "the .harness/mld/ non-injection guarantee" \
-  "hd: consolidated finding names the mld non-injection guarantee"
+assert_not_contains "$OUT" "the .harness/mld/ non-injection guarantee" \
+  "hd (F077 round-1 nit N3): consolidated finding omits the mld check when .harness/mld/ doesn't exist"
 FINDING_COUNT=$(printf '%s' "$OUT" | grep -c "CLAUDE_PLUGIN_ROOT is not set")
 if [ "$FINDING_COUNT" = "1" ]; then
   pass "hd: the CLAUDE_PLUGIN_ROOT-unset finding appears exactly once, not once per check"
@@ -6170,6 +6176,18 @@ fi
 OUT=$(run_doctor "$DIR_DOC_NOROOT")
 assert_not_contains "$OUT" "CLAUDE_PLUGIN_ROOT is not set" \
   "hd: the consolidated finding does not appear when CLAUDE_PLUGIN_ROOT is set"
+
+# Mirror case: .harness/mld/ DOES exist -> the mld check WOULD have run if
+# CLAUDE_PLUGIN_ROOT were set, so the consolidated finding must include it.
+DIR_DOC_NOROOT_MLD="$WORK/doctor-plugin-root-unset-with-mld"
+make_healthy_doctor_fixture "$DIR_DOC_NOROOT_MLD"
+mkdir -p "$DIR_DOC_NOROOT_MLD/.harness/mld"
+OUT=$(env -u CLAUDE_PLUGIN_ROOT python3 "$DOCTOR_PY" "$DIR_DOC_NOROOT_MLD")
+assert_contains "$OUT" \
+  "CLAUDE_PLUGIN_ROOT is not set -- 4 checks could not run and were silently skipped" \
+  "hd (F077 round-1 nit N3): with .harness/mld/ present, the count rises to 4"
+assert_contains "$OUT" "the .harness/mld/ non-injection guarantee" \
+  "hd (F077 round-1 nit N3): with .harness/mld/ present, the mld check is named"
 
 # mld/ present, plugin root set, but that root has no hooks/session-start.sh at all.
 DIR_DOC_MLD_NOFILE="$WORK/doctor-mld-nofile"

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -6164,7 +6164,7 @@ assert_contains "$OUT" "features.json cross-validation" \
 assert_contains "$OUT" "plugin_version drift" \
   "hd: consolidated finding names plugin_version drift"
 assert_not_contains "$OUT" "the .harness/mld/ non-injection guarantee" \
-  "hd (F077 round-1 nit N3): consolidated finding omits the mld check when .harness/mld/ doesn't exist"
+  "hd (F073 round-1 nit N3): consolidated finding omits the mld check when .harness/mld/ doesn't exist"
 FINDING_COUNT=$(printf '%s' "$OUT" | grep -c "CLAUDE_PLUGIN_ROOT is not set")
 if [ "$FINDING_COUNT" = "1" ]; then
   pass "hd: the CLAUDE_PLUGIN_ROOT-unset finding appears exactly once, not once per check"
@@ -6185,9 +6185,9 @@ mkdir -p "$DIR_DOC_NOROOT_MLD/.harness/mld"
 OUT=$(env -u CLAUDE_PLUGIN_ROOT python3 "$DOCTOR_PY" "$DIR_DOC_NOROOT_MLD")
 assert_contains "$OUT" \
   "CLAUDE_PLUGIN_ROOT is not set -- 4 checks could not run and were silently skipped" \
-  "hd (F077 round-1 nit N3): with .harness/mld/ present, the count rises to 4"
+  "hd (F073 round-1 nit N3): with .harness/mld/ present, the count rises to 4"
 assert_contains "$OUT" "the .harness/mld/ non-injection guarantee" \
-  "hd (F077 round-1 nit N3): with .harness/mld/ present, the mld check is named"
+  "hd (F073 round-1 nit N3): with .harness/mld/ present, the mld check is named"
 
 # mld/ present, plugin root set, but that root has no hooks/session-start.sh at all.
 DIR_DOC_MLD_NOFILE="$WORK/doctor-mld-nofile"


### PR DESCRIPTION
## Summary
- Deferred nit N3 from PR #123's round-1 review, picked up now.
- `check_mld_non_injection` already no-ops on a missing `.harness/mld/` directory before it even looks at `plugin_root`, so for the common case of a project with no mld/ dir, that check was never going to run regardless of `CLAUDE_PLUGIN_ROOT` being unset. The consolidated finding was claiming it was skipped "because of" the unset variable regardless.
- `check_plugin_root_unset` now takes `project_dir` too and only includes the mld line when `.harness/mld/` actually exists, so both the count and the message accurately reflect what the unset variable specifically caused to be skipped.

## Test plan
- [x] Net +2 assertions: the existing no-mld fixture now asserts 3 checks / no mld phrase; a new fixture WITH `.harness/mld/` asserts 4 checks / mld phrase present.
- [x] Mutation-tested: reverting to unconditional inclusion fails exactly the 2 assertions guarding this fix, nothing else.
- [x] Full suite: 1543/1543 assertions passed.
- [x] Secret scan on the diff: clean.