### PR TITLE
Release v5.3.0-alpha: alpha designation + isolated-install docs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vv-harness",
   "displayName": "VV Claude Code Harness",
-  "version": "5.2.0",
+  "version": "5.3.0-alpha",
   "description": "Multi-session continuity, parallel Agent Teams coordination, and mechanical quality enforcement for Claude Code.",
   "author": {
     "name": "oeftimie",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Version history for the VV Claude Code Harness. The current version lives in `.claude-plugin/plugin.json`.
 
+### v5.3.0-alpha (2026-08-05)
+
+**Alpha designation for the v5.2.0 dashboard chain (F088-F093), no functional change.**
+Marks the dashboard feature (an opt-in, live, animated view of Agent Teams session
+activity — see v5.2.0's entry below for what it does) as alpha quality while it gets
+broader real-world use before being folded into a stable release. Pin a single project
+to this exact tag for isolated testing without affecting any other project's installed
+version — see INSTALL.md, "Installing a specific version (alpha/pre-release/pinned),
+in one project only", for the `extraKnownMarketplaces` setup. Also fixes a real bug
+this alpha's own release process caught: `test/run-tests.sh`'s semver check only
+matched a bare `MAJOR.MINOR.PATCH` and rejected any pre-release suffix, which this
+version needed.
+
 ### v5.2.0 (2026-08-05)
 
 **An opt-in, live, animated dashboard for watching an Agent Teams session as it runs**

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,6 +34,39 @@ That's it. Claude Code auto-discovers the plugin's skills (`/harness-init`,
 the SessionStart orientation points to by absolute path — no plugin "rules" mechanism
 exists.
 
+### Installing a specific version (alpha/pre-release/pinned), in one project only
+
+The commands above always install whatever's on this repo's default branch, and
+`/plugin update` tracks it going forward. To pin one project to a specific tagged
+version instead — for example to try a pre-release before it's the default, without
+affecting any other project's installed version — add an `extraKnownMarketplaces`
+entry to that project's `.claude/settings.json` (or `.claude/settings.local.json` to
+keep it out of version control), naming the tag as the `ref`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "vv-harness-alpha": {
+      "source": {
+        "source": "github",
+        "repo": "oeftimie/vv-claude-harness",
+        "ref": "v5.3.0-alpha"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "vv-harness@vv-harness-alpha": true
+  }
+}
+```
+
+Restart the Claude Code session in that project (or run `/plugin marketplace update`)
+for the pinned marketplace to take effect. This installs and pins to exactly the
+commit tagged `v5.3.0-alpha`; `/plugin update` from that point only moves within that
+same pinned marketplace, so the project stays on the alpha until you change the `ref`
+yourself. A marketplace `ref` accepts any branch or tag name, not just a release tag —
+useful for pointing a single test project at an in-progress feature branch too.
+
 ## Update
 
 ```

--- a/README.md
+++ b/README.md
@@ -306,6 +306,11 @@ spoke, quality-gate verdicts, and judge subagents — served locally with no ext
 dependencies. See [INSTALL.md](./INSTALL.md), "Optional: Live Session Dashboard", for
 setup and its known limitations.
 
+v5.3.0-alpha marks the dashboard as alpha quality for broader testing before it's
+folded into a stable release — pin a single project to it via `extraKnownMarketplaces`
+without touching any other project's plugin version (see INSTALL.md, "Installing a
+specific version").
+
 ## Architecture
 
 ### Global (travels with you)

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -11824,16 +11824,20 @@ root = sys.argv[1]
 manifest = json.load(open(f"{root}/.claude-plugin/plugin.json"))
 version = manifest.get("version", "")
 print(version)
-print("SEMVER_OK" if re.match(r"^\d+\.\d+\.\d+$", version) else "SEMVER_BAD")
+# Real semver: MAJOR.MINOR.PATCH with an optional dot-separated pre-release
+# suffix (e.g. "5.3.0-alpha", "5.3.0-alpha.1") -- the original pattern here
+# only matched a bare MAJOR.MINOR.PATCH and rejected any pre-release tag.
+SEMVER_RE = r"^\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$"
+print("SEMVER_OK" if re.match(SEMVER_RE, version) else "SEMVER_BAD")
 PYEOF
 )
 PLUGIN_VERSION=$(echo "$PLUGIN_VERSION_INFO" | sed -n '1p')
 PLUGIN_VERSION_SEMVER=$(echo "$PLUGIN_VERSION_INFO" | sed -n '2p')
 
-if [ "$PLUGIN_VERSION" = "5.2.0" ]; then
-  pass "f093: plugin.json version equals exactly 5.2.0"
+if [ "$PLUGIN_VERSION" = "5.3.0-alpha" ]; then
+  pass "f093: plugin.json version equals exactly 5.3.0-alpha"
 else
-  fail "f093: plugin.json version equals exactly 5.2.0 (got '$PLUGIN_VERSION')"
+  fail "f093: plugin.json version equals exactly 5.3.0-alpha (got '$PLUGIN_VERSION')"
 fi
 
 if [ "$PLUGIN_VERSION_SEMVER" = "SEMVER_OK" ]; then


### PR DESCRIPTION
## Summary

Bumps to `5.3.0-alpha` (no functional change from `v5.2.0`) to mark the F088-F093 dashboard chain as alpha quality for broader real-world testing before it's folded into a stable release.

- Adds an INSTALL.md section on pinning a single project to a specific tagged version via `extraKnownMarketplaces` (ref-pinned `github` source) — lets the dashboard alpha be tried in one project without affecting any other project's installed plugin version.
- Fixes `test/run-tests.sh`'s semver check, which only matched a bare `MAJOR.MINOR.PATCH` and rejected any pre-release suffix — a real bug this release's own version bump caught.
- CHANGELOG.md entry, README.md evolution-narrative note.

## Test plan

- [x] Full suite passes: `bash test/run-tests.sh` → 1844/1844, both with and without `$CLAUDE_PROJECT_DIR` set
- [x] Verified the `extraKnownMarketplaces` mechanism directly against official docs (`code.claude.com/docs/en/plugin-marketplaces`), not guessed