### PR TITLE
fix: anchor debugging.md Phase-header tests, fix garden-path wording (F081)

### DIFF
--- a/.harness/features.json
+++ b/.harness/features.json
@@ -2225,6 +2225,29 @@
       "failure_reason": null,
       "discovered_via": "OVI-81 (Linear, via OVI-73 handoff, investigated per Ovidiu's 2026-08-02 pickup instruction)",
       "spec": null
+    },
+    {
+      "id": "F081",
+      "description": "PR #125 (F074/OVI-82) round-1 review nits N3/N4, deferred at merge as 'take or leave' optional polish, picked up now per Ovidiu's 'work until blocked' instruction. N3 (test-anchoring precision): the 4 test assertions pinning rules/debugging.md's Phase headers matched the bare substring 'Phase N' anywhere in the file, not the actual '## Phase N' markdown heading -- adequate in practice (the reviewer's own mutation happened to still catch it) but didn't pin the structure the feature actually claims to guarantee. N4 (wording): 'A check that errors must report UNKNOWN, never PASS' reads as a garden-path sentence on first parse ('a check that errors' misreads as a complete noun phrase before the sentence resolves). Fixed both: assertions now match '## Phase N' exactly; the sentence now reads 'A check that errors out must report UNKNOWN, never PASS'.",
+      "priority": 79,
+      "status": "passing",
+      "scope": [
+        "rules/debugging.md",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F074"
+      ],
+      "assigned_to": null,
+      "test_file": "test/run-tests.sh",
+      "coverage": "No new assertions (existing 4 Phase-header assertions tightened in place, same count). Mutation-tested the anchoring fix specifically: replaced the real '## Phase 3' heading with a differently-worded heading that still contains the bare substring 'Phase 3' elsewhere in prose (e.g. '(formerly Phase 3)') -- confirmed this now correctly fails the anchored assertion, where the OLD unanchored version would have passed incorrectly (a live demonstration of the gap N3 identified, not just a hypothetical). Restored, reran clean. The wording fix (N4) has no test dependency on the exact changed phrase -- confirmed via grep that no assertion matches the literal string 'A check that errors must report' before changing it. Full suite 1541/1541 throughout.",
+      "notes": "Both nits were explicitly optional ('take or leave') at F074's merge. Folded in now that they're cheap and no higher-priority work is queued.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": "F074 (review-pr125-f074, nits N3/N4, deferred at merge; picked up 2026-08-03 per Ovidiu's 'work until blocked' instruction)",
+      "spec": null
     }
   ]
 }

--- a/rules/debugging.md
+++ b/rules/debugging.md
@@ -11,7 +11,7 @@ Find the root cause. NEVER fix a symptom or add a workaround.
   editing code ("I think the crash is X because Y, I'll fix it by Z"). Costs one message
   and lets the human correct a wrong model early.
 - An empty or clean result is not a negative result until the command is known to have run.
-  A check that errors must report UNKNOWN, never PASS — a silently-missing tool or a query
+  A check that errors out must report UNKNOWN, never PASS — a silently-missing tool or a query
   that exits 0 without actually executing looks identical to a genuine clean result unless
   you confirm the command ran.
 

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -9612,8 +9612,8 @@ fi
 assert_contains "$(cat "$DEBUG_RULE" 2>/dev/null)" "NEVER fix a symptom or add a workaround" \
   "rd (OVI-82): states the root-cause-only rule"
 for PHASE in "Phase 1" "Phase 2" "Phase 3" "Phase 4"; do
-  assert_contains "$(cat "$DEBUG_RULE" 2>/dev/null)" "$PHASE" \
-    "rd (OVI-82): $PHASE is present"
+  assert_contains "$(cat "$DEBUG_RULE" 2>/dev/null)" "## $PHASE" \
+    "rd (OVI-82): $PHASE is present as a heading"
 done
 assert_contains "$(cat "$DEBUG_RULE" 2>/dev/null)" "is not a negative result until the command is known to have run" \
   "rd (OVI-82): the empty-result-is-not-a-negative-result gotcha (OVI-68) is included"


### PR DESCRIPTION
## Summary
- Deferred nits N3/N4 from PR #125's round-1 review, picked up now. Both explicitly optional at merge time.
- N3: the 4 test assertions pinning `rules/debugging.md`'s Phase headers matched a bare `Phase N` substring anywhere in the file, not the actual `## Phase N` markdown heading. Now anchored to the real heading.
- N4: "A check that errors must report UNKNOWN, never PASS" reads as a garden-path sentence on first parse. Now "A check that errors out must report UNKNOWN, never PASS".

## Test plan
- [x] Mutation-tested the anchoring fix specifically: replaced the real `## Phase 3` heading with a differently-worded one that still contains the bare substring "Phase 3" in prose -- confirmed this now correctly fails, where the old unanchored assertion would have passed incorrectly (live demonstration of the gap, not hypothetical).
- [x] Full suite: 1541/1541 assertions passed (no new assertions -- existing 4 tightened in place).
- [x] Secret scan on the diff: clean.