### PR TITLE
perf: cut redundant subprocess spawns across the harness's hottest hooks

### DIFF
--- a/.claude/hooks/commit-gate.sh
+++ b/.claude/hooks/commit-gate.sh
@@ -1199,7 +1199,19 @@ def added_lines(diff_text):
             current_line += 1
 
 
-def secret_scan_exempt_paths(project_root):
+def load_harness_config(project_root):
+    # One read of harness.json, shared by secret_scan_exempt_paths() and
+    # style_gate_enabled() below -- both previously opened and json.load'd
+    # this same file independently on every commit-gated Bash call.
+    path = os.path.join(project_root, ".harness", "harness.json")
+    try:
+        with open(path) as fh:
+            return json.load(fh)
+    except (OSError, ValueError):
+        return {}
+
+
+def secret_scan_exempt_paths(harness_config):
     # Opt-in, harness.json-configured list of paths (verbatim, relative to
     # project_root, matching the diff's own path form) additionally exempt
     # from the secret scan -- for a project whose own test suite must stage
@@ -1214,13 +1226,7 @@ def secret_scan_exempt_paths(project_root):
     # fixtures, not a defense against the LEAD itself adding an unwise
     # exemption -- LEAD_OWNED protects against teammates, not against the
     # lead's own mistakes.
-    path = os.path.join(project_root, ".harness", "harness.json")
-    try:
-        with open(path) as fh:
-            data = json.load(fh)
-    except (OSError, ValueError):
-        return []
-    paths = data.get("secret_scan_exempt_paths")
+    paths = harness_config.get("secret_scan_exempt_paths")
     if not isinstance(paths, list):
         return []
     return [p for p in paths if isinstance(p, str)]
@@ -1265,14 +1271,8 @@ def find_style_violation(lines, deadline):
     return None
 
 
-def style_gate_enabled(project_root):
-    path = os.path.join(project_root, ".harness", "harness.json")
-    try:
-        with open(path) as fh:
-            data = json.load(fh)
-    except (OSError, ValueError):
-        return False
-    style_gate = data.get("style_gate")
+def style_gate_enabled(harness_config):
+    style_gate = harness_config.get("style_gate")
     if not isinstance(style_gate, dict):
         return False
     return bool(style_gate.get("enabled", False))
@@ -1297,12 +1297,13 @@ def main():
             return
         lines = list(added_lines(diff_text))
         deadline = time.monotonic() + SCAN_TIME_BUDGET_SECONDS
-        exempt_paths = secret_scan_exempt_paths(project_root)
+        harness_config = load_harness_config(project_root)
+        exempt_paths = secret_scan_exempt_paths(harness_config)
         reason = find_secret(lines, deadline, exempt_paths)
         if reason:
             print(reason)
             return
-        if style_gate_enabled(project_root):
+        if style_gate_enabled(harness_config):
             reason = find_style_violation(lines, deadline)
             if reason:
                 print(reason)

--- a/.claude/hooks/enforce-scope.sh
+++ b/.claude/hooks/enforce-scope.sh
@@ -435,7 +435,7 @@ if [ -n "$FILE_PATH" ]; then
     # scoped teammate blocked from an out-of-scope edit sees nothing at all.
     echo "Edit blocked: $FILE_PATH is outside your assigned scope." >&2
     echo "Your scope (from $SCOPE_FILE):" >&2
-    cat "$SCOPE_FILE" | grep -v '^#' | grep -v '^$' >&2
+    grep -v -e '^#' -e '^$' "$SCOPE_FILE" >&2
     echo "" >&2
     echo "Repair: request a scope expansion from the lead: SendMessage({ type: \"message\", recipient: \"team-lead\", content: \"Requesting scope expansion to $FILE_PATH because [reason].\" })" >&2
     _dashboard_log "block" "scope-violation:out-of-scope-edit" || true

--- a/.claude/hooks/verify-git-identity.sh
+++ b/.claude/hooks/verify-git-identity.sh
@@ -27,20 +27,17 @@ if [ ! -f ".harness/harness.json" ]; then
     exit 0
 fi
 
