### PR TITLE
fix: stop burying harness_state.py diagnostics on stdout during TaskCompleted rejection (F083)

### DIFF
--- a/.claude/hooks/verify-task-quality.sh
+++ b/.claude/hooks/verify-task-quality.sh
@@ -105,8 +105,13 @@ increment_correction_cycles() {
     # concurrent edit. There is nothing left for this shell wrapper to do
     # but invoke the module and stay fail-open on its exit code, matching
     # this hook's documented posture for the correction_cycles side effect.
+    # No `2>&1` here (PR #120 round-1 review, NIT-2): harness_state.py
+    # already writes every diagnostic to its own stderr; merging that onto
+    # this function's stdout would bury it, since Claude Code discards a
+    # hook's stdout entirely on exit 2 (see the header comment above) and
+    # every call site of this function is on the exit-2 rejection path.
     python3 "$STATE_MODULE" increment-correction-cycles .harness/features.json "$FEATURE_ID" \
-        2>&1 || true
+        || true
 }
 
 # Stage 1: Smoke test (fast compile/syntax check)

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -2248,6 +2248,30 @@
       "failure_reason": null,
       "discovered_via": "F074 (review-pr125-f074, nits N3/N4, deferred at merge; picked up 2026-08-03 per Ovidiu's 'work until blocked' instruction)",
       "spec": null
+    },
+    {
+      "id": "F083",
+      "description": "PR #120 (F070/OVI-107) round-1 review NIT-2, deferred at merge as 'minor, pre-existing, but newly load-bearing', picked up now per Ovidiu's 'work until blocked' instruction: verify-task-quality.sh.template's increment_correction_cycles() invoked harness_state.py with `2>&1`, merging its stderr diagnostics (e.g. 'timed out waiting for lock') onto the function's own STDOUT. Every one of this function's 3 call sites is on the exit-2 rejection path, and Claude Code discards a hook's stdout entirely on exit 2, surfacing only stderr to the blocked agent -- so any diagnostic this function could ever produce was silently buried, exactly when the hook is already rejecting completion and the diagnostic matters most. Fix: removed `2>&1`, letting harness_state.py's stderr (it never writes to stdout on this code path) flow straight through to the hook's own stderr.",
+      "priority": 80,
+      "status": "passing",
+      "scope": [
+        "skills/harness-init/verify-task-quality.sh.template",
+        ".claude/hooks/verify-task-quality.sh",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F070"
+      ],
+      "assigned_to": null,
+      "test_file": "test/run-tests.sh",
+      "coverage": "3 new suite assertions: harness_state.py's own diagnostic (invoked the same way the fixed template now does, no 2>&1) never lands on stdout and does land on stderr, using a fast no-matching-feature error path rather than the existing 6-second lock-timeout wait; plus a structural grep confirming the shell wrapper's own call site genuinely dropped the 2>&1 (not just that harness_state.py behaves correctly in isolation -- the wrapper could still re-merge them). Mutation-tested: reverting the template's call site back to 2>&1 fails exactly the structural grep assertion and the pre-existing template/live-copy drift check (F047, since only the template was mutated), nothing else -- confirms the two harness_state.py-level assertions correctly isolate that layer from the wrapper layer. Manually verified the actual runtime effect before writing the test (per this repo's own debugging.md discipline): held the lock in a background process, invoked harness_state.py the fixed way, confirmed empirically that stdout was empty and stderr alone carried the timeout message. Full suite 1544/1544 both before and after restoring the mutation.",
+      "notes": "Verified all 3 call sites of increment_correction_cycles (lines ~124, 135, 168 in the template) are exclusively on paths ending in `exit 2` before concluding the fix has no downside -- there is no success-path invocation where stdout output would have mattered differently.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": "F070 (review-pr120-f070, NIT-2, deferred at merge; picked up 2026-08-03 per Ovidiu's 'work until blocked' instruction)",
+      "spec": null
     }
   ]
 }

--- a/skills/harness-init/verify-task-quality.sh.template
+++ b/skills/harness-init/verify-task-quality.sh.template
@@ -105,8 +105,13 @@ increment_correction_cycles() {
     # concurrent edit. There is nothing left for this shell wrapper to do
     # but invoke the module and stay fail-open on its exit code, matching
     # this hook's documented posture for the correction_cycles side effect.
+    # No `2>&1` here (PR #120 round-1 review, NIT-2): harness_state.py
+    # already writes every diagnostic to its own stderr; merging that onto
+    # this function's stdout would bury it, since Claude Code discards a
+    # hook's stdout entirely on exit 2 (see the header comment above) and
+    # every call site of this function is on the exit-2 rejection path.
     python3 "$STATE_MODULE" increment-correction-cycles .harness/features.json "$FEATURE_ID" \
-        2>&1 || true
+        || true
 }
 
 # Stage 1: Smoke test (fast compile/syntax check)

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -5512,6 +5512,40 @@ else
   fail "hs: a timed-out increment modified features.json anyway (correction_cycles is $CC_AFTER)"
 fi
 
