### PR TITLE
release: v5.1.1 -- adversarial review of v5.0.1/v5.1.0's own fixes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vv-harness",
   "displayName": "VV Claude Code Harness",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Multi-session continuity, parallel Agent Teams coordination, and mechanical quality enforcement for Claude Code.",
   "author": {
     "name": "oeftimie",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 Version history for the VV Claude Code Harness. The current version lives in `.claude-plugin/plugin.json`.
 
+### v5.1.1 (2026-08-03)
+
+**A round of adversarial review on v5.0.1/v5.1.0's own fixes, closing every deferred nit
+from those reviews plus completing OVI-105's third task.** Pure bugfixes and test-quality
+hardening -- no new capability.
+
+`hooks/session-start.sh`'s orientation could still exceed the platform's 10,000-char cap
+(OVI-105's third task): the `SESSION_INCOMPLETE` warning, `claude-progress.txt`'s tail, and
+`context_summary.md`'s Active Context were each capped by line count only, which bounds
+nothing if the lines themselves are long. Added the same truncate-and-point pattern
+already used for feature descriptions to all three -- calibrated once, then recalibrated
+after review caught the first value already truncating this repo's own real Active
+Context on ordinary content.
+
+Four nits deferred from the v5.0.1/v5.1.0 review rounds, picked up and fixed: `doctor.py`'s
+consolidated `CLAUDE_PLUGIN_ROOT`-unset finding named the `.harness/mld/` non-injection
+check even for projects with no `mld/` directory, where that check was never going to run
+regardless; `harness_state.py`'s top-level `import fcntl` made every read-only verb
+Unix-only, not just the write path that actually needs it; a shell wrapper merged
+`harness_state.py`'s stderr diagnostics onto its own stdout, which Claude Code discards
+entirely on the TaskCompleted hook's rejection path -- burying every diagnostic exactly
+when it mattered most; and a permanent flock error (e.g. `ENOLCK`) was treated identically
+to ordinary lock contention, burning the full lock timeout before reporting a misleading
+message.
+
+**Tests**: `test/run-tests.sh` carries 1559 assertions, up from 1541 -- every fix above is
+independently pinned and mutation-tested, several against empirically-verified failure
+modes (real inter-process lock contention, a real blocked import, real stdout/stderr
+channel separation) rather than only reasoned about.
+
 ### v5.1.0 (2026-08-02)
 
 **The additive follow-ups from the same external code review pass that shipped v5.0.1**

--- a/README.md
+++ b/README.md
@@ -241,6 +241,16 @@ quiet about each one individually; and two new rule files, `rules/debugging.md` 
 four-phase systematic root-cause process) and `rules/tdd.md` (the 5-step TDD loop and
 coverage bar), join the SessionStart rule-pointer block.
 
+Adversarial review of v5.0.1/v5.1.0's own fixes surfaced four more issues, closed in
+v5.1.1: `session-start.sh`'s orientation could still exceed the 10,000-char platform cap
+via three line-count-only-capped sections (SESSION_INCOMPLETE, `claude-progress.txt`,
+Active Context), now truncated the same way feature descriptions already were; a
+`CLAUDE_PLUGIN_ROOT`-unset finding named a check that was never going to run anyway;
+`harness_state.py`'s top-level `import fcntl` made read-only verbs Unix-only when only
+the write path needs it; a shell wrapper buried `harness_state.py`'s diagnostics on
+stdout, which Claude Code discards on the TaskCompleted hook's rejection path; and a
+permanent flock error was treated identically to ordinary lock contention.
+
 ## Architecture
 
 ### Global (travels with you)


### PR DESCRIPTION
## Summary
- Version bump to 5.1.1, CHANGELOG entry, README pass covering: OVI-105's third task (F079, total output budget for the orientation block, PR #128) and four nits deferred from the v5.0.1/v5.1.0 review rounds -- doctor's mld-check overstatement (F080, PR #130), rules/debugging.md test anchoring + wording (F081, PR #131), harness_state.py's fcntl import scoping (F082, PR #132), buried TaskCompleted diagnostics (F083, PR #133), and flock permanent-vs-contention error handling (F084, PR #134).
- Pure bugfix patch release -- no new capability.

## Test plan
- [x] Full suite: 1559/1559 assertions passed (up from 1541 pre-batch).
- [x] Secret scan on the diff: clean.