-# Extract expected identity from harness.json
-EXPECTED_NAME=$(python3 -c "
+# Extract expected identity from harness.json (one parse of the file for both fields)
+GIT_IDENTITY=$(python3 -c "
 import json
 with open('.harness/harness.json') as f:
     data = json.load(f)
-print(data.get('git_identity', {}).get('user_name', ''))
+identity = data.get('git_identity', {})
+print(identity.get('user_name', ''))
+print(identity.get('user_email', ''))
 " 2>/dev/null)
-
-EXPECTED_EMAIL=$(python3 -c "
-import json
-with open('.harness/harness.json') as f:
-    data = json.load(f)
-print(data.get('git_identity', {}).get('user_email', ''))
-" 2>/dev/null)
+EXPECTED_NAME=$(printf '%s\n' "$GIT_IDENTITY" | sed -n '1p')
+EXPECTED_EMAIL=$(printf '%s\n' "$GIT_IDENTITY" | sed -n '2p')
 
 if [ -z "$EXPECTED_NAME" ] || [ -z "$EXPECTED_EMAIL" ]; then
     exit 0
@@ -97,9 +94,13 @@ if ! echo "$COMMAND" | grep -qE 'git\s+(push|pull|clone|fetch)'; then
     exit 0
 fi
 
-# Check current git identity
-CURRENT_NAME=$(git config user.name 2>/dev/null)
-CURRENT_EMAIL=$(git config user.email 2>/dev/null)
+# Check current git identity (one git-config call for both fields). --get-regexp lists
+# a match from every scope that defines it (system/global/local), lowest priority first,
+# so the last matching line per key is the effective value -- same as plain `git config
+# user.name` -- and must be picked with an END-block, not just filtered.
+CURRENT_IDENTITY=$(git config --get-regexp '^user\.(name|email)$' 2>/dev/null)
+CURRENT_NAME=$(printf '%s\n' "$CURRENT_IDENTITY" | awk '$1 == "user.name" {$1=""; sub(/^ /, ""); v=$0} END{print v}')
+CURRENT_EMAIL=$(printf '%s\n' "$CURRENT_IDENTITY" | awk '$1 == "user.email" {$1=""; sub(/^ /, ""); v=$0} END{print v}')
 
 if [ "$CURRENT_NAME" != "$EXPECTED_NAME" ] || [ "$CURRENT_EMAIL" != "$EXPECTED_EMAIL" ]; then
     echo "Git push blocked: identity mismatch." >&2

--- a/.claude/hooks/verify-task-quality.sh
+++ b/.claude/hooks/verify-task-quality.sh
@@ -219,84 +219,86 @@ FULL_OUTPUT=$(bash .harness/init.sh full_test 2>&1) || {
     exit 2
 }
 
-# Coverage target gate: compare the targeted feature's own recorded `coverage`
-# number against its `coverage_target` (falls back to 95). Skipped entirely when
-# coverage isn't a number yet (e.g. this repo's own descriptive strings) --
-# proportional: don't punish projects without numeric coverage tooling.
-if [ -n "$FEATURE_ID" ] && [ -f ".harness/features.json" ]; then
-    COVERAGE_RESULT=$(python3 - ".harness/features.json" "$FEATURE_ID" <<'PYEOF'
+# Coverage target gate, claim-matched proof warning, and stale-in-progress
+# reminder all read .harness/features.json -- one load, one process, feeding
+# all three checks below, instead of three independent python3 subprocesses
+# each re-opening and re-parsing the same file.
+COVERAGE_RESULT=""
+PROOF_WARNING=""
+IN_PROGRESS=0
+if [ -f ".harness/features.json" ]; then
+    _CHECKS=$(python3 - ".harness/features.json" "$FEATURE_ID" <<'PYEOF'
 import json
 import sys
 
 path, feature_id = sys.argv[1], sys.argv[2]
 with open(path) as fh:
     data = json.load(fh)
-match = next((f for f in data.get("features", []) if f.get("id") == feature_id), None)
-if match is None:
-    sys.exit(0)
-coverage = match.get("coverage")
-if not isinstance(coverage, (int, float)) or isinstance(coverage, bool):
-    sys.exit(0)
-target = match.get("coverage_target")
-if not isinstance(target, int) or isinstance(target, bool):
-    target = 95
-if coverage < target:
-    print(f"{coverage}|{target}")
-PYEOF
-)
-    if [ -n "$COVERAGE_RESULT" ]; then
-        ACHIEVED="${COVERAGE_RESULT%%|*}"
-        TARGET="${COVERAGE_RESULT##*|}"
-        echo "Task rejected: coverage $ACHIEVED% is below the target $TARGET%." >&2
-        increment_correction_cycles
-        _dashboard_log "block" "coverage-below-target" || true
-        exit 2
-    fi
-fi
+features = data.get("features", [])
+match = next((f for f in features if f.get("id") == feature_id), None) if feature_id else None
+
+# Coverage target gate: compare the targeted feature's own recorded `coverage`
+# number against its `coverage_target` (falls back to 95). Skipped entirely when
+# coverage isn't a number yet (e.g. this repo's own descriptive strings) --
+# proportional: don't punish projects without numeric coverage tooling.
+coverage_result = ""
+if match is not None:
+    coverage = match.get("coverage")
+    if isinstance(coverage, (int, float)) and not isinstance(coverage, bool):
+        target = match.get("coverage_target")
+        if not isinstance(target, int) or isinstance(target, bool):
+            target = 95
+        if coverage < target:
+            coverage_result = f"{coverage}|{target}"
+print(coverage_result)
 
 # Claim-matched proof: warn (never block) when this feature accepts with no
 # proof recorded, or with proof whose evidence_type doesn't match its declared
 # qa_binding. Reads both fields directly off the feature object -- no external
 # lookup, no re-parsing of prose.
-PROOF_WARNING=""
-if [ -n "$FEATURE_ID" ] && [ -f ".harness/features.json" ]; then
-    PROOF_WARNING=$(python3 - ".harness/features.json" "$FEATURE_ID" <<'PYEOF'
-import json
-import sys
+proof_warning = ""
+if match is not None:
+    proof = match.get("proof")
+    qa_binding = match.get("qa_binding")
+    if not proof:
+        proof_warning = f"WARN: {feature_id} accepted with no proof recorded."
+    elif qa_binding and proof.get("evidence_type") != qa_binding:
+        proof_warning = (
+            f"WARN: {feature_id}'s proof.evidence_type "
+            f"'{proof.get('evidence_type')}' does not match its declared "
+            f"qa_binding '{qa_binding}'. Fix the proof or the binding."
+        )
+print(proof_warning)
 
-path, feature_id = sys.argv[1], sys.argv[2]
-with open(path) as fh:
-    data = json.load(fh)
-match = next((f for f in data.get("features", []) if f.get("id") == feature_id), None)
-if match is None:
-    sys.exit(0)
-proof = match.get("proof")
-qa_binding = match.get("qa_binding")
-if not proof:
-    print(f"WARN: {feature_id} accepted with no proof recorded.")
-elif qa_binding and proof.get("evidence_type") != qa_binding:
-    print(
-        f"WARN: {feature_id}'s proof.evidence_type "
-        f"'{proof.get('evidence_type')}' does not match its declared "
-        f"qa_binding '{qa_binding}'. Fix the proof or the binding."
-    )
+# Remind about stale in-progress features. Matches the original's exact
+# f['status'] indexing (not .get) and its own fallback: any exception here
+# (e.g. a feature missing "status" entirely) defaults the count to 0, same
+# as the previous "python3 ... 2>/dev/null || echo 0" bash-level fallback.
+try:
+    in_progress = len([f for f in features if f['status'] == 'in-progress'])
+except Exception:
+    in_progress = 0
+print(in_progress)
 PYEOF
 )
+    COVERAGE_RESULT=$(printf '%s\n' "$_CHECKS" | sed -n '1p')
+    PROOF_WARNING=$(printf '%s\n' "$_CHECKS" | sed -n '2p')
+    IN_PROGRESS=$(printf '%s\n' "$_CHECKS" | sed -n '3p')
+    [ -n "$IN_PROGRESS" ] || IN_PROGRESS=0
 fi
 
-# Remind about stale in-progress features
+if [ -n "$COVERAGE_RESULT" ]; then
+    ACHIEVED="${COVERAGE_RESULT%%|*}"
+    TARGET="${COVERAGE_RESULT##*|}"
+    echo "Task rejected: coverage $ACHIEVED% is below the target $TARGET%." >&2
+    increment_correction_cycles
+    _dashboard_log "block" "coverage-below-target" || true
+    exit 2
+fi
+
 IN_PROGRESS_NOTE=""
-if [ -f ".harness/features.json" ]; then
-    IN_PROGRESS=$(python3 -c "
-import json, sys
-with open('.harness/features.json') as f:
-    data = json.load(f)
-in_progress = [f for f in data.get('features', []) if f['status'] == 'in-progress']
-print(len(in_progress))
-" 2>/dev/null || echo "0")
-    if [ "$IN_PROGRESS" -gt 0 ]; then
-        IN_PROGRESS_NOTE="Note: $IN_PROGRESS feature(s) still marked in-progress. Update features.json if your feature is complete."
-    fi
+if [ "$IN_PROGRESS" -gt 0 ]; then
+    IN_PROGRESS_NOTE="Note: $IN_PROGRESS feature(s) still marked in-progress. Update features.json if your feature is complete."
 fi
 
 # All checks passed. Claude Code's own hooks docs (code.claude.com/docs/en/hooks)

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -1,7 +1,7 @@
 {
   "project": "vv-claude-harness",
   "created": "2026-07-22",
-  "total_features": 96,
+  "total_features": 98,
   "passing": 91,
   "features": [
     {
@@ -2730,6 +2730,48 @@
       "approaches_tried": [],
       "failure_reason": null,
       "discovered_via": "Second adversarial review of F088-F093 (2026-08-05), Finding 3",
+      "spec": null
+    },
+    {
+      "id": "F097",
+      "description": "hooks/session-start.sh has no mechanism that measures or enforces its actual total orientation output against the platform's 10,000-char cap -- only four independent, hand-tuned local budgets (three sections capped via print_budgeted_block at 2600 chars each, one description field capped separately at 200 chars) plus an unbounded rule-pointer block whose own comment admits it varies 1800-2900 chars depending on the installed CLAUDE_PLUGIN_ROOT path length and which optional WARNING blocks fire. Found by a 4-angle /simplify altitude review (2026-08-06): the git history shows this was chased reactively across three commits (2000 -> broke on real content -> recalibrated to 2600 with an arithmetic margin comment -> a later review found the margin isn't a fixed number at all, softened to a 'judgment call'). Repeated recalibration of a magic constant is the signal that the underlying problem (no measured total) was never actually solved. Fix: buffer the orientation output (or count characters as it's built) and truncate/report against the ACTUAL accumulated length at the end, as a final safety net IN ADDITION TO (not instead of) the existing per-section budgets kept for readability/prioritization -- converts 'we hope the sum of hand-tuned constants stays under 10,000 for every CLAUDE_PLUGIN_ROOT path length' into a mechanically guaranteed invariant, removing the need for a fourth recalibration commit next time install-path length or block count changes. Deliberately NOT attempted as part of the /simplify pass that discovered it -- flagged by two independent reviewers as a larger structural change than the mechanical dedup fixes done in that pass.",
+      "priority": 97,
+      "status": "pending",
+      "scope": [
+        "hooks/session-start.sh",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Deferred, not urgent -- this is an improvement to an already-working safety margin, not a live bug. The existing per-section budgets have held up in practice (no known real-world overflow incident). Additive, not a replacement, so it can land independently whenever picked up.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": "4-angle /simplify altitude review of hooks/session-start.sh (2026-08-06)",
+      "spec": null
+    },
+    {
+      "id": "F098",
+      "description": "hooks/session-start.sh independently loads and json.load's .harness/features.json in five separate python3 subprocesses scattered through the file (passing/total count, next-claimable selection, spec-drift check, scope-enforcement check, test_file-existence check) -- each pays interpreter startup plus a fresh parse of a file whose own comments note can carry >13,000-char descriptions across many features. Found by a 4-angle /simplify review (2026-08-06, efficiency and simplification angles both flagged this independently); two of the five call sites (passing/total count, next-claimable) were already consolidated toward harness_state.py delegation in the same review pass (see F088/notes and the session-start.sh commit history around 2026-08-06), but the remaining three (spec-drift, scope-enforcement, test_file-existence) still each spawn their own process. Fix: one python3 script that loads features.json once and runs all remaining checks against the in-memory feature list, printing each block conditionally -- roughly halves the remaining python3 spawn count on this hot path (every session start, every /compact). Deliberately NOT attempted as part of the /simplify pass that discovered it -- both reviewers who found it explicitly called it 'a larger structural change... worth considering' rather than a concrete line-level fix, and the individual consolidations already applied capture most of the measured benefit (see the benchmark in this session's own conversation: ~45% reduction in per-call wall-clock time from a similar single-spawn consolidation elsewhere in this chain).",
+      "priority": 98,
+      "status": "pending",
+      "scope": [
+        "hooks/session-start.sh",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "notes": "Deferred, not urgent -- real but lower-value than F097; the individually-fixed spawns (this same review pass) already capture most of the win. A future session picking this up should re-measure the actual remaining spawn count first, since it may have already shrunk further from other work.",
+      "correction_cycles": 0,
+      "scope_expansions": [],
+      "approaches_tried": [],
+      "failure_reason": null,
+      "discovered_via": "4-angle /simplify efficiency+simplification review of hooks/session-start.sh (2026-08-06)",
       "spec": null
     }
   ]

--- a/hooks/session-end.sh
+++ b/hooks/session-end.sh
@@ -12,25 +12,44 @@ GAPS=""
 add_gap() { GAPS="${GAPS}${1}
 "; }
 
-FEAT_DIRTY=$(git -C "$ROOT" status --porcelain -- .harness/features.json 2>/dev/null)
-PROG_DIRTY=$(git -C "$ROOT" status --porcelain -- .harness/claude-progress.txt 2>/dev/null)
+# add_note prints an informational, non-blocking discipline note (never written to
+# SESSION_INCOMPLETE): a shared prefix line followed by the note's own message.
+add_note() { printf 'Discipline note (informational, not blocking):\n%s\n' "$1"; }
+
+# Single git status scan of .harness/ -- FEAT_DIRTY, PROG_DIRTY, and DIRTY_META below
+# all derive from this one call instead of each re-scanning overlapping scope.
+META_STATUS=$(git -C "$ROOT" status --porcelain -- .harness/ 2>/dev/null)
+FEAT_DIRTY=$(printf '%s\n' "$META_STATUS" | grep -F '.harness/features.json' || true)
+PROG_DIRTY=$(printf '%s\n' "$META_STATUS" | grep -F '.harness/claude-progress.txt' || true)
 if [ -n "$FEAT_DIRTY" ] && [ -z "$PROG_DIRTY" ]; then
   add_gap "features.json changed but claude-progress.txt has no new handoff."
 fi
 
-WIP_GAPS=$(python3 - "$H/features.json" <<'PYEOF' 2>/dev/null || true
+# Single features.json load feeding both the in-progress WIP gap (blocking) and the
+# passing-no-proof note (informational) below -- the two blocks stay logically
+# distinct, they just share one python3 process and one json.load. The two blocks are
+# joined by a record-separator (0x1e) that can't appear in our own generated text.
+FEATURE_NOTES=$(python3 - "$H/features.json" <<'PYEOF' 2>/dev/null || true
 import json, sys
+
 try:
     feats = json.load(open(sys.argv[1])).get("features", [])
-    for f in feats:
-        if f.get("status") != "in-progress":
-            continue
-        if not f.get("test_file") or f.get("coverage") in (None, ""):
-            print(f"{f.get('id', '?')} is in-progress but missing test_file or coverage.")
 except Exception:
-    pass
+    feats = []
+wip = []
+proof = []
+for f in feats:
+    if f.get("status") == "in-progress" and (
+        not f.get("test_file") or f.get("coverage") in (None, "")
+    ):
+        wip.append(f"{f.get('id', '?')} is in-progress but missing test_file or coverage.")
+    if f.get("status") == "passing" and not f.get("proof"):
+        proof.append(f"{f.get('id', '?')} is passing with no proof recorded.")
+print("\n".join(wip) + "\x1e" + "\n".join(proof))
 PYEOF
 )
+WIP_GAPS="${FEATURE_NOTES%%$'\x1e'*}"
+PROOF_NOTES="${FEATURE_NOTES#*$'\x1e'}"
 [ -n "$WIP_GAPS" ] && add_gap "$WIP_GAPS"
 
 TODAY=$(date -u +%Y-%m-%d)
@@ -41,8 +60,7 @@ if ! grep -q "${MS_PATTERNS[@]}" "$H/context_summary.md" 2>/dev/null; then
   add_gap "Missing '## Meta-Session $TODAY' retrospective in context_summary.md."
 fi
 
-DIRTY_META=$(git -C "$ROOT" status -s -- .harness/ 2>/dev/null \
-  | grep -v '\.harness/SESSION_INCOMPLETE' || true)
+DIRTY_META=$(printf '%s\n' "$META_STATUS" | grep -v '\.harness/SESSION_INCOMPLETE' || true)
 if [ -n "$DIRTY_META" ]; then
   add_gap "Uncommitted .harness/ metadata - commit with a docs: prefix."
 fi
@@ -59,40 +77,26 @@ fi
 # gap) -- newer and softer than the Meta-Session retrospective check above, reviewed on
 # its own cadence (rules/mld-review.md) rather than gated every session.
 MLD_DIR="$H/mld"
-MLD_TODAY=$(date -u +%Y-%m-%d)
-MLD_TODAY_LOCAL=$(date +%Y-%m-%d)
 MLD_FOUND=""
 if [ -d "$MLD_DIR" ]; then
-  if find "$MLD_DIR" -maxdepth 1 -name "${MLD_TODAY}-*.md" -print -quit 2>/dev/null \
+  if find "$MLD_DIR" -maxdepth 1 -name "${TODAY}-*.md" -print -quit 2>/dev/null \
       | grep -q .; then
     MLD_FOUND=1
-  elif [ "$MLD_TODAY_LOCAL" != "$MLD_TODAY" ] \
-      && find "$MLD_DIR" -maxdepth 1 -name "${MLD_TODAY_LOCAL}-*.md" -print -quit \
+  elif [ "$TODAY_LOCAL" != "$TODAY" ] \
+      && find "$MLD_DIR" -maxdepth 1 -name "${TODAY_LOCAL}-*.md" -print -quit \
         2>/dev/null | grep -q .; then
     MLD_FOUND=1
   fi
 fi
 if [ -z "$MLD_FOUND" ]; then
-  printf 'Discipline note (informational, not blocking): no .harness/mld/ entry found\n'
-  printf 'for today (%s) -- see /harness-continue'"'"'s Session End step to write one.\n' \
-    "$MLD_TODAY"
+  MLD_MSG="no .harness/mld/ entry found for today ($TODAY) -- see"
+  MLD_MSG="$MLD_MSG /harness-continue's Session End step to write one."
+  add_note "$MLD_MSG"
 fi
 
 # Proof discipline note: informational only, never written to SESSION_INCOMPLETE
 # (not a gap) -- a passing feature with no proof recorded is worth surfacing, not
 # blocking the next session over.
-PROOF_NOTES=$(python3 - "$H/features.json" <<'PYEOF' 2>/dev/null || true
-import json, sys
-try:
-    feats = json.load(open(sys.argv[1])).get("features", [])
-    for f in feats:
-        if f.get("status") == "passing" and not f.get("proof"):
-            print(f"{f.get('id', '?')} is passing with no proof recorded.")
-except Exception:
-    pass
-PYEOF
-)
-[ -n "$PROOF_NOTES" ] && \
-  printf 'Discipline note (informational, not blocking):\n%s\n' "$PROOF_NOTES"
+[ -n "$PROOF_NOTES" ] && add_note "$PROOF_NOTES"
 
 exit 0

--- a/hooks/session-end.sh
+++ b/hooks/session-end.sh
@@ -4,7 +4,7 @@
 # Hard budget: must complete well under the 1.5s SessionEnd timeout. Always exits 0.
 set -uo pipefail
 
-ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || ROOT=$(pwd)
+ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 H="$ROOT/.harness"
 [ -d "$H" ] || exit 0
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -13,21 +13,25 @@ H="$ROOT/.harness"
 [ -d "$H" ] || exit 0
 
 STDIN_JSON=$(cat 2>/dev/null || true)
-SOURCE=$(printf '%s' "$STDIN_JSON" | python3 -c '
+# One parse of STDIN_JSON for both fields, separated by an ASCII Record
+# Separator (0x1e) rather than a newline: session_id is untrusted and may
+# itself carry embedded newlines (see the sanitization comment below), so a
+# newline-delimited split would silently truncate it at its own first
+# embedded newline.
+FIELD_SEP=$'\x1e'
+PARSED=$(printf '%s' "$STDIN_JSON" | python3 -c '
 import json, sys
+source, session_id = "", ""
 try:
-    print(json.load(sys.stdin).get("source", ""))
+    data = json.load(sys.stdin)
+    source = data.get("source", "")
+    session_id = data.get("session_id") or ""
 except Exception:
     pass
+sys.stdout.write(f"{source}\x1e{session_id}")
 ' 2>/dev/null || true)
-
-SESSION_ID=$(printf '%s' "$STDIN_JSON" | python3 -c '
-import json, sys
-try:
-    print(json.load(sys.stdin).get("session_id") or "")
-except Exception:
-    pass
-' 2>/dev/null || true)
+SOURCE=${PARSED%%$FIELD_SEP*}
+SESSION_ID=${PARSED#*$FIELD_SEP}
 # session_id is externally supplied and echoed into the orientation block below --
 # never trust it raw. Unfiltered, a newline lets it inject arbitrary lines into the
 # most authoritative position in this hook's output (directly under the orientation
@@ -93,7 +97,28 @@ if [ -f "$H/SESSION_INCOMPLETE" ]; then
 fi
 
 echo ""
-python3 - "$H/features.json" <<'PYEOF' 2>/dev/null || true
+# STATE_MODULE is the delegate-when-available switch for both blocks below:
+# a per-project harness_state.py (v5+ projects) owns the counting/claimable
+# algorithms; older projects initialized before that module existed fall back
+# to the inline computation.
+STATE_MODULE="$ROOT/.claude/hooks/harness_state.py"
+
+# Features passing-count: delegate to harness_state.py's own `counts` verb
+# when available instead of reimplementing the same sum-of-passing here.
+if [ -f "$STATE_MODULE" ] && [ -f "$H/features.json" ]; then
+  COUNTS_RESULT=$(python3 "$STATE_MODULE" counts "$H/features.json" 2>/dev/null || true)
+  if [ -n "$COUNTS_RESULT" ]; then
+    python3 - "$COUNTS_RESULT" <<'PYEOF' 2>/dev/null || true
+import json, sys
+try:
+    data = json.loads(sys.argv[1])
+    print(f"Features: {data['passing']}/{data['total']} passing")
+except Exception:
+    pass
+PYEOF
+  fi
+else
+  python3 - "$H/features.json" <<'PYEOF' 2>/dev/null || true
 import json, sys
 try:
     feats = json.load(open(sys.argv[1])).get("features", [])
@@ -102,11 +127,8 @@ try:
 except Exception:
     pass
 PYEOF
+fi
 
-# next-claimable: delegate the algorithm to harness_state.py when a per-project
-# copy exists (v5+ projects); fall back to the inline computation otherwise
-# (older projects initialized before this module existed).
-STATE_MODULE="$ROOT/.claude/hooks/harness_state.py"
 # OVI-105: a feature's description is free text with no length cap
 # (.harness/features.json has carried descriptions past 13,000 chars in real
 # use), and this whole script's stdout is what's capped at 10,000 chars
@@ -115,16 +137,17 @@ STATE_MODULE="$ROOT/.claude/hooks/harness_state.py"
 # warning and every rule pointer below -- from being silently pushed past
 # the cap by one long description. The full text is never lost; it's still
 # in features.json, just not echoed whole into every session's orientation.
-if [ -f "$STATE_MODULE" ] && [ -f "$H/features.json" ]; then
-  RESULT=$(python3 "$STATE_MODULE" next-claimable "$H/features.json" 2>/dev/null || true)
-  if [ "$RESULT" = "no claimable feature" ]; then
-    echo "Next claimable: none (no pending or failed features)"
-  elif [ -n "$RESULT" ]; then
-    python3 - "$RESULT" <<'PYEOF' 2>/dev/null || true
+#
+# print_next_claimable_line is the single formatter shared by both the
+# harness_state.py-delegated path and the inline fallback below -- each path
+# only has to produce a feature's JSON (or the literal "no claimable
+# feature") into RESULT; the truncation and "Next claimable: ..." line are
+# written once here, not copy-pasted per path.
+print_next_claimable_line() {
+  python3 - "$1" <<'PYEOF' 2>/dev/null || true
 import json, sys
 try:
-    data = json.loads(sys.argv[1])
-    f = data["next"]
+    f = json.loads(sys.argv[1])
     scope = ", ".join(f.get("scope") or [])
     desc = f.get("description", "")
     DESC_LIMIT = 200
@@ -135,9 +158,22 @@ try:
 except Exception:
     pass
 PYEOF
+}
+
+# next-claimable: delegate the algorithm to harness_state.py when a per-project
+# copy exists (v5+ projects); fall back to the inline computation otherwise
+# (older projects initialized before this module existed).
+if [ -f "$STATE_MODULE" ] && [ -f "$H/features.json" ]; then
+  RESULT=$(python3 "$STATE_MODULE" next-claimable "$H/features.json" 2>/dev/null || true)
+  if [ -n "$RESULT" ] && [ "$RESULT" != "no claimable feature" ]; then
+    # unwrap harness_state.py's {"next": {...}, "count": N} down to just the
+    # feature, so the fallback branch below and this one feed the same shape
+    # into the shared formatter.
+    RESULT=$(python3 -c 'import json, sys; print(json.dumps(json.loads(sys.argv[1])["next"]))' \
+      "$RESULT" 2>/dev/null || true)
   fi
 else
-  python3 - "$H/features.json" <<'PYEOF' 2>/dev/null || true
+  RESULT=$(python3 - "$H/features.json" <<'PYEOF' 2>/dev/null || true
 import json, sys
 try:
     feats = json.load(open(sys.argv[1])).get("features", [])
@@ -146,19 +182,19 @@ try:
                  and all(status.get(d) == "passing" for d in (f.get("depends_on") or []))]
     claimable.sort(key=lambda f: f.get("priority", 999))
     if claimable:
-        f = claimable[0]
-        scope = ", ".join(f.get("scope") or [])
-        desc = f.get("description", "")
-        DESC_LIMIT = 200
-        if len(desc) > DESC_LIMIT:
-            full_len = len(desc)
-            desc = desc[:DESC_LIMIT] + f"... ({full_len} chars total, see .harness/features.json for the full description)"
-        print(f"Next claimable: {f.get('id', '?')} - {desc} (scope: {scope})")
+        print(json.dumps(claimable[0]))
     else:
-        print("Next claimable: none (no pending or failed features)")
+        print("no claimable feature")
 except Exception:
     pass
 PYEOF
+)
+fi
+
+if [ "$RESULT" = "no claimable feature" ]; then
+  echo "Next claimable: none (no pending or failed features)"
+elif [ -n "$RESULT" ]; then
+  print_next_claimable_line "$RESULT"
 fi
 
 python3 - "$H/features.json" <<'PYEOF' 2>/dev/null || true
@@ -247,20 +283,18 @@ if [ -f "$H/context_summary.md" ]; then
     | print_budgeted_block ".harness/context_summary.md" || true
 fi
 
-EXPECTED_NAME=$(python3 -c '
+# One parse of harness.json for both fields.
+GIT_IDENTITY=$(python3 -c '
 import json, sys
 try:
-    print(json.load(open(sys.argv[1])).get("git_identity", {}).get("user_name", ""))
+    identity = json.load(open(sys.argv[1])).get("git_identity", {})
+    print(identity.get("user_name", ""))
+    print(identity.get("user_email", ""))
 except Exception:
     pass
 ' "$H/harness.json" 2>/dev/null || true)
-EXPECTED_EMAIL=$(python3 -c '
-import json, sys
-try:
-    print(json.load(open(sys.argv[1])).get("git_identity", {}).get("user_email", ""))
-except Exception:
-    pass
-' "$H/harness.json" 2>/dev/null || true)
+EXPECTED_NAME=$(printf '%s\n' "$GIT_IDENTITY" | sed -n '1p')
+EXPECTED_EMAIL=$(printf '%s\n' "$GIT_IDENTITY" | sed -n '2p')
 ACTUAL_NAME=$(git config user.name 2>/dev/null || true)
 ACTUAL_EMAIL=$(git config user.email 2>/dev/null || true)
 MISMATCH=""

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -8,7 +8,7 @@
 # linked review-cadence rule for what that directory is and why).
 set -uo pipefail
 
-ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || ROOT=$(pwd)
+ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 H="$ROOT/.harness"
 [ -d "$H" ] || exit 0
 
@@ -197,10 +197,18 @@ elif [ -n "$RESULT" ]; then
   print_next_claimable_line "$RESULT"
 fi
 
-python3 - "$H/features.json" <<'PYEOF' 2>/dev/null || true
-import hashlib, json, sys
+# F098: spec-drift, scope-armed, and test_file-existence each used to open and
+# json.load .harness/features.json in their own python3 process; one load here
+# feeds all three, each still in its OWN try/except (not one shared one) so a
+# crash in one check can't silently skip the other two the way a single shared
+# try/except would -- matching the original's per-block failure isolation.
+python3 - "$ROOT" "$H/features.json" <<'PYEOF' 2>/dev/null || true
+import hashlib, json, os, sys
+
+root, features_path = sys.argv[1], sys.argv[2]
+feats = json.load(open(features_path)).get("features", [])
+
 try:
-    feats = json.load(open(sys.argv[1])).get("features", [])
     drifted = []
     for f in feats:
         spec = f.get("spec") or {}
@@ -217,13 +225,8 @@ try:
         print("Re-run the spec gate (harness-issue-prep) before implementing these.")
 except Exception:
     pass
-PYEOF
 
-python3 - "$ROOT" "$H/features.json" <<'PYEOF' 2>/dev/null || true
-import json, os, sys
 try:
-    root, features_path = sys.argv[1], sys.argv[2]
-    feats = json.load(open(features_path)).get("features", [])
     armed_needed = any(
         f.get("status") == "in-progress" and f.get("assigned_to") is not None
         for f in feats
@@ -237,17 +240,12 @@ try:
             print("write it before spawning teammates or use worktree isolation.")
 except Exception:
     pass
-PYEOF
 
 # F066: a passing/in-progress feature's test_file is a claim, not a fact -- this
 # reproduces doctor.py's check_feature_test_files at session-start scope (cheap,
 # same os.path.isfile cost as the spec-drift hash check above) so faithful
 # orientation can't hand the session a fabricated picture.
-python3 - "$ROOT" "$H/features.json" <<'PYEOF' 2>/dev/null || true
-import json, os, sys
 try:
-    root, features_path = sys.argv[1], sys.argv[2]
-    feats = json.load(open(features_path)).get("features", [])
     missing = []
     for f in feats:
         if f.get("status") not in ("passing", "in-progress"):
@@ -295,8 +293,14 @@ except Exception:
 ' "$H/harness.json" 2>/dev/null || true)
 EXPECTED_NAME=$(printf '%s\n' "$GIT_IDENTITY" | sed -n '1p')
 EXPECTED_EMAIL=$(printf '%s\n' "$GIT_IDENTITY" | sed -n '2p')
-ACTUAL_NAME=$(git config user.name 2>/dev/null || true)
-ACTUAL_EMAIL=$(git config user.email 2>/dev/null || true)
+# One git-config call for both fields. --get-regexp lists a match from every
+# scope that defines it (system/global/local), lowest priority first, so the
+# LAST matching line per key is the effective value -- same as plain
+# `git config user.name` -- and must be picked with an END-block, not just
+# filtered.
+ACTUAL_IDENTITY=$(git config --get-regexp '^user\.(name|email)$' 2>/dev/null || true)
+ACTUAL_NAME=$(printf '%s\n' "$ACTUAL_IDENTITY" | awk '$1 == "user.name" {$1=""; sub(/^ /, ""); v=$0} END{print v}')
+ACTUAL_EMAIL=$(printf '%s\n' "$ACTUAL_IDENTITY" | awk '$1 == "user.email" {$1=""; sub(/^ /, ""); v=$0} END{print v}')
 MISMATCH=""
 if [ -n "$EXPECTED_NAME" ] && [ "$EXPECTED_NAME" != "$ACTUAL_NAME" ]; then MISMATCH=1; fi
 if [ -n "$EXPECTED_EMAIL" ] && [ "$EXPECTED_EMAIL" != "$ACTUAL_EMAIL" ]; then MISMATCH=1; fi

--- a/skills/harness-init/commit-gate.sh.template
+++ b/skills/harness-init/commit-gate.sh.template
@@ -1199,7 +1199,19 @@ def added_lines(diff_text):
             current_line += 1
 
 
-def secret_scan_exempt_paths(project_root):
+def load_harness_config(project_root):
+    # One read of harness.json, shared by secret_scan_exempt_paths() and
+    # style_gate_enabled() below -- both previously opened and json.load'd
+    # this same file independently on every commit-gated Bash call.
+    path = os.path.join(project_root, ".harness", "harness.json")
+    try:
+        with open(path) as fh:
+            return json.load(fh)
+    except (OSError, ValueError):
+        return {}
+
+
+def secret_scan_exempt_paths(harness_config):
     # Opt-in, harness.json-configured list of paths (verbatim, relative to
     # project_root, matching the diff's own path form) additionally exempt
     # from the secret scan -- for a project whose own test suite must stage
@@ -1214,13 +1226,7 @@ def secret_scan_exempt_paths(project_root):
     # fixtures, not a defense against the LEAD itself adding an unwise
     # exemption -- LEAD_OWNED protects against teammates, not against the
     # lead's own mistakes.
-    path = os.path.join(project_root, ".harness", "harness.json")
-    try:
-        with open(path) as fh:
-            data = json.load(fh)
-    except (OSError, ValueError):
-        return []
-    paths = data.get("secret_scan_exempt_paths")
+    paths = harness_config.get("secret_scan_exempt_paths")
     if not isinstance(paths, list):
         return []
     return [p for p in paths if isinstance(p, str)]
@@ -1265,14 +1271,8 @@ def find_style_violation(lines, deadline):
     return None
 
 
-def style_gate_enabled(project_root):
-    path = os.path.join(project_root, ".harness", "harness.json")
-    try:
-        with open(path) as fh:
-            data = json.load(fh)
-    except (OSError, ValueError):
-        return False
-    style_gate = data.get("style_gate")
+def style_gate_enabled(harness_config):
+    style_gate = harness_config.get("style_gate")
     if not isinstance(style_gate, dict):
         return False
     return bool(style_gate.get("enabled", False))
@@ -1297,12 +1297,13 @@ def main():
             return
         lines = list(added_lines(diff_text))
         deadline = time.monotonic() + SCAN_TIME_BUDGET_SECONDS
-        exempt_paths = secret_scan_exempt_paths(project_root)
+        harness_config = load_harness_config(project_root)
+        exempt_paths = secret_scan_exempt_paths(harness_config)
         reason = find_secret(lines, deadline, exempt_paths)
         if reason:
             print(reason)
             return
-        if style_gate_enabled(project_root):
+        if style_gate_enabled(harness_config):
             reason = find_style_violation(lines, deadline)
             if reason:
                 print(reason)

--- a/skills/harness-init/enforce-scope.sh.template
+++ b/skills/harness-init/enforce-scope.sh.template
@@ -435,7 +435,7 @@ if [ -n "$FILE_PATH" ]; then
     # scoped teammate blocked from an out-of-scope edit sees nothing at all.
     echo "Edit blocked: $FILE_PATH is outside your assigned scope." >&2
     echo "Your scope (from $SCOPE_FILE):" >&2
-    cat "$SCOPE_FILE" | grep -v '^#' | grep -v '^$' >&2
+    grep -v -e '^#' -e '^$' "$SCOPE_FILE" >&2
     echo "" >&2
     echo "Repair: request a scope expansion from the lead: SendMessage({ type: \"message\", recipient: \"team-lead\", content: \"Requesting scope expansion to $FILE_PATH because [reason].\" })" >&2
     _dashboard_log "block" "scope-violation:out-of-scope-edit" || true

--- a/skills/harness-init/init.sh.template
+++ b/skills/harness-init/init.sh.template
@@ -116,9 +116,8 @@ case "$STACK" in
         if [ "$TARGET" = "smoke_test" ]; then
             echo ""
             echo "--- Python Syntax Check ---"
-            find . -name "*.py" -not -path "./.git/*" -not -path "./venv/*" -not -path "./.venv/*" | head -50 | while read f; do
-                python3 -m py_compile "$f" 2>&1 && true
-            done
+            find . -name "*.py" -not -path "./.git/*" -not -path "./venv/*" -not -path "./.venv/*" | head -50 \
+                | python3 -m compileall -q -i - 2>&1 || true
             echo "Syntax check complete."
         else
             echo ""

--- a/skills/harness-init/verify-git-identity.sh.template
+++ b/skills/harness-init/verify-git-identity.sh.template
@@ -27,20 +27,17 @@ if [ ! -f ".harness/harness.json" ]; then
     exit 0
 fi
 
-# Extract expected identity from harness.json
-EXPECTED_NAME=$(python3 -c "
+# Extract expected identity from harness.json (one parse of the file for both fields)
+GIT_IDENTITY=$(python3 -c "
 import json
 with open('.harness/harness.json') as f:
     data = json.load(f)
-print(data.get('git_identity', {}).get('user_name', ''))
+identity = data.get('git_identity', {})
+print(identity.get('user_name', ''))
+print(identity.get('user_email', ''))
 " 2>/dev/null)
-
-EXPECTED_EMAIL=$(python3 -c "
-import json
-with open('.harness/harness.json') as f:
-    data = json.load(f)
-print(data.get('git_identity', {}).get('user_email', ''))
-" 2>/dev/null)
+EXPECTED_NAME=$(printf '%s\n' "$GIT_IDENTITY" | sed -n '1p')
+EXPECTED_EMAIL=$(printf '%s\n' "$GIT_IDENTITY" | sed -n '2p')
 
 if [ -z "$EXPECTED_NAME" ] || [ -z "$EXPECTED_EMAIL" ]; then
     exit 0
@@ -97,9 +94,13 @@ if ! echo "$COMMAND" | grep -qE 'git\s+(push|pull|clone|fetch)'; then
     exit 0
 fi
 
-# Check current git identity
-CURRENT_NAME=$(git config user.name 2>/dev/null)
-CURRENT_EMAIL=$(git config user.email 2>/dev/null)
+# Check current git identity (one git-config call for both fields). --get-regexp lists
+# a match from every scope that defines it (system/global/local), lowest priority first,
+# so the last matching line per key is the effective value -- same as plain `git config
+# user.name` -- and must be picked with an END-block, not just filtered.
+CURRENT_IDENTITY=$(git config --get-regexp '^user\.(name|email)$' 2>/dev/null)
+CURRENT_NAME=$(printf '%s\n' "$CURRENT_IDENTITY" | awk '$1 == "user.name" {$1=""; sub(/^ /, ""); v=$0} END{print v}')
+CURRENT_EMAIL=$(printf '%s\n' "$CURRENT_IDENTITY" | awk '$1 == "user.email" {$1=""; sub(/^ /, ""); v=$0} END{print v}')
 
 if [ "$CURRENT_NAME" != "$EXPECTED_NAME" ] || [ "$CURRENT_EMAIL" != "$EXPECTED_EMAIL" ]; then
     echo "Git push blocked: identity mismatch." >&2

--- a/skills/harness-init/verify-task-quality.sh.template
+++ b/skills/harness-init/verify-task-quality.sh.template
@@ -219,84 +219,86 @@ FULL_OUTPUT=$(bash .harness/init.sh full_test 2>&1) || {
     exit 2
 }
 
-# Coverage target gate: compare the targeted feature's own recorded `coverage`
-# number against its `coverage_target` (falls back to 95). Skipped entirely when
-# coverage isn't a number yet (e.g. this repo's own descriptive strings) --
-# proportional: don't punish projects without numeric coverage tooling.
-if [ -n "$FEATURE_ID" ] && [ -f ".harness/features.json" ]; then
-    COVERAGE_RESULT=$(python3 - ".harness/features.json" "$FEATURE_ID" <<'PYEOF'
+# Coverage target gate, claim-matched proof warning, and stale-in-progress
+# reminder all read .harness/features.json -- one load, one process, feeding
+# all three checks below, instead of three independent python3 subprocesses
+# each re-opening and re-parsing the same file.
+COVERAGE_RESULT=""
+PROOF_WARNING=""
+IN_PROGRESS=0
+if [ -f ".harness/features.json" ]; then
+    _CHECKS=$(python3 - ".harness/features.json" "$FEATURE_ID" <<'PYEOF'
 import json
 import sys
 
 path, feature_id = sys.argv[1], sys.argv[2]
 with open(path) as fh:
     data = json.load(fh)
-match = next((f for f in data.get("features", []) if f.get("id") == feature_id), None)
-if match is None:
-    sys.exit(0)
-coverage = match.get("coverage")
-if not isinstance(coverage, (int, float)) or isinstance(coverage, bool):
-    sys.exit(0)
-target = match.get("coverage_target")
-if not isinstance(target, int) or isinstance(target, bool):
-    target = 95
-if coverage < target:
-    print(f"{coverage}|{target}")
-PYEOF
-)
-    if [ -n "$COVERAGE_RESULT" ]; then
-        ACHIEVED="${COVERAGE_RESULT%%|*}"
-        TARGET="${COVERAGE_RESULT##*|}"
-        echo "Task rejected: coverage $ACHIEVED% is below the target $TARGET%." >&2
-        increment_correction_cycles
-        _dashboard_log "block" "coverage-below-target" || true
-        exit 2
-    fi
-fi
+features = data.get("features", [])
+match = next((f for f in features if f.get("id") == feature_id), None) if feature_id else None
+
+# Coverage target gate: compare the targeted feature's own recorded `coverage`
+# number against its `coverage_target` (falls back to 95). Skipped entirely when
+# coverage isn't a number yet (e.g. this repo's own descriptive strings) --
+# proportional: don't punish projects without numeric coverage tooling.
+coverage_result = ""
+if match is not None:
+    coverage = match.get("coverage")
+    if isinstance(coverage, (int, float)) and not isinstance(coverage, bool):
+        target = match.get("coverage_target")
+        if not isinstance(target, int) or isinstance(target, bool):
+            target = 95
+        if coverage < target:
+            coverage_result = f"{coverage}|{target}"
+print(coverage_result)
 
 # Claim-matched proof: warn (never block) when this feature accepts with no
 # proof recorded, or with proof whose evidence_type doesn't match its declared
 # qa_binding. Reads both fields directly off the feature object -- no external
 # lookup, no re-parsing of prose.
-PROOF_WARNING=""
-if [ -n "$FEATURE_ID" ] && [ -f ".harness/features.json" ]; then
-    PROOF_WARNING=$(python3 - ".harness/features.json" "$FEATURE_ID" <<'PYEOF'
-import json
-import sys
+proof_warning = ""
+if match is not None:
+    proof = match.get("proof")
+    qa_binding = match.get("qa_binding")
+    if not proof:
+        proof_warning = f"WARN: {feature_id} accepted with no proof recorded."
+    elif qa_binding and proof.get("evidence_type") != qa_binding:
+        proof_warning = (
+            f"WARN: {feature_id}'s proof.evidence_type "
+            f"'{proof.get('evidence_type')}' does not match its declared "
+            f"qa_binding '{qa_binding}'. Fix the proof or the binding."
+        )
+print(proof_warning)
 
-path, feature_id = sys.argv[1], sys.argv[2]
-with open(path) as fh:
-    data = json.load(fh)
-match = next((f for f in data.get("features", []) if f.get("id") == feature_id), None)
-if match is None:
-    sys.exit(0)
-proof = match.get("proof")
-qa_binding = match.get("qa_binding")
-if not proof:
-    print(f"WARN: {feature_id} accepted with no proof recorded.")
-elif qa_binding and proof.get("evidence_type") != qa_binding:
-    print(
-        f"WARN: {feature_id}'s proof.evidence_type "
-        f"'{proof.get('evidence_type')}' does not match its declared "
-        f"qa_binding '{qa_binding}'. Fix the proof or the binding."
-    )
+# Remind about stale in-progress features. Matches the original's exact
+# f['status'] indexing (not .get) and its own fallback: any exception here
+# (e.g. a feature missing "status" entirely) defaults the count to 0, same
+# as the previous "python3 ... 2>/dev/null || echo 0" bash-level fallback.
+try:
+    in_progress = len([f for f in features if f['status'] == 'in-progress'])
+except Exception:
+    in_progress = 0
+print(in_progress)
 PYEOF
 )
+    COVERAGE_RESULT=$(printf '%s\n' "$_CHECKS" | sed -n '1p')
+    PROOF_WARNING=$(printf '%s\n' "$_CHECKS" | sed -n '2p')
+    IN_PROGRESS=$(printf '%s\n' "$_CHECKS" | sed -n '3p')
+    [ -n "$IN_PROGRESS" ] || IN_PROGRESS=0
 fi
 
-# Remind about stale in-progress features
+if [ -n "$COVERAGE_RESULT" ]; then
+    ACHIEVED="${COVERAGE_RESULT%%|*}"
+    TARGET="${COVERAGE_RESULT##*|}"
+    echo "Task rejected: coverage $ACHIEVED% is below the target $TARGET%." >&2
+    increment_correction_cycles
+    _dashboard_log "block" "coverage-below-target" || true
+    exit 2
+fi
+
 IN_PROGRESS_NOTE=""
-if [ -f ".harness/features.json" ]; then
-    IN_PROGRESS=$(python3 -c "
-import json, sys
-with open('.harness/features.json') as f:
-    data = json.load(f)
-in_progress = [f for f in data.get('features', []) if f['status'] == 'in-progress']
-print(len(in_progress))
-" 2>/dev/null || echo "0")
-    if [ "$IN_PROGRESS" -gt 0 ]; then
-        IN_PROGRESS_NOTE="Note: $IN_PROGRESS feature(s) still marked in-progress. Update features.json if your feature is complete."
-    fi
+if [ "$IN_PROGRESS" -gt 0 ]; then
+    IN_PROGRESS_NOTE="Note: $IN_PROGRESS feature(s) still marked in-progress. Update features.json if your feature is complete."
 fi
 
 # All checks passed. Claude Code's own hooks docs (code.claude.com/docs/en/hooks)

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -66,16 +66,25 @@ make_fixture() {
   git -C "$1" commit -q -m "fixture baseline"
 }
 
+# CLAUDE_PROJECT_DIR is explicitly set to the fixture dir ($1) in all three
+# helpers below, matching run_dashboard_log()'s own pattern (see its comment) --
+# session-start.sh/session-end.sh now prefer CLAUDE_PROJECT_DIR over git-toplevel
+# (the same F089 consistency fix applied to dashboard-log.sh earlier), so merely
+# `cd`ing into the fixture and relying on git-toplevel would let any ambient
+# CLAUDE_PROJECT_DIR already set in the environment running this suite (exactly
+# what happens under a real Claude Code hook invocation, e.g.
+# verify-task-quality.sh's own TaskCompleted run) leak through and point these
+# hooks at the real repo instead of the isolated fixture.
 run_session_start() {
-  (cd "$1" && printf '%s' "$2" | env -u CLAUDE_PLUGIN_ROOT bash "$HOOKS_DIR/session-start.sh")
+  (cd "$1" && printf '%s' "$2" | CLAUDE_PROJECT_DIR="$1" env -u CLAUDE_PLUGIN_ROOT bash "$HOOKS_DIR/session-start.sh")
 }
 
 run_session_start_with_root() {
-  (cd "$1" && printf '%s' "$2" | CLAUDE_PLUGIN_ROOT="$3" bash "$HOOKS_DIR/session-start.sh")
+  (cd "$1" && printf '%s' "$2" | CLAUDE_PROJECT_DIR="$1" CLAUDE_PLUGIN_ROOT="$3" bash "$HOOKS_DIR/session-start.sh")
 }
 
 run_session_end() {
-  (cd "$1" && bash "$HOOKS_DIR/session-end.sh" </dev/null)
+  (cd "$1" && CLAUDE_PROJECT_DIR="$1" bash "$HOOKS_DIR/session-end.sh" </dev/null)
 }
 
 run_statusline() {
@@ -694,7 +703,7 @@ print(json.dumps({
 }))
 ')
 OUT=$(cd "$DIR_SID" && printf '%s' "$INJECT_JSON" \
-  | env -u CLAUDE_PLUGIN_ROOT bash "$HOOKS_DIR/session-start.sh")
+  | CLAUDE_PROJECT_DIR="$DIR_SID" env -u CLAUDE_PLUGIN_ROOT bash "$HOOKS_DIR/session-start.sh")
 RC=$?
 assert_rc0 "$RC" "sid: a newline-bearing session_id exits 0"
 INJECT_LINES=$(printf '%s\n' "$OUT" | wc -l | tr -d ' ')

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -888,6 +888,9 @@ RC=$?
 assert_rc0 "$RC" "pf: session-end exits 0 with a passing-no-proof feature"
 assert_contains "$OUT" "F002" "pf: proof discipline note names the feature"
 assert_contains "$OUT" "no proof" "pf: proof discipline note mentions no proof"
+assert_contains "$OUT" \
+  $'Discipline note (informational, not blocking):\nF001 is passing with no proof recorded.' \
+  "pf: proof note prefix sits on its own line above the message (add_note format)"
 if [ -f "$DIR_PROOF/.harness/SESSION_INCOMPLETE" ]; then
   fail "pf: a missing-proof note must not write SESSION_INCOMPLETE"
 else
@@ -930,6 +933,9 @@ assert_rc0 "$RC" "md1: session-end exits 0 with no .harness/mld/ entry"
 assert_contains "$OUT" "no .harness/mld/ entry found" \
   "md1: mld discipline note fires when today's entry is missing"
 assert_contains "$OUT" "$TODAY" "md1: mld discipline note names today's date"
+assert_contains "$OUT" \
+  $'Discipline note (informational, not blocking):\nno .harness/mld/ entry found' \
+  "md1: mld note prefix sits on its own line above the message (add_note format)"
 if [ -f "$DIR_MLD_MISSING/.harness/SESSION_INCOMPLETE" ]; then
   fail "md1: a missing-mld note must not write SESSION_INCOMPLETE"
 else
@@ -974,6 +980,43 @@ RC=$?
 assert_rc0 "$RC" "md3: session-end exits 0 with only a stale mld entry"
 assert_contains "$OUT" "no .harness/mld/ entry found" \
   "md3: a stale (non-today) mld entry does not satisfy the discipline check"
+
+# F4 (simplify pass): both notes firing in the same run must each carry the shared
+# add_note() prefix, in its own consistent format -- not just one of the two.
+DIR_NOTES_BOTH="$WORK/session-end-notes-both"
+make_fixture "$DIR_NOTES_BOTH"
+TODAY=$(date -u +%Y-%m-%d)
+printf '\n## Meta-Session %s\n- clean\n' "$TODAY" \
+  >> "$DIR_NOTES_BOTH/.harness/context_summary.md"
+python3 - "$DIR_NOTES_BOTH/.harness/features.json" <<'PYEOF'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path) as fh:
+    data = json.load(fh)
+for feature in data["features"]:
+    if feature["id"] == "F002":
+        feature["status"] = "passing"
+        feature["coverage"] = 96
+with open(path, "w") as fh:
+    json.dump(data, fh, indent=2)
+    fh.write("\n")
+PYEOF
+git -C "$DIR_NOTES_BOTH" add -A
+git -C "$DIR_NOTES_BOTH" commit -q -m "no mld entry, F002 passing with no proof"
+OUT=$(run_session_end "$DIR_NOTES_BOTH")
+RC=$?
+assert_rc0 "$RC" "mp: session-end exits 0 with both notes firing"
+PREFIX_COUNT=$(printf '%s\n' "$OUT" \
+  | grep -c '^Discipline note (informational, not blocking):$')
+if [ "$PREFIX_COUNT" -eq 2 ]; then
+  pass "mp: both the mld note and the proof note use the shared add_note() prefix"
+else
+  fail "mp: expected 2 standalone add_note() prefix lines, got $PREFIX_COUNT"
+fi
+assert_contains "$OUT" "no .harness/mld/ entry found" "mp: mld note still fires"
+assert_contains "$OUT" "F002 is passing with no proof recorded." "mp: proof note still fires"
 
 echo ""
 echo "== statusline.sh =="

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -6060,6 +6060,20 @@ else
   fail "hs: next-claimable output differs -- plain: '$NEXT_PLAIN' module: '$NEXT_MODULE'"
 fi
 
+# session-start.sh's "Features: N/M passing" line delegates to harness_state.py's
+# own `counts` verb when a per-project copy exists, mirroring the next-claimable
+# delegation exercised just above -- confirm the line matches whether the module
+# is present or not, reusing the same two fixtures/outputs.
+FEATURES_PLAIN=$(printf '%s\n' "$OUT_PLAIN" | grep "^Features:")
+FEATURES_MODULE=$(printf '%s\n' "$OUT_MODULE" | grep "^Features:")
+if [ -n "$FEATURES_PLAIN" ] && [ "$FEATURES_PLAIN" = "$FEATURES_MODULE" ]; then
+  pass "hs: Features passing-count line is identical whether harness_state.py is present or not"
+else
+  fail "hs: Features line differs -- plain: '$FEATURES_PLAIN' module: '$FEATURES_MODULE'"
+fi
+assert_contains "$FEATURES_PLAIN" "1/3 passing" \
+  "hs: Features line reports 1/3 passing (fallback and delegated paths agree)"
+
 # F084/PR#120 round-1 review NIT-4: _with_file_lock's flock retry loop used to
 # catch bare OSError, treating a permanent error (e.g. ENOLCK -- errno 77,
 # "no locks available", distinct from EWOULDBLOCK/EAGAIN which flock(LOCK_NB)


### PR DESCRIPTION
## Summary

Two sessions of `/simplify` work, goal: reduce redundant subprocess spawns across every script the harness ships (`hooks/`, `skills/harness-init/*.sh.template`), not just one file.

**Session 1** (earlier commits on this branch) — `hooks/session-start.sh`, `hooks/session-end.sh`, `hooks/statusline.sh` (no findings, already clean):
- Consolidated duplicate `python3` spawns parsing the same stdin JSON / `harness.json` field into one each.
- Delegated the "Features: N/M passing" line to `harness_state.py`'s `counts` verb, matching the next block's existing delegation pattern.
- De-duplicated copy-pasted "next claimable" truncation/print logic into one shared function.
- `session-end.sh`: four `date` spawns → two, three `git status` calls → one, two `features.json` parses → one; added a shared `add_note()` helper.
- Filed F097 (no measured total-output safety net against the 10,000-char cap) and F098 (three of five `features.json` parses in session-start.sh still separate) as follow-ups — flagged as structurally bigger than a mechanical dedup.

**Session 2** (this PR's newest commit) — scoped to every remaining harness script, goal explicitly performance:
- `verify-git-identity.sh` (fires on every Bash call): merged two `harness.json` parses and two `git config` calls into one each.
- `verify-task-quality.sh` (every TaskCompleted): merged three `features.json` parses into one.
- `commit-gate.sh`: merged two `harness.json` parses (secret-scan exemptions + style gate) into one.
- `init.sh.template`: replaced a loop of up to 50 `python3 -m py_compile` spawns with one `compileall` call.
- `session-start.sh`/`session-end.sh`: fixed `ROOT` resolution to prefer `CLAUDE_PROJECT_DIR`, matching every other hook (implements F098's remaining scope in session-start.sh, plus the git-config dedup).
- `enforce-scope.sh`: collapsed a `cat | grep -v | grep -v` to one `grep`.
- Fixed `test/run-tests.sh` fixture isolation: the `CLAUDE_PROJECT_DIR` fix above exposed that `run_session_start`/`run_session_start_with_root`/`run_session_end` never set it, so the real value from a live TaskCompleted hook invocation leaked into fixture tests and pointed them at this repo instead of their temp fixtures — the same bug class already fixed for `dashboard-log.sh`'s test helper, fixed here the same way.

Two proposed fixes were tried and reverted after concrete test failures, not applied: a `commit-gate.sh` prefilter (skip parsing unless `"git"` appears in the command) broke F051's escaped-git evasion tests (`g\it`, `$'\x67it'` decode to "git" without the literal substring ever appearing raw); merging `enforce-scope.sh`'s FILE_PATH/COMMAND extraction was judged too risky given each field's independently fought-for fail-open/fail-closed exit-code contract (F043) with dedicated regression tests.

## Test plan

- [x] `bash test/run-tests.sh` — 1852/1852 passing
- [x] Same suite re-run with `CLAUDE_PROJECT_DIR` set (matching the real TaskCompleted hook environment) — 1852/1852 passing
- [x] All `skills/harness-init/*.sh.template` copies re-synced with their installed `.claude/hooks/` counterparts (F047 drift check)
- [x] `bash -n` (stock bash 3.2 parse check) clean on every touched file