+# F083/PR#120 round-1 review NIT-2: verify-task-quality.sh.template's
+# increment_correction_cycles() used to merge harness_state.py's stderr onto
+# its OWN stdout via `2>&1`, and every call site of that function is on the
+# exit-2 rejection path -- where Claude Code discards a hook's stdout
+# entirely and surfaces only stderr to the agent. That merge silently buried
+# every diagnostic this function could ever produce. Confirm the fix
+# directly: run harness_state.py the same way the (now-fixed) template
+# invokes it -- no `2>&1` -- against a fixture with no matching feature id
+# (a fast error path, no lock-timeout wait needed), and confirm the
+# diagnostic lands on stderr only, never stdout.
+HS_STDERR_CHECK="$WORK/hs-stderr-routing"
+mkdir -p "$HS_STDERR_CHECK"
+printf '{"features": [{"id": "F001", "status": "in-progress", "correction_cycles": 0}]}' \
+  > "$HS_STDERR_CHECK/features.json"
+HS_STDOUT_ONLY=$(python3 "$STATE_MODULE_TEMPLATE" increment-correction-cycles \
+  "$HS_STDERR_CHECK/features.json" F404_NOT_A_REAL_FEATURE 2>/dev/null)
+HS_STDERR_ONLY=$(python3 "$STATE_MODULE_TEMPLATE" increment-correction-cycles \
+  "$HS_STDERR_CHECK/features.json" F404_NOT_A_REAL_FEATURE 2>&1 1>/dev/null)
+assert_empty "$HS_STDOUT_ONLY" \
+  "hs (F083): harness_state.py's diagnostic never lands on stdout"
+assert_contains "$HS_STDERR_ONLY" "no feature with id" \
+  "hs (F083): harness_state.py's diagnostic lands on stderr"
+
+# The shell wrapper's own call site: grep the template directly to confirm
+# the `2>&1` that used to merge them is genuinely gone (not just that
+# harness_state.py itself behaves -- the wrapper could still re-merge them).
+VTQ_TEMPLATE="$TEMPLATES_DIR/verify-task-quality.sh.template"
+if grep -A1 'increment-correction-cycles .harness/features.json "\$FEATURE_ID"' "$VTQ_TEMPLATE" \
+  | grep -q '2>&1'; then
+  fail "hs (F083): verify-task-quality.sh.template still merges stderr onto stdout at the increment call site"
+else
+  pass "hs (F083): verify-task-quality.sh.template no longer merges stderr onto stdout at the increment call site"
+fi
+
 DIR_HS_PLAIN="$WORK/hs-delegate-plain"
 make_fixture "$DIR_HS_PLAIN"
 OUT_PLAIN=$(run_session_start "$DIR_HS_PLAIN" '{"source":"startup"}')


### PR DESCRIPTION
## Summary
- Deferred nit N2 from PR #120's round-1 review, picked up now.
- `verify-task-quality.sh.template`'s `increment_correction_cycles()` invoked `harness_state.py` with `2>&1`, merging its stderr diagnostics onto the function's own stdout. Every one of this function's 3 call sites is on the exit-2 rejection path, and Claude Code discards a hook's stdout entirely on exit 2, surfacing only stderr to the blocked agent -- so any diagnostic (e.g. a lock timeout) was silently buried exactly when the hook is already rejecting completion and the diagnostic matters most.
- Removed `2>&1`; `harness_state.py` never writes to stdout on this code path, so its stderr now flows straight through to the hook's own stderr.

## Test plan
- [x] Manually verified the actual runtime effect before writing any test: held the lock in a background process, invoked `harness_state.py` the fixed way, confirmed empirically that stdout was empty and stderr alone carried the timeout message.
- [x] 3 new suite assertions: the diagnostic never lands on stdout / does land on stderr (fast no-matching-feature error path, not the slow lock-timeout wait), plus a structural grep confirming the shell wrapper's own call site genuinely dropped `2>&1`.
- [x] Mutation-tested: reverting the call site fails exactly the structural grep assertion and the pre-existing template/live-copy drift check, nothing else.
- [x] Full suite: 1544/1544 assertions passed.
- [x] Secret scan on the diff: clean.