### PR TITLE
docs: sync recorded plugin_version to 5.1.1

### DIFF
--- a/.harness/harness.json
+++ b/.harness/harness.json
@@ -22,5 +22,5 @@
       "stamper": "ovidiu"
     }
   },
-  "plugin_version": "5.1.0"
+  "plugin_version": "5.1.1"
 }


### PR DESCRIPTION
## Summary
- `.harness/harness.json` still recorded `plugin_version: "5.1.0"` after the v5.1.1 release. Caught by re-running `harness-doctor` against this repo itself, fixed via `doctor.py --fix`, which now reports `healthy`.

## Test plan
- [x] `doctor.py .` reports `healthy` after the fix.
- [x] Full suite: 1559/1559 assertions passed (unchanged, no logic touched).