### PR TITLE
v5.6.0: clear the remaining feature backlog (F087, F094-F098, F107, F108)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vv-harness",
   "displayName": "VV Claude Code Harness",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Multi-session continuity, parallel Agent Teams coordination, and mechanical quality enforcement for Claude Code.",
   "author": {
     "name": "oeftimie",

--- a/.claude/hooks/check-remaining-tasks.sh
+++ b/.claude/hooks/check-remaining-tasks.sh
@@ -141,28 +141,38 @@ NEXT=$(printf '%s' "$RESULT" | python3 -c "
 import json
 import sys
 
+# The whole formatter is guarded: a malformed feature entry (e.g. an explicit
+# null description, which f.get('description', '') passes through as None)
+# must degrade to a minimal nudge, never crash the substitution -- under
+# set -euo pipefail a crash here would suppress the exit-2 block verdict
+# entirely (silent fail-open). Mirrors session-start.sh's own try/except
+# around the identical cap logic.
 data = json.load(sys.stdin)
 f = data['next']
-status_note = ' (retry)' if f.get('status') == 'failed' else ''
-scope_list = f.get('scope') or []
-scope = ', '.join(scope_list) or 'no scope defined'
-# F107: description and scope are the same unbounded-field class F071 and
-# F085 already closed for session-start.sh's orientation -- this line goes
-# straight to stderr, into a blocked agent's context, on exit 2. Same
-# truncate-and-point caps and marker wording, so the two hooks stay
-# consistent.
-SCOPE_LIMIT = 150
-if len(scope) > SCOPE_LIMIT:
-    noun = 'path' if len(scope_list) == 1 else 'paths'
-    scope = scope[:SCOPE_LIMIT] + f\"... ({len(scope_list)} {noun} total, see .harness/features.json)\"
-desc = f.get('description', '')
-DESC_LIMIT = 200
-if len(desc) > DESC_LIMIT:
-    full_len = len(desc)
-    desc = desc[:DESC_LIMIT] + f\"... ({full_len} chars total, see .harness/features.json for the full description)\"
-print(f\"{data['count']} claimable feature(s). Next: {f.get('id')}: \"
-      f\"{desc} (priority {f.get('priority', 'unset')})\"
-      f\"{status_note} [scope: {scope}]\")
+try:
+    status_note = ' (retry)' if f.get('status') == 'failed' else ''
+    scope_list = [str(p) for p in (f.get('scope') or [])]
+    scope = ', '.join(scope_list) or 'no scope defined'
+    # F107: description and scope are the same unbounded-field class F071 and
+    # F085 already closed for session-start.sh's orientation -- this line goes
+    # straight to stderr, into a blocked agent's context, on exit 2. Same
+    # truncate-and-point caps and marker wording, so the two hooks stay
+    # consistent.
+    SCOPE_LIMIT = 150
+    if len(scope) > SCOPE_LIMIT:
+        noun = 'path' if len(scope_list) == 1 else 'paths'
+        scope = scope[:SCOPE_LIMIT] + f\"... ({len(scope_list)} {noun} total, see .harness/features.json)\"
+    desc = f.get('description') or ''
+    DESC_LIMIT = 200
+    if len(desc) > DESC_LIMIT:
+        full_len = len(desc)
+        desc = desc[:DESC_LIMIT] + f\"... ({full_len} chars total, see .harness/features.json for the full description)\"
+    print(f\"{data['count']} claimable feature(s). Next: {f.get('id')}: \"
+          f\"{desc} (priority {f.get('priority', 'unset')})\"
+          f\"{status_note} [scope: {scope}]\")
+except Exception:
+    print(f\"{data.get('count', '?')} claimable feature(s). Next: {f.get('id', 'unknown')}\"
+          \" (details unavailable; see .harness/features.json)\")
 ")
 
 echo "$NEXT" >&2

--- a/.claude/hooks/check-remaining-tasks.sh
+++ b/.claude/hooks/check-remaining-tasks.sh
@@ -144,9 +144,24 @@ import sys
 data = json.load(sys.stdin)
 f = data['next']
 status_note = ' (retry)' if f.get('status') == 'failed' else ''
-scope = ', '.join(f.get('scope') or []) or 'no scope defined'
+scope_list = f.get('scope') or []
+scope = ', '.join(scope_list) or 'no scope defined'
+# F107: description and scope are the same unbounded-field class F071 and
+# F085 already closed for session-start.sh's orientation -- this line goes
+# straight to stderr, into a blocked agent's context, on exit 2. Same
+# truncate-and-point caps and marker wording, so the two hooks stay
+# consistent.
+SCOPE_LIMIT = 150
+if len(scope) > SCOPE_LIMIT:
+    noun = 'path' if len(scope_list) == 1 else 'paths'
+    scope = scope[:SCOPE_LIMIT] + f\"... ({len(scope_list)} {noun} total, see .harness/features.json)\"
+desc = f.get('description', '')
+DESC_LIMIT = 200
+if len(desc) > DESC_LIMIT:
+    full_len = len(desc)
+    desc = desc[:DESC_LIMIT] + f\"... ({full_len} chars total, see .harness/features.json for the full description)\"
 print(f\"{data['count']} claimable feature(s). Next: {f.get('id')}: \"
-      f\"{f.get('description')} (priority {f.get('priority', 'unset')})\"
+      f\"{desc} (priority {f.get('priority', 'unset')})\"
       f\"{status_note} [scope: {scope}]\")
 ")
 

--- a/.claude/hooks/commit-gate.sh
+++ b/.claude/hooks/commit-gate.sh
@@ -373,7 +373,28 @@ if [ "$COMMAND_RC" -eq 1 ]; then
     deny_json "command could not be safely extracted from tool input (best-effort, pattern-based check; treating as a compound-stage-and-commit risk out of caution)."
 fi
 
-DENY_REASON=$(python3 - "$COMMAND" "$PROJECT_ROOT" <<'PYEOF'
+# F096 (second adversarial review, 2026-08-05): $COMMAND used to be passed
+# to this analysis python3 process via argv (`python3 - "$COMMAND" ...`,
+# reading its own script from the same stdin the heredoc below fed it), the
+# same ARG_MAX-exec-failure class F088-F093 fixed for deny_json()'s
+# payload -- an extremely large Bash command (over ~1MB on macOS, as low as
+# 128KB per-argument on Linux) failed this exec silently, DENY_REASON came
+# back empty, and the caller below fell through to an unintended allow, one
+# call site earlier in the exact same chain deny_json() already guards
+# (mirrors the identical fix in enforce-scope.sh.template, F096). Fixed the
+# same way (F094/F089 round 2's own established pattern): the python source
+# is read into a variable via a heredoc FIRST, then invoked with `-c`,
+# freeing stdin to carry $COMMAND itself -- unbounded in size, unlike
+# $PROJECT_ROOT, which stays on argv since it never grows with attacker
+# input. Unlike enforce-scope.sh.template's analogous fix, no DENY_REASON
+# length cap is added here: every reason this script's own main() can print
+# is either one of its own fixed constants (DENY_COMPOUND et al.) or built
+# from a staged-diff path/line number, never from raw command/segment text
+# reflected back -- so, unlike enforce-scope.sh.template's write-target/
+# segment quoting, DENY_REASON here was never made attacker-sized by this
+# bug in the first place; only the argv-vs-stdin transport of $COMMAND
+# itself needed fixing.
+IFS= read -r -d '' _COMMIT_ANALYSIS_PY <<'PYEOF' || true
 import fnmatch
 import json
 import os
@@ -1322,8 +1343,10 @@ def style_gate_enabled(harness_config):
 
 
 def main():
-    command = sys.argv[1]
-    project_root = sys.argv[2]
+    # F096: read from stdin, not argv[1] -- see the heredoc-assembly comment
+    # above this script's own invocation for why.
+    command = sys.stdin.read()
+    project_root = sys.argv[1]
 
     parsed = parse_command(command)
     if not any(sc == "commit" for _, sc, _, _ in parsed):
@@ -1379,7 +1402,7 @@ def main():
 
 main()
 PYEOF
-)
+    DENY_REASON=$(printf '%s' "$COMMAND" | python3 -c "$_COMMIT_ANALYSIS_PY" "$PROJECT_ROOT")
 
 # Passing-flip full_test gate (F102). Runs only when the python above
 # established "commit, no deny" via the sentinel. The comparison is INDEX

--- a/.claude/hooks/commit-gate.sh
+++ b/.claude/hooks/commit-gate.sh
@@ -386,14 +386,13 @@ fi
 # is read into a variable via a heredoc FIRST, then invoked with `-c`,
 # freeing stdin to carry $COMMAND itself -- unbounded in size, unlike
 # $PROJECT_ROOT, which stays on argv since it never grows with attacker
-# input. Unlike enforce-scope.sh.template's analogous fix, no DENY_REASON
-# length cap is added here: every reason this script's own main() can print
-# is either one of its own fixed constants (DENY_COMPOUND et al.) or built
-# from a staged-diff path/line number, never from raw command/segment text
-# reflected back -- so, unlike enforce-scope.sh.template's write-target/
-# segment quoting, DENY_REASON here was never made attacker-sized by this
-# bug in the first place; only the argv-vs-stdin transport of $COMMAND
-# itself needed fixing.
+# input. Every reason this script's python main() can print is either one
+# of its own fixed constants (DENY_COMPOUND et al.) or built from a
+# staged-diff path/line number, never from raw command/segment text
+# reflected back -- but the shell-level passing-flip deny reason below is
+# NOT bounded: it interpolates the last 15 lines of full_test output, whose
+# character count is unbounded, so that call site caps its tail to
+# FULL_TAIL_MAX_LEN before it reaches deny_json()'s argv.
 IFS= read -r -d '' _COMMIT_ANALYSIS_PY <<'PYEOF' || true
 import fnmatch
 import json
@@ -1472,8 +1471,12 @@ PYEOF
         if [ -f ".harness/init.sh" ]; then
             echo "commit-gate: staged features.json flips $FLIPPED to passing; running full_test..." >&2
             FULL_OUTPUT=$(bash .harness/init.sh full_test 2>&1) || {
+                # tail -15 bounds the line count but not the character count; an
+                # oversized tail on deny_json's argv would fail the exec (ARG_MAX)
+                # and silently convert this DENY into an allow (rc=0, no output).
+                FULL_TAIL_MAX_LEN=2048
                 FULL_TAIL=$(printf '%s\n' "$FULL_OUTPUT" | tail -15)
-                deny_json "passing-flip-full-test-failed: this commit flips $FLIPPED to 'passing' but the full test suite fails. Fix the failures or keep the feature in-progress. Full test output (last 15 lines): $FULL_TAIL"
+                deny_json "passing-flip-full-test-failed: this commit flips $FLIPPED to 'passing' but the full test suite fails. Fix the failures or keep the feature in-progress. Full test output (last 15 lines): ${FULL_TAIL:0:$FULL_TAIL_MAX_LEN}"
             }
         else
             echo "commit-gate: staged features.json flips $FLIPPED to passing, but .harness/init.sh is" \

--- a/.claude/hooks/enforce-scope.sh
+++ b/.claude/hooks/enforce-scope.sh
@@ -190,8 +190,19 @@ deny_json() {
     # silently converting a scope-violation DENIAL into an ALLOW (confirmed
     # live: a 1.2MB Write to a lead-owned file that correctly denies under
     # ARG_MAX returns rc=0 with an empty stdout once the payload is large
-    # enough). Only small, bounded values (the reason and finding strings)
-    # stay on argv.
+    # enough). "finding" is a small, fixed, per-call-site literal, genuinely
+    # bounded -- but "reason" is NOT: a second adversarial review (2026-08-05,
+    # F096) found this comment overclaiming boundedness for "reason" too. The
+    # Bash-command scope-violation reasons below quote the offending write
+    # target or raw segment verbatim (see _check_segment()/main()'s own
+    # comments), both derived from $COMMAND, so an attacker-sized $COMMAND
+    # can make "reason" itself attacker-sized -- reaching the exact same
+    # ARG_MAX exec failure this comment already describes for the payload,
+    # one call site later. The Bash-command call site below now caps its
+    # reason to DENY_REASON_MAX_LEN characters before calling this function
+    # (F096) so "reason" stays genuinely bounded by the time it lands here;
+    # the fixed literal reasons the other call sites pass (e.g. "state file
+    # is lead-owned...") were always bounded regardless.
     #
     # The python source is read into a variable via a TOP-LEVEL heredoc
     # (F094 round 2), NOT `python3 -c "$(cat <<'PYEOF' ...)"` -- see
@@ -449,7 +460,21 @@ if [ -n "$COMMAND" ]; then
         SCOPE_PATTERNS+=("$pattern")
     done < "$SCOPE_FILE"
 
-    DENY_REASON=$(python3 - "$COMMAND" "$PROJECT_ROOT" "${SCOPE_PATTERNS[@]}" <<'PYEOF'
+    # F096 (second adversarial review, 2026-08-05): $COMMAND used to be
+    # passed to this analysis python3 process via argv (`python3 -
+    # "$COMMAND" ...`, reading its own script from the same stdin the
+    # heredoc below fed it), the same ARG_MAX-exec-failure class F088-F093
+    # fixed for deny_json()'s payload -- an extremely large Bash command
+    # (over ~1MB on macOS, as low as 128KB per-argument on Linux) failed
+    # this exec silently, DENY_REASON came back empty, and the caller below
+    # (`if [ -n "$DENY_REASON" ]`) then fell through to an unintended allow,
+    # one call site earlier in the exact same chain deny_json() already
+    # guards. Fixed the same way (F094/F089 round 2's own established
+    # pattern): the python source is read into a variable via a heredoc
+    # FIRST, then invoked with `-c`, freeing stdin to carry $COMMAND itself
+    # -- unbounded in size, unlike $PROJECT_ROOT/the scope patterns, which
+    # stay on argv since neither grows with attacker input.
+    IFS= read -r -d '' _SCOPE_ANALYSIS_PY <<'PYEOF' || true
 import os
 import re
 import sys
@@ -1921,9 +1946,11 @@ def normalize(path, project_root):
 
 
 def main():
-    command = sys.argv[1]
-    project_root = sys.argv[2]
-    patterns = sys.argv[3:]
+    # F096: read from stdin, not argv[1] -- see the heredoc-assembly comment
+    # above this script's own invocation for why.
+    command = sys.stdin.read()
+    project_root = sys.argv[1]
+    patterns = sys.argv[2:]
     for segment in segments_of(command):
         try:
             if _check_segment(segment, project_root, patterns):
@@ -2028,10 +2055,20 @@ def _check_segment(segment, project_root, patterns):
 
 main()
 PYEOF
-)
+    DENY_REASON=$(printf '%s' "$COMMAND" | python3 -c "$_SCOPE_ANALYSIS_PY" "$PROJECT_ROOT" "${SCOPE_PATTERNS[@]}")
 
     if [ -n "$DENY_REASON" ]; then
-        deny_json "$DENY_REASON" "scope-violation:out-of-scope-command"
+        # F096: cap DENY_REASON before it reaches deny_json(), whose own
+        # "reason" argument stays on argv (see that function's comment) --
+        # the scope-violation messages above quote the offending write
+        # target or raw segment verbatim, both derived from $COMMAND, so an
+        # attacker-sized $COMMAND can still make DENY_REASON itself
+        # attacker-sized even after the stdin fix above (a huge write
+        # target/segment, not a huge command as a whole). 2048 matches
+        # commit-gate.sh.template's own SECRET_SCAN_MAX_LEN precedent for a
+        # bounded-cap value; well under either OS's ARG_MAX floor.
+        DENY_REASON_MAX_LEN=2048
+        deny_json "${DENY_REASON:0:$DENY_REASON_MAX_LEN}" "scope-violation:out-of-scope-command"
     fi
 fi
 

--- a/.harness/HARNESS_BACKLOG.md
+++ b/.harness/HARNESS_BACKLOG.md
@@ -1,0 +1,13 @@
+# Harness Backlog
+
+Candidates the Phase 5.5 promotion and ablation passes have surfaced. Not
+auto-applied: a human or a dedicated session executes a row, then marks it
+promoted. Cross-project pattern aggregation is a future extension, not done
+here -- this file is per-project.
+
+| date | observation | proposed owner | evidence pointer | score | status | last_seen |
+|---|---|---|---|---|---|---|
+| 2026-08-09 | Recurring bug classes get fixed one call site at a time (ARG_MAX argv class needed 3 fixes across 3 sessions); no rule tells the implementer to sweep the class | rule file edit (tdd.md or debugging.md: "when fixing an instance of a recurring class, grep for the class") | Meta-Session 2026-08-09 (batch), F096 + review round | 1 | candidate | 2026-08-09 |
+| 2026-08-09 | Feature scope arrays omit test/run-tests.sh even though every feature writes tests there; enforce-scope would deny a teammate its own TDD writes | skill (harness-issue-prep/harness-init: default the project's test-runner path into scope for testable features) | review finding "F094/F095/F096 edited test/run-tests.sh outside their recorded scope" | 1 | candidate | 2026-08-09 |
+| 2026-08-09 | Multi-dimension review workflows verify duplicate findings separately (~2x verify cost); dedup barrier before verify fan-out is the fix | not-yet (workflow authoring pattern, no durable owner file yet) | Meta-Session 2026-08-09 (batch), review workflow wf_62aae2ac-e3b | 1 | candidate | 2026-08-09 |
+| 2026-08-09 | Ablation: commit-gate compound-stage-and-commit denial fired twice on the lead's own merge/suite one-liners (git commit && bash suite) -- both times a false positive on a non-staging command, repaired by splitting; matcher may be too broad | revise (narrow the compound detection to commands that actually stage) | this session's merge phase, two denials | 1 | candidate | 2026-08-09 |

--- a/.harness/claude-progress.txt
+++ b/.harness/claude-progress.txt
@@ -1082,3 +1082,19 @@ Session 2026-08-08 (F100-F104, v5.4.0 release):
 - Next: release v5.5.0 (PR + review + merge + tag) is in flight this
   session; after that, no pending features remain in features.json.
 - Blockers: none.
+
+## Session 2026-08-09 (dynamic-workflow batch: F087, F094-F098, F107, F108 -> v5.6.0)
+- Feature: all 8 remaining pending features, implemented by 6 parallel
+  worktree agents (one Workflow call), merged sequentially, then a
+  3-reviewer + adversarial-verify workflow (16 confirmed findings, all
+  fixed in one review-round commit).
+- Status: complete; suite 2059/2059; v5.6.0 bumped with CHANGELOG entry.
+- Decisions: F087's prep.stamp left unconfigured (Ovidiu's 2026-08-04
+  deferral stands); F098 needed no source change (consolidation had
+  already landed in 6f85267 -- behavioral spawn-count test added);
+  F094's spec-mandated rec.x/rec.y turned out to be dead state and was
+  removed in review (spec/cleanup conflict disclosed in features.json).
+  Details in context_summary.md Meta-Session 2026-08-09 (batch).
+- Next: PR from eovidiu/remaining-8, review, merge, tag v5.6.0. After
+  that ZERO pending features remain -- new work needs fresh scoping.
+- Blockers: none.

--- a/.harness/context_summary.md
+++ b/.harness/context_summary.md
@@ -4,6 +4,7 @@ Persistent record of architectural decisions, discovered patterns, gotchas, and 
 This file is referenced in CLAUDE.md and loaded every session.
 
 ## Active Context
+- **v5.6.0 released 2026-08-09 (F087, F094-F098, F107, F108): the ENTIRE remaining backlog cleared in one dynamic-workflow batch.** Six worktree-isolated implementer agents in parallel (one Workflow call), lead merged their branches sequentially into eovidiu/remaining-8 with union conflict resolution on test/run-tests.sh, then a 3-reviewer + adversarial-verify workflow over the combined diff found 16 confirmed findings (all fixed in one review-round commit): the standouts were commit-gate's unbounded $FULL_TAIL converting a passing-flip DENY into a silent ALLOW (live-reproduced), F107's null-description crash suppressing the exit-2 nudge, and F097's truncation cutting the very rule pointers it protects. F098 needed no source change (commit 6f85267 had already landed the consolidation; a behavioral spawn-count test now pins it). F087's prep.stamp config remains deliberately unconfigured (Ovidiu's 2026-08-04 deferral stands). Suite 2059/2059. ZERO pending features remain in features.json -- new work needs fresh scoping. portage-curator still needs `/plugin` update + `/harness-doctor --fix` in its own session.
 - **v5.5.0 released 2026-08-09 (F085, F105, F106): review follow-through.** Exit-3 skip protocol for focused_test (a skip is never a green), not-run baseline keys dropped from last_gate.json (reached-and-unconfigured only; ordering skips preserve), orientation scope field capped. F086 was found already passing (stale handoff). NO pending features remain in features.json -- per the standing guidance below, new work needs fresh scoping, not an assumed queue. portage-curator still needs `/plugin` update + `/harness-doctor --fix` in its own session.
 - **v5.4.0 released 2026-08-08 (F100-F104): quality-gate redesign.** TaskCompleted now runs smoke + the feature's own focused test (never full_test); full_test is enforced by the commit gate when a staged features.json flips a status to passing; correction_cycles counts only green-to-red transitions against a .harness/last_gate.json baseline; harness-init SKILL.md carries the "full_test must be satisfiable mid-project, aggregates as ratchets" authoring rule. Motivated by a portage-curator field report (v3.5.0 hooks) -- that project still needs `/plugin` update + `/harness-doctor --fix` in its own session to pick this up. F085/F086 remain the queued pending features.
 - The entire locally-discovered bug/design-gap chain that started with F023 is now CLOSED: F023-F062 (40 features, no Linear issue) all shipped. Full per-feature detail lives in features.json's own per-feature `notes` fields and the per-feature Meta-Session entries below; `claude-progress.txt`'s consolidated session entries cover the wall-clock history.
@@ -123,6 +124,13 @@ This file is referenced in CLAUDE.md and loaded every session.
 - Capability-block memories decay: before telling the user something is blocked
   (permissions, tooling), re-verify against current .claude/settings.json and repo
   state — a one-line grep beats a wasted round-trip.
+- When a bug class has recurred (same root cause, different call site), sweep for the
+  class across the codebase before closing the feature -- the ARG_MAX argv class
+  needed three separate fixes across three sessions because each fix stopped at the
+  cited site. (backlog)
+- Dedup findings across review dimensions BEFORE the adversarial-verify fan-out:
+  three reviewers independently re-report the same defect, and verifying each copy
+  separately multiplies verify cost ~2x for zero extra signal. (backlog)
 - Small independent-edit batches (docs, hook guards, rule text) fit single-session
   mode regardless of file count; reserve teams for genuinely parallel feature work.
 - Ground-truth a reviewer's OWN restated claim too, not just the original code under
@@ -1757,3 +1765,32 @@ session-end.sh at the next SessionStart.
   implementation; one vv-harness:reviewer pass planned at PR time
   (pattern from v5.4.0, where round 1 found three real MEDs).
 - Test growth: 1949 -> 1979 assertions across three features.
+
+## Meta-Session 2026-08-09 (batch: F087, F094-F098, F107, F108 -> v5.6.0)
+- Scope accuracy: F094/F095/F096 recorded scope arrays WITHOUT test/run-tests.sh
+  even though every feature's tests land there -- a reassigned teammate under
+  enforce-scope would have been denied writing its own regression tests (review
+  confirmed live). Fixed in features.json; future scoping should include the test
+  runner path by default for any feature with testable behavior.
+- Model calibration: six Sonnet implementers, zero correction cycles at implement
+  time; all 16 confirmed defects were caught by the Opus reviewer + adversarial
+  verify round, and several (FULL_TAIL allow, null-description fail-open) were in
+  the implementers' *own* new guard code. Pattern holds: implementers are cheap
+  and reliable for scoped TDD work, the review round is where quality is bought.
+- Discovery lineage: the review round found a live silent-allow (FULL_TAIL) one
+  call site beyond F096's spec -- the third instance of the ARG_MAX class. When a
+  bug class recurs, grep for the CLASS (all argv interpolation sites into
+  deny_json), don't just fix the cited site.
+- Approach patterns: (1) union-merge of append-only test-section conflicts (strip
+  markers, keep both sides) worked 3/3 times with zero manual repair beyond a
+  separator line -- viable default for parallel-implementer batches sharing one
+  test file. (2) Leftover agent worktrees under .claude/worktrees/ made repo-wide
+  *.md-count assertions fail (7 copies of every file); remove worktrees before
+  running the suite from the main checkout. (3) An 11-agent verify fan-out hit the
+  session token limit mid-run; the workflow degraded gracefully (findings kept,
+  verdicts missing) and most unverified findings duplicated confirmed ones --
+  dedup BEFORE verify would have halved the verify fan-out (barrier + dedup is
+  justified there).
+- Plan approval: none used (standing "work the remaining items" instruction);
+  self-serve resolution disclosed per-feature in features.json notes.
+- Test growth: 1979 -> 2059 assertions across eight features + one review round.

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -2453,7 +2453,7 @@
       "id": "F087",
       "description": "The readiness-stamp HMAC (schemas/readiness-stamp.md's mint/consumer recipe, implemented in skills/harness-issue-prep/SKILL.md Step 7) has no round-trip test anywhere in this repo. Re-verifying OVI-45's original finding on 2026-08-04 confirmed: `.harness/harness.json` has no `prep` key (harness-issue-prep runs in local-only mode on this repo today, so Step 7 never fires), and no file under `.harness/`, `MAINTENANCE_LOG.md`, or `docs/` contains the string `vv-harness-readiness-stamp` -- the mint has never actually minted a stamp here. Add a `test/run-tests.sh` fixture that exercises the full recipe headlessly (the `VV_HARNESS_STAMP_KEY` env-var key source from the documented 3-source resolution chain -- no macOS Keychain needed): compute `hmac(spec_hash|base_sha|lane|repo)` per the documented recipe, confirm it verifies, and confirm a tampered field (wrong spec_hash, wrong base_sha) fails verification. This closes the one gap the mint-side implementation doesn't already cover on its own -- a regression in the HMAC logic would otherwise go undetected until an unattended runner started depending on it.",
       "priority": 88,
-      "status": "pending",
+      "status": "passing",
       "scope": [
         "skills/harness-issue-prep/SKILL.md",
         "schemas/readiness-stamp.md",
@@ -2461,12 +2461,14 @@
       ],
       "depends_on": [],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
+      "test_file": "test/run-tests.sh",
+      "coverage": "Test-only feature. 5 assertions green on first run (mint-side implementation was already correct); tamper negatives proven non-vacuous via a throwaway sabotaged copy flipping them to FAIL. Review round 1: the section duplicated much of the pre-existing F012 stamp block (whose coverage the section's original comment wrongly denied existed) -- comment corrected to position this as supplementary (env-var-only key source + base_sha tamper, which F012 lacks), and added what self-comparison could not catch: an independent oracle recomputing schemas/readiness-stamp.md's documented recipe, plus lane, repo, and wrong-key tamper negatives.",
       "notes": "Deliberately deferred, not urgent -- Ovidiu's call (2026-08-04): hold until closer to actually building the external unattended runner that would consume these stamps, since nothing configures or exercises stamping on this repo today. When picked up, also worth configuring `prep.stamp` in `.harness/harness.json` (currently absent, so Step 7 is a no-op regardless of this test) as part of the same pass, and checking that whatever runner gets built actually implements all six of schemas/readiness-stamp.md's \"Consumer verification rules\", not just the marker line.",
       "correction_cycles": 0,
       "scope_expansions": [],
-      "approaches_tried": [],
+      "approaches_tried": [
+        "Extracts the REAL Step 7 snippet from SKILL.md (F012's extraction pattern), not a re-implementation. prep.stamp in .harness/harness.json deliberately NOT configured -- Ovidiu's 2026-08-04 deferral note stands; only the test gap is closed."
+      ],
       "failure_reason": null,
       "discovered_via": "OVI-45 (comparative-analysis re-verification during this session, 2026-08-04): original analysis flagged spec-gate signing as macOS-Keychain-only; re-checking against current code found the 3-source key-resolution chain (Keychain, key-file, env var) already resolves that, but surfaced a different, still-real gap -- zero test coverage and zero live consumers on this repo.",
       "spec": null
@@ -2671,20 +2673,23 @@
       "id": "F094",
       "description": "Dashboard: positionRing() writes directly to style.transform while an animejs animation may be mid-flight on the same node (pulse() at 280ms, layoutSpokes() on every node create/remove), and anime.js v3 rebuilds the whole transform string from its own internal snapshot on every animation frame, silently clobbering any external write. Found by a second adversarial review of the F088-F093 dashboard chain (2026-08-05): confirmed in headless Chrome that a node mid-pulse when another agent spawns (triggering layoutSpokes()) ends up stuck at its pre-layout ring position until the next full layout pass. Cosmetic only (nodes self-correct on the next layout event), not a data-correctness or security issue -- deferred rather than blocking the F088-F093 merge on the reviewer's own explicit recommendation. Fix: take positioning off `transform` entirely (the same way centering was already moved off it during the first review's fix round) -- store x/y on the node record and set style.left/style.top directly via calc(), leaving `transform` owned exclusively by anime.js for scale/opacity.",
       "priority": 94,
-      "status": "pending",
+      "status": "passing",
       "scope": [
-        "hooks/dashboard/index.html"
+        "hooks/dashboard/index.html",
+        "test/run-tests.sh"
       ],
       "depends_on": [
         "F091"
       ],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
+      "test_file": "test/run-tests.sh",
+      "coverage": "TDD: structural assertions in run-tests.sh confirmed red against pre-fix source (worktree agent), green after. Ring position moved off style.transform onto style.left/top via calc(); transform is exclusively anime.js-owned. Review round 1 removed the write-only rec.x/rec.y record state (and its two pinning assertions) the spec's own wording had induced -- spec/cleanup conflict resolved in favor of the no-unused-state rule. Manual QA binding stands (no browser harness in the runner).",
       "notes": "Deferred, not urgent -- confirmed via headless Chrome reproduction during the second adversarial review of F088-F093, but self-corrects on the next layout pass and has no security or correctness impact beyond a transient visual glitch.",
       "correction_cycles": 0,
       "scope_expansions": [],
-      "approaches_tried": [],
+      "approaches_tried": [
+        "Implemented in parallel worktree batch (workflow wf_dcbc1636-cef) with F095; two pre-existing F091 assertions legitimately updated (single-arg gateBadgeKind, literal badge-gate-block class) rather than left stale."
+      ],
       "failure_reason": null,
       "discovered_via": "Second adversarial review of F088-F093 (2026-08-05), Finding 4",
       "spec": null
@@ -2693,20 +2698,23 @@
       "id": "F095",
       "description": "Dashboard: gate badges are keyed on verdict only (gate-<verdict>), not on which specific gate produced it, so when multiple gate scripts (enforce-scope, commit-gate, check-remaining-tasks, verify-task-quality) log the same verdict in one session, they share one DOM badge element and each new event's `title` (payload.gate + ': ' + payload.finding, the only place the finding class is shown) silently overwrites the previous gate's. Found by a second adversarial review of the F088-F093 dashboard chain (2026-08-05): since enforce-scope now logs skipped/allow on every tool call and commit-gate logs allow on every non-commit Bash call, the overwrite is near-continuous in practice, so the badge tooltip mostly reflects whichever gate happened to fire last rather than a specific, meaningful finding. Deferred rather than blocking the F088-F093 merge on the reviewer's own explicit recommendation -- the block-is-visible-at-all fix from the first review round still holds, this is about attribution precision within that. Fix: key the badge on both gate and verdict (`gate-<sanitized-gate-name>-<verdict>`) instead of verdict alone, adjusting the corresponding CSS attribute selector.",
       "priority": 95,
-      "status": "pending",
+      "status": "passing",
       "scope": [
-        "hooks/dashboard/index.html"
+        "hooks/dashboard/index.html",
+        "test/run-tests.sh"
       ],
       "depends_on": [
         "F091"
       ],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
+      "test_file": "test/run-tests.sh",
+      "coverage": "TDD: structural assertions confirmed red pre-fix, green post. gateBadgeKind(gate, verdict) now keys badges per gate+verdict (shared sanitizeClassFragment helper); CSS moved to [class*=][class$=] suffix selectors so verdict colors work for any gate name. Manual QA binding stands.",
       "notes": "Deferred, not urgent -- cosmetic attribution-precision issue, not a security or correctness bug; the more severe badge-overwrite bug (a block being erased by the next allow) was already fixed in F088-F093's own merge.",
       "correction_cycles": 0,
       "scope_expansions": [],
-      "approaches_tried": [],
+      "approaches_tried": [
+        "Same worktree batch as F094; committed separately, each commit independently suite-green."
+      ],
       "failure_reason": null,
       "discovered_via": "Second adversarial review of F088-F093 (2026-08-05), Finding 6",
       "spec": null
@@ -2715,21 +2723,24 @@
       "id": "F096",
       "description": "enforce-scope.sh's DENY_REASON and the Bash $COMMAND it embeds are still passed via argv to the analysis python3 process in one call site each (not the deny_json() logging call, which was fixed for the ARG_MAX bypass during F088-F093's own merge) -- so an extremely large Bash command (over the OS's ARG_MAX, ~1MB on macOS, as low as 128KB per-argument on Linux) can still fail the analysis step itself and fall through to an unintended allow, via the same root-cause class as the critical bug F088-F093 fixed, just one call site earlier in the chain. Found by a second adversarial review (2026-08-05): confirmed this specific residual case is PRE-EXISTING on main (not a regression introduced by F088-F093), but F089's new deny_json() header comment overclaims that 'only small, bounded values stay on argv' when the reason string it receives is not actually bounded. Deferred rather than blocking the F088-F093 merge on the reviewer's own explicit recommendation, since it predates this feature chain and is a pre-existing gap, not a new one. Fix: feed $COMMAND to the upstream analysis python via stdin as well (mirroring the fix already applied to deny_json() itself), and/or cap DENY_REASON's length before it reaches deny_json(); at minimum, correct the overclaiming comment to disclose the residual instead of asserting full boundedness.",
       "priority": 96,
-      "status": "pending",
+      "status": "passing",
       "scope": [
         ".claude/hooks/enforce-scope.sh",
         ".claude/hooks/commit-gate.sh",
         "skills/harness-init/enforce-scope.sh.template",
-        "skills/harness-init/commit-gate.sh.template"
+        "skills/harness-init/commit-gate.sh.template",
+        "test/run-tests.sh"
       ],
       "depends_on": [],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
+      "test_file": "test/run-tests.sh",
+      "coverage": "TDD: 6 assertions (oversized out-of-scope write, oversized compound commit) confirmed red with the fix stashed ('Argument list too long' visible), green restored. $COMMAND now rides stdin at the analysis call sites in both hooks; DENY_REASON capped at 2048 in enforce-scope (commit-gate's python reasons traced as bounded constants). Review round 1 found and fixed the residual the comment overclaimed away: commit-gate's shell-level $FULL_TAIL deny reason was unbounded on argv -- live-reproduced silent ALLOW of a red-suite passing flip; now capped (FULL_TAIL_MAX_LEN=2048) with a regression test.",
       "notes": "Pre-existing on main, not a regression from F088-F093 -- deferred per the reviewing agent's own explicit recommendation. The critical, reachable-in-practice instance of this bug class (in deny_json() itself) was fixed as part of F088-F093's merge; this is the residual, harder-to-reach upstream call site.",
       "correction_cycles": 0,
       "scope_expansions": [],
-      "approaches_tried": [],
+      "approaches_tried": [
+        "Live ARG_MAX repro (2MB command) before fixing; templates and live copies kept byte-identical (F047 check covers)."
+      ],
       "failure_reason": null,
       "discovered_via": "Second adversarial review of F088-F093 (2026-08-05), Finding 3",
       "spec": null
@@ -2738,19 +2749,21 @@
       "id": "F097",
       "description": "hooks/session-start.sh has no mechanism that measures or enforces its actual total orientation output against the platform's 10,000-char cap -- only four independent, hand-tuned local budgets (three sections capped via print_budgeted_block at 2600 chars each, one description field capped separately at 200 chars) plus an unbounded rule-pointer block whose own comment admits it varies 1800-2900 chars depending on the installed CLAUDE_PLUGIN_ROOT path length and which optional WARNING blocks fire. Found by a 4-angle /simplify altitude review (2026-08-06): the git history shows this was chased reactively across three commits (2000 -> broke on real content -> recalibrated to 2600 with an arithmetic margin comment -> a later review found the margin isn't a fixed number at all, softened to a 'judgment call'). Repeated recalibration of a magic constant is the signal that the underlying problem (no measured total) was never actually solved. Fix: buffer the orientation output (or count characters as it's built) and truncate/report against the ACTUAL accumulated length at the end, as a final safety net IN ADDITION TO (not instead of) the existing per-section budgets kept for readability/prioritization -- converts 'we hope the sum of hand-tuned constants stays under 10,000 for every CLAUDE_PLUGIN_ROOT path length' into a mechanically guaranteed invariant, removing the need for a fourth recalibration commit next time install-path length or block count changes. Deliberately NOT attempted as part of the /simplify pass that discovered it -- flagged by two independent reviewers as a larger structural change than the mechanical dedup fixes done in that pass.",
       "priority": 97,
-      "status": "pending",
+      "status": "passing",
       "scope": [
         "hooks/session-start.sh",
         "test/run-tests.sh"
       ],
       "depends_on": [],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
+      "test_file": "test/run-tests.sh",
+      "coverage": "TDD: overflow fixture (3x5000-char blocks + 1500-char plugin root) confirmed 18241-char output red, under-10k green; no-false-positive fixture. Review round 1: truncation was cutting the buffer tail -- exactly the rule pointers and /harness-continue line -- so the footer is now built separately and survives whenever it fits; body cap clamped >= 0 and a final hard cap holds the 10k invariant even for pathological roots. New footer-survival fixture (800-char root).",
       "notes": "Deferred, not urgent -- this is an improvement to an already-working safety margin, not a live bug. The existing per-section budgets have held up in practice (no known real-world overflow incident). Additive, not a replacement, so it can land independently whenever picked up.",
       "correction_cycles": 0,
       "scope_expansions": [],
-      "approaches_tried": [],
+      "approaches_tried": [
+        "ORIENTATION_CHAR_CAP=9800 (200-char margin); additive to per-section budgets, none touched."
+      ],
       "failure_reason": null,
       "discovered_via": "4-angle /simplify altitude review of hooks/session-start.sh (2026-08-06)",
       "spec": null
@@ -2759,19 +2772,21 @@
       "id": "F098",
       "description": "hooks/session-start.sh independently loads and json.load's .harness/features.json in five separate python3 subprocesses scattered through the file (passing/total count, next-claimable selection, spec-drift check, scope-enforcement check, test_file-existence check) -- each pays interpreter startup plus a fresh parse of a file whose own comments note can carry >13,000-char descriptions across many features. Found by a 4-angle /simplify review (2026-08-06, efficiency and simplification angles both flagged this independently); two of the five call sites (passing/total count, next-claimable) were already consolidated toward harness_state.py delegation in the same review pass (see F088/notes and the session-start.sh commit history around 2026-08-06), but the remaining three (spec-drift, scope-enforcement, test_file-existence) still each spawn their own process. Fix: one python3 script that loads features.json once and runs all remaining checks against the in-memory feature list, printing each block conditionally -- roughly halves the remaining python3 spawn count on this hot path (every session start, every /compact). Deliberately NOT attempted as part of the /simplify pass that discovered it -- both reviewers who found it explicitly called it 'a larger structural change... worth considering' rather than a concrete line-level fix, and the individual consolidations already applied capture most of the measured benefit (see the benchmark in this session's own conversation: ~45% reduction in per-call wall-clock time from a similar single-spawn consolidation elsewhere in this chain).",
       "priority": 98,
-      "status": "pending",
+      "status": "passing",
       "scope": [
         "hooks/session-start.sh",
         "test/run-tests.sh"
       ],
       "depends_on": [],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
+      "test_file": "test/run-tests.sh",
+      "coverage": "No source change needed: commit 6f85267 (already on main) had consolidated all three named checks (spec-drift, scope-enforcement, test_file-existence) into one python3 heredoc -- re-measured 0 of 3 remaining before touching anything. Added a behavioral regression test: a PATH-shimmed fake python3 logs every invocation and asserts all three checks' distinguishing fragments land in exactly ONE spawn, so a future re-split is caught empirically, not by source grep.",
       "notes": "Deferred, not urgent -- real but lower-value than F097; the individually-fixed spawns (this same review pass) already capture most of the win. A future session picking this up should re-measure the actual remaining spawn count first, since it may have already shrunk further from other work.",
       "correction_cycles": 0,
       "scope_expansions": [],
-      "approaches_tried": [],
+      "approaches_tried": [
+        "Re-measure before implementing (per lead instruction) -- avoided duplicating an already-landed consolidation."
+      ],
       "failure_reason": null,
       "discovered_via": "4-angle /simplify efficiency+simplification review of hooks/session-start.sh (2026-08-06)",
       "spec": null
@@ -2975,7 +2990,7 @@
       "id": "F107",
       "description": "check-remaining-tasks.sh.template's reassignment message ('Next: <id>: <description> (priority N) [scope: ...]', emitted on stderr at exit 2 straight into the blocked agent's context) has NO length cap on either description or scope -- the same unbounded-field class F071 (description) and F085 (scope) closed for session-start.sh's orientation, missed here because F085's own spec named only session-start.sh. Apply both caps with the same truncate-and-point markers, in the template and the synced .claude/hooks copy.",
       "priority": 107,
-      "status": "pending",
+      "status": "passing",
       "scope": [
         "skills/harness-init/check-remaining-tasks.sh.template",
         ".claude/hooks/check-remaining-tasks.sh",
@@ -2984,11 +2999,13 @@
       "depends_on": [],
       "assigned_to": null,
       "test_file": "test/run-tests.sh",
-      "coverage": null,
+      "coverage": "TDD: 9 assertions (13222-char description, 12-path scope, empty-scope fallback) red-then-green against the template via install_hooks/run_hook. Reused F071/F085's exact cap values (DESC_LIMIT=200, SCOPE_LIMIT=150) and marker wording. Review round 1: an explicitly-null description crashed the formatter and set -euo pipefail suppressed the exit-2 nudge entirely (silent fail-open, a regression this feature introduced) -- formatter now null-safe and try/except-guarded, with a null-description fixture asserting exit 2 survives.",
       "notes": null,
       "correction_cycles": 0,
       "scope_expansions": [],
-      "approaches_tried": [],
+      "approaches_tried": [
+        "Template and .claude/hooks copy kept identical; F047 sync check covers the pair."
+      ],
       "failure_reason": null,
       "discovered_via": "PR #156 adversarial review (review-pr156 reviewer agent), 2026-08-09.",
       "spec": null,
@@ -2998,7 +3015,7 @@
       "id": "F108",
       "description": ".harness/init.sh is a per-project copy made at init time, so v5.5.0's focused_test exit-code contract (exit 3 reserved for skips; runner exit-3 remapped; missing-file guard) does not reach existing projects: a project that adopted focused_test under v5.4.0 keeps its old exit-0 skip arms and the pre-F106 fake-green persists silently. harness-doctor should detect a focused_test-supporting init.sh that lacks the skip contract (e.g. no 'skipped (exit 3)' marker / no run_focused remap) and report it as upgrade-available with the hand-apply repair, mirroring how it reports other stale artifacts. INSTALL.md's --fix steps should mention init.sh is never auto-refreshed (it is the one genuinely decision-shaped per-project file).",
       "priority": 108,
-      "status": "pending",
+      "status": "passing",
       "scope": [
         "skills/harness-doctor/doctor.py",
         "skills/harness-doctor/SKILL.md",
@@ -3008,11 +3025,13 @@
       "depends_on": [],
       "assigned_to": null,
       "test_file": "test/run-tests.sh",
-      "coverage": null,
+      "coverage": "TDD: 5 assertions confirmed red against pre-change doctor.py (git stash), green restored. check_focused_test_skip_contract is report-only (no fix_id; --fix leaves it, pinned by a fixture). Review round 1 hardened it: markers now checked on non-comment lines only, and a leftover pre-F106 'treating as pass' arm is positively detected -- so a partially hand-applied repair or a comment quoting the markers can no longer clear a live fake-green; 4 new fixtures plus a drift guard tying the marker strings to the shipped init.sh.template. SKILL.md check 10 and INSTALL.md updated.",
       "notes": null,
       "correction_cycles": 0,
       "scope_expansions": [],
-      "approaches_tried": [],
+      "approaches_tried": [
+        "Fixtures derived from real git history (78087c5/912bc3c), not synthetic contracts. NOTE: this repo's own .harness/init.sh has no focused_test support at all -- the v5.5.0 contract source is skills/harness-init/init.sh.template (lead's spawn note had this wrong; implementer corrected it)."
+      ],
       "failure_reason": null,
       "discovered_via": "PR #156 adversarial review (review-pr156 reviewer agent), 2026-08-09.",
       "spec": null,

--- a/.harness/mld/2026-08-09-cc88f3b9-bfd7-40cb-be41-c54a79e95581.md
+++ b/.harness/mld/2026-08-09-cc88f3b9-bfd7-40cb-be41-c54a79e95581.md
@@ -1,0 +1,32 @@
+# MLD 2026-08-09 (session cc88f3b9-bfd7-40cb-be41-c54a79e95581)
+
+## Mistakes
+- First Workflow launch failed: the `args` JSON never reached the script (and my
+  payload had stray placeholder strings in the features arrays that would have
+  broken it anyway). Relaunched with the job list embedded in the script body.
+- Told the F108 implementer this repo's own .harness/init.sh carried the v5.5.0
+  contract; it does not (no focused_test support at all -- the contract lives in
+  skills/harness-init/init.sh.template). The agent caught and corrected it.
+- Briefly appended a non-verbatim sentence to F087's spec text in the workflow
+  script while working around JS quoting; caught and reverted before launch.
+- Ran the first post-merge suite with six agent worktrees still under
+  .claude/worktrees/ -- two repo-wide *.md-count assertions failed on the copies.
+
+## Learnings
+- Embedding job data in the workflow script body is more reliable than the args
+  channel for large payloads; args also invites JSON-in-JSON escaping errors.
+- Union-resolving append-only test-section merge conflicts (strip markers, keep
+  both sides, one separator line) worked 3/3 with zero repair.
+- An adversarial-verify fan-out should dedup findings across review dimensions
+  first: ~half the verify agents re-verified duplicates, and the batch hit the
+  session token limit partly because of it.
+- The ARG_MAX argv silent-allow class has now needed three fixes at three call
+  sites across three sessions -- class-sweep on recurrence, not site-fix.
+
+## Desires
+- A journal-level dedup helper for workflow findings (same file+line+claim) so
+  verify fan-outs don't multiply.
+- A way for the lead to see per-agent token burn live during a workflow (the
+  11 verify failures surfaced only in the completion notification).
+- The commit-gate's compound detector narrowed to commands that actually stage;
+  it denied two non-staging `git commit && <suite>` one-liners this session.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 Version history for the VV Claude Code Harness. The current version lives in `.claude-plugin/plugin.json`.
 
+### v5.6.0 (2026-08-09)
+
+Clears the entire remaining feature backlog (F087, F094–F098, F107, F108) in one
+parallel-implementation batch, plus one adversarial-review round over the combined
+diff.
+
+1. **Doctor detects a stale `focused_test` skip contract (F108)** — `harness-doctor`
+   now flags a per-project `init.sh` that supports `focused_test` but predates
+   v5.5.0's exit-3 skip protocol (F106), as upgrade-available with a hand-apply
+   repair; `--fix` never rewrites `init.sh`. The check reads non-comment lines only
+   and positively detects leftover pre-F106 `treating as pass` arms, so a partially
+   hand-applied repair or a marker-quoting comment cannot clear a live fake-green.
+   `INSTALL.md` now states `init.sh` is never auto-refreshed.
+2. **ARG_MAX silent-allow residuals closed (F096)** — `enforce-scope.sh` and
+   `commit-gate.sh` now feed `$COMMAND` to their analysis python via stdin (the
+   remaining call site of the class F088–F093 fixed), cap `DENY_REASON` at 2048
+   chars, and — found by this release's review round — cap the passing-flip deny
+   reason's `full_test` tail, which could previously blow argv and silently convert
+   that DENY into an ALLOW.
+3. **Measured orientation total (F097)** — `session-start.sh` buffers the orientation
+   body and enforces the 10k platform cap against its actual accumulated length
+   (additive to the per-section budgets), with the rule-pointer footer built
+   separately so truncation can never drop it.
+4. **Reassignment message caps (F107)** — `check-remaining-tasks.sh`'s `Next:` line
+   gets the same description/scope truncate-and-point caps as the orientation
+   (F071/F085 class), with a null-safe, guarded formatter so a malformed feature
+   entry degrades instead of suppressing the exit-2 nudge.
+5. **Dashboard fixes (F094, F095)** — ring positioning moved off `transform` (owned
+   exclusively by anime.js now) onto `style.left/top`, and gate badges are keyed
+   per gate+verdict so different gates' findings no longer overwrite one badge.
+6. **Readiness-stamp HMAC round-trip (F087)** — env-var-key round-trip test with an
+   independent schema-recipe oracle and spec_hash/base_sha/lane/repo/key tamper
+   negatives. `prep.stamp` remains deliberately unconfigured on this repo.
+7. **Single-load regression pin (F098)** — a behavioral test proves the session-start
+   checks share one `features.json`-loading python spawn (the consolidation itself
+   had already landed via an earlier perf commit).
+
 ### v5.5.0 (2026-08-09)
 
 Closes out the v5.4.0 review's deferred findings plus one older orientation bug.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -181,6 +181,15 @@ initialized under v3, run without the plugin's install mechanism):
    field (F068) to the currently installed plugin's version, so the next `harness-doctor`
    run compares against the version you're actually on rather than a stale one.
 
+`.harness/init.sh` is never auto-refreshed by `--fix` — it's the one genuinely
+decision-shaped per-project file (it mixes in project-specific stack logic), so
+upgrades to it are always hand-applied. In particular, a project that adopted the
+`focused_test` target before v5.5.0 (F106) may still carry the pre-F106 exit-0 skip
+arms instead of the exit-3 skip contract (a `skipped (exit 3)` marker, a `run_focused`
+exit-3 remap); `harness-doctor` reports the gap, but closing it means comparing
+`.harness/init.sh`'s `focused_test` block against
+`skills/harness-init/init.sh.template`'s by hand.
+
 ## Personalize your CLAUDE.md
 
 `templates/CLAUDE.md` in this repo is a starting template for your personal

--- a/hooks/dashboard/index.html
+++ b/hooks/dashboard/index.html
@@ -179,17 +179,20 @@
     color: #12141a;
     font-weight: 600;
   }
-  /* Gate verdict badges: keyed by the verdict itself (gateBadgeKind()
-     below), not one shared "gate" kind -- addBadge() reuses an existing
-     element by DOM lookup on its kind string, so a single shared kind let
-     a block verdict's badge be silently overwritten by the very next
-     allow verdict. The attribute selector is the default look for any
-     verdict (matches the old shared amber styling); the block/skipped
-     rules override it for the verdicts that must stay visually distinct,
-     using equal specificity so source order (below) decides. */
+  /* Gate verdict badges: keyed by both the gate AND the verdict
+     (gateBadgeKind() below), not verdict alone -- addBadge() reuses an
+     existing element by DOM lookup on its kind string, so a shared
+     per-verdict kind let two different gate scripts logging the same
+     verdict in one session (e.g. enforce-scope's allow and commit-gate's
+     allow) silently overwrite each other's title/finding. The attribute
+     selector is the default look for any gate/verdict pair (matches the
+     old shared amber styling); the block/skipped rules override it via a
+     suffix selector on the verdict, so they apply regardless of which
+     gate produced it, using equal specificity so source order (below)
+     decides. */
   .badge[class*="badge-gate-"] { background: var(--gate); }
-  .badge.badge-gate-block { background: var(--permission); color: #fff; }
-  .badge.badge-gate-skipped { background: var(--border); color: var(--text); }
+  .badge[class*="badge-gate-"][class$="-block"] { background: var(--permission); color: #fff; }
+  .badge[class*="badge-gate-"][class$="-skipped"] { background: var(--border); color: var(--text); }
   .badge-judge { background: var(--judge); color: #fff; }
   .badge-permission { background: var(--permission); color: #fff; }
 </style>
@@ -397,23 +400,29 @@
 
   var leadNode = { el: leadNodeEl, badgesEl: leadBadgesEl };
 
-  function gateBadgeKind(verdict) {
-    // Each verdict gets its own badge kind ("gate-block", "gate-allow",
-    // "gate-skipped", ...) so addBadge()'s reuse-by-lookup never lets one
-    // verdict's badge silently overwrite a different verdict's -- a block
-    // verdict must stay visible instead of being erased by the next allow.
-    // Sanitized to a safe class-name fragment since verdict is data from a
-    // hook payload, not a fixed enum this page controls.
-    var normalized = String(verdict || "unknown")
+  function sanitizeClassFragment(value) {
+    // Safe class-name fragment for data from a hook payload, not a fixed
+    // enum this page controls.
+    return String(value || "unknown")
       .toLowerCase()
       .replace(/[^a-z0-9_-]/g, "-");
-    return "gate-" + normalized;
+  }
+
+  function gateBadgeKind(gate, verdict) {
+    // Each (gate, verdict) pair gets its own badge kind ("gate-commit-gate-
+    // block", "gate-enforce-scope-allow", ...) so addBadge()'s reuse-by-
+    // lookup never lets one gate's verdict badge silently overwrite a
+    // different gate's -- keying on verdict alone let enforce-scope's
+    // allow/skipped and commit-gate's allow (both logged on nearly every
+    // tool call) repeatedly clobber each other's title/finding even though
+    // they came from different gate scripts.
+    return "gate-" + sanitizeClassFragment(gate) + "-" + sanitizeClassFragment(verdict);
   }
 
   function handleGateEvent(payload, node) {
     // Quality-gate hooks (F089): a gate/verdict/finding-bearing log line.
     var text = "GATE:" + (payload.verdict || "?");
-    var badgeEl = addBadge(node.badgesEl, gateBadgeKind(payload.verdict), text);
+    var badgeEl = addBadge(node.badgesEl, gateBadgeKind(payload.gate, payload.verdict), text);
     badgeEl.title = payload.gate + (payload.finding ? ": " + payload.finding : "");
   }
 

--- a/hooks/dashboard/index.html
+++ b/hooks/dashboard/index.html
@@ -256,11 +256,9 @@
       // animated frame (pulse() at 280ms, or layoutSpokes() firing mid-
       // animation on node create/remove), so a direct style.transform write
       // here would be silently clobbered until the next full layout pass.
-      // x/y are stored on the node record and applied via style.left/top
-      // using calc() off the CSS-declared 50%/50% base, leaving `transform`
-      // owned exclusively by anime.js for scale/opacity.
-      rec.x = x;
-      rec.y = y;
+      // Position is applied via style.left/top using calc() off the
+      // CSS-declared 50%/50% base, leaving `transform` owned exclusively
+      // by anime.js for scale/opacity.
       rec.el.style.left = "calc(50% + " + x + "px)";
       rec.el.style.top = "calc(50% + " + y + "px)";
     }
@@ -338,7 +336,7 @@
 
     spokesEl.appendChild(el);
 
-    rec = { agentType: agentType || null, el: el, labelEl: labelEl, badgesEl: badgesEl, isJudge: false, x: 0, y: 0 };
+    rec = { agentType: agentType || null, el: el, labelEl: labelEl, badgesEl: badgesEl, isJudge: false };
     agents[agentId] = rec;
 
     if (isJudgeType(agentType)) markAsJudge(rec);

--- a/hooks/dashboard/index.html
+++ b/hooks/dashboard/index.html
@@ -248,13 +248,18 @@
       var y = radius * Math.sin(angle);
       var rec = agents[ids[i]];
       if (!rec) continue;
-      // Two distinct-axis functions (translateX/translateY), not a second
-      // bare translate(...) -- anime.js's transform Map is keyed by
-      // function name, so a second "translate" entry would collide with
-      // and silently replace the centering offset (now handled off
-      // `transform` entirely; see .node's `translate` CSS property).
-      rec.el.style.transform =
-        "translateX(" + x + "px) translateY(" + y + "px)";
+      // Ring position is off `transform` entirely -- anime.js v3 rebuilds
+      // the whole transform string from its own internal snapshot on every
+      // animated frame (pulse() at 280ms, or layoutSpokes() firing mid-
+      // animation on node create/remove), so a direct style.transform write
+      // here would be silently clobbered until the next full layout pass.
+      // x/y are stored on the node record and applied via style.left/top
+      // using calc() off the CSS-declared 50%/50% base, leaving `transform`
+      // owned exclusively by anime.js for scale/opacity.
+      rec.x = x;
+      rec.y = y;
+      rec.el.style.left = "calc(50% + " + x + "px)";
+      rec.el.style.top = "calc(50% + " + y + "px)";
     }
   }
 
@@ -330,7 +335,7 @@
 
     spokesEl.appendChild(el);
 
-    rec = { agentType: agentType || null, el: el, labelEl: labelEl, badgesEl: badgesEl, isJudge: false };
+    rec = { agentType: agentType || null, el: el, labelEl: labelEl, badgesEl: badgesEl, isJudge: false, x: 0, y: 0 };
     agents[agentId] = rec;
 
     if (isJudgeType(agentType)) markAsJudge(rec);

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -335,6 +335,14 @@ if [ -n "$MISMATCH" ]; then
 fi
 
 echo ""
+)
+
+# The fixed footer (rule pointers + the /harness-continue line) is built
+# separately so the safety-net truncation below can never cut it: the overflow
+# is always caused by the variable-length body blocks, and cutting the buffer's
+# tail would otherwise drop exactly the rules the session is being told to
+# read (found by adversarial review of this feature's first round).
+FOOTER=$(
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
   echo "Agent Teams protocol: read $CLAUDE_PLUGIN_ROOT/rules/agent-teams-protocol.md" \
     "before spawning teammates."
@@ -349,12 +357,29 @@ fi
 echo "Run /harness-continue for the full interactive flow (mode choice, smoke test, team plan)."
 )
 
+# The body is capped at what the 9800-char total leaves after the footer and a
+# 200-char allowance for the truncation marker line, so body + marker + footer
+# stays under the platform's 10,000-char cap with the footer surviving whenever
+# it can (a pathologically long CLAUDE_PLUGIN_ROOT can make the footer alone
+# approach the cap; the clamp and the final hard cap keep the total invariant
+# even then, at the cost of the footer's tail).
 ORIENTATION_CHAR_CAP=9800
-ORIENTATION_LEN=${#ORIENTATION}
-if [ "$ORIENTATION_LEN" -gt "$ORIENTATION_CHAR_CAP" ]; then
-  printf '%s\n' "${ORIENTATION:0:$ORIENTATION_CHAR_CAP}"
-  echo "... (orientation truncated: $ORIENTATION_LEN chars total, exceeds the ${ORIENTATION_CHAR_CAP}-char safety cap; see .harness/ files directly for full context)"
+BODY_CHAR_CAP=$((ORIENTATION_CHAR_CAP - ${#FOOTER} - 200))
+if [ "$BODY_CHAR_CAP" -lt 0 ]; then
+  BODY_CHAR_CAP=0
+fi
+ORIENTATION_LEN=$(( ${#ORIENTATION} + ${#FOOTER} ))
+if [ "${#ORIENTATION}" -gt "$BODY_CHAR_CAP" ]; then
+  FINAL="${ORIENTATION:0:$BODY_CHAR_CAP}
+... (orientation truncated: $ORIENTATION_LEN chars total, exceeds the ${ORIENTATION_CHAR_CAP}-char safety cap; see .harness/ files directly for full context)
+$FOOTER"
 else
-  printf '%s\n' "$ORIENTATION"
+  FINAL="$ORIENTATION
+$FOOTER"
+fi
+if [ "${#FINAL}" -gt "$ORIENTATION_CHAR_CAP" ]; then
+  printf '%s\n' "${FINAL:0:$ORIENTATION_CHAR_CAP}"
+else
+  printf '%s\n' "$FINAL"
 fi
 exit 0

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -43,6 +43,19 @@ SESSION_ID=${PARSED#*$FIELD_SEP}
 # injection (found by adversarial review of PR #62).
 SESSION_ID=$(printf '%s' "$SESSION_ID" | tr -cd 'A-Za-z0-9._-' | cut -c1-64)
 
+# F097: the per-section budgets below (print_budgeted_block, the description/
+# scope truncation in print_next_claimable_line) each bound one block in
+# isolation, but nothing ever measured their SUM against the platform's
+# 10,000-char cap (line 3) -- three PR #128 commits chased that sum by hand
+# (2000 -> broke on real content -> recalibrated to 2600 -> a later review
+# found even that constant was a judgment call, not a derived bound) and the
+# rule-pointer block's own comment admits its length still varies 1800-2900
+# chars with CLAUDE_PLUGIN_ROOT's install path. Buffering the whole body in
+# this subshell and measuring $ORIENTATION's actual length below turns "we
+# hope the sum of hand-tuned constants stays under 10,000" into a mechanically
+# guaranteed invariant, additive to (not a replacement for) the per-section
+# budgets kept for readability/prioritization.
+ORIENTATION=$(
 if [ "$SOURCE" = "compact" ]; then
   echo "## Compaction recovery"
   echo "Context was just compacted. Re-read the Active Context section of"
@@ -334,4 +347,14 @@ if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
   echo "TDD process: $CLAUDE_PLUGIN_ROOT/rules/tdd.md (read before implementing a feature or bugfix)."
 fi
 echo "Run /harness-continue for the full interactive flow (mode choice, smoke test, team plan)."
+)
+
+ORIENTATION_CHAR_CAP=9800
+ORIENTATION_LEN=${#ORIENTATION}
+if [ "$ORIENTATION_LEN" -gt "$ORIENTATION_CHAR_CAP" ]; then
+  printf '%s\n' "${ORIENTATION:0:$ORIENTATION_CHAR_CAP}"
+  echo "... (orientation truncated: $ORIENTATION_LEN chars total, exceeds the ${ORIENTATION_CHAR_CAP}-char safety cap; see .harness/ files directly for full context)"
+else
+  printf '%s\n' "$ORIENTATION"
+fi
 exit 0

--- a/skills/harness-doctor/SKILL.md
+++ b/skills/harness-doctor/SKILL.md
@@ -97,6 +97,16 @@ and points to `/harness-init` instead of running any checks.
    since `session-start.sh` is invoked directly from `CLAUDE_PLUGIN_ROOT` and is
    never copied per-project. If `.harness/mld/` doesn't exist, or the plugin root
    can't be determined, there is nothing to guard and no finding is produced.
+10. **focused_test skip contract** (F108): `.harness/init.sh` is a per-project copy
+    made at init time, so v5.5.0's focused_test exit-code contract (F106 — exit 3
+    reserved for a skip, a runner's own exit 3 remapped to 1, a missing test file
+    skipped rather than faked green) never reaches a project that adopted
+    `focused_test` before F106 shipped. If `init.sh` mentions `focused_test` outside
+    a comment (the same support-detection heuristic `verify-task-quality.sh` uses)
+    but is missing either the `skipped (exit 3)` marker or the `run_focused` exit-3
+    remap, the doctor reports it as upgrade-available. An `init.sh` with no
+    `focused_test` support at all, or none present, produces no finding — there is
+    nothing to check yet.
 
 ## Finding classification
 
@@ -125,8 +135,11 @@ field; nothing else does.
 Anything it cannot mechanically resolve —
 missing `python3`/`git`, a hard-required hook that was deleted outright, a JSON parse
 error, a `features.json` validation failure, a `context_summary.md` missing a required
-section — is reported unchanged after the fix pass, because that is a judgment call,
-not a copy step.
+section, a stale focused_test skip contract in `.harness/init.sh` (check 10) — is
+reported unchanged after the fix pass, because that is a judgment call, not a copy
+step. `init.sh` in particular is never rewritten by `--fix` at all: it is the one
+genuinely decision-shaped per-project file (it mixes in project-specific stack logic),
+so its finding always carries a hand-apply repair instead of a fix.
 
 **Report-first is the whole point: the doctor never writes anything without explicit
 approval.** Run it plain first, read the findings, and only re-run with `--fix` once

--- a/skills/harness-doctor/SKILL.md
+++ b/skills/harness-doctor/SKILL.md
@@ -103,10 +103,13 @@ and points to `/harness-init` instead of running any checks.
     skipped rather than faked green) never reaches a project that adopted
     `focused_test` before F106 shipped. If `init.sh` mentions `focused_test` outside
     a comment (the same support-detection heuristic `verify-task-quality.sh` uses)
-    but is missing either the `skipped (exit 3)` marker or the `run_focused` exit-3
-    remap, the doctor reports it as upgrade-available. An `init.sh` with no
-    `focused_test` support at all, or none present, produces no finding — there is
-    nothing to check yet.
+    but is missing the `skipped (exit 3)` marker or the `run_focused` exit-3 remap
+    — or still carries a pre-F106 `treating as pass` fake-green arm, which catches a
+    partially hand-applied repair — the doctor reports it as upgrade-available. All
+    of these are checked against non-comment lines only, so a comment quoting the
+    markers (a TODO note, or the finding text pasted as a reminder) neither
+    satisfies nor triggers the check. An `init.sh` with no `focused_test` support
+    at all, or none present, produces no finding — there is nothing to check yet.
 
 ## Finding classification
 

--- a/skills/harness-doctor/doctor.py
+++ b/skills/harness-doctor/doctor.py
@@ -413,12 +413,21 @@ def check_focused_test_skip_contract(project_dir):
     )
     if "focused_test" not in non_comment:
         return []  # doesn't support focused_test at all -- nothing to check
-    if "skipped (exit 3)" in text and "run_focused" in text:
+    # Both tests run against non_comment: a comment quoting the markers (a TODO
+    # note, or the doctor's own finding text pasted as a reminder) must not
+    # satisfy the contract, and the pre-F106 fake-green wording is checked
+    # positively so a partially hand-applied repair (some arms upgraded, some
+    # still 'treating as pass') is still flagged, not cleared by the first
+    # upgraded arm's markers.
+    has_markers = "skipped (exit 3)" in non_comment and "run_focused" in non_comment
+    has_fake_green = "treating as pass" in non_comment
+    if has_markers and not has_fake_green:
         return []
     return [Finding(
         "upgrade available: .harness/init.sh supports focused_test but is missing "
-        "the v5.5.0 exit-3 skip contract (F106) -- no 'skipped (exit 3)' marker "
-        "and/or no run_focused exit-3 remap, so a skip can be reported as a fake green",
+        "the v5.5.0 exit-3 skip contract (F106) -- no 'skipped (exit 3)' marker, "
+        "no run_focused exit-3 remap, and/or a leftover pre-F106 'treating as "
+        "pass' arm, so a skip can be reported as a fake green",
         "hand-apply: compare .harness/init.sh's focused_test block against "
         "skills/harness-init/init.sh.template's and add the missing skip markers "
         "and remap by hand -- init.sh is never auto-refreshed by doctor --fix "

--- a/skills/harness-doctor/doctor.py
+++ b/skills/harness-doctor/doctor.py
@@ -394,6 +394,39 @@ def check_version_drift(project_dir, plugin_root):
     )]
 
 
+def check_focused_test_skip_contract(project_dir):
+    """F108: .harness/init.sh is a per-project copy made at init time, so
+    v5.5.0's focused_test exit-code contract (F106 -- exit 3 reserved for
+    skips, a runner's own exit 3 remapped to 1, missing test files skipped
+    rather than faked green) never reaches a project that adopted
+    focused_test before F106 shipped. That project's init.sh still has the
+    old exit-0 skip arms, and the pre-F106 fake-green persists silently.
+    init.sh is the one genuinely decision-shaped per-project file (it mixes
+    in project-specific stack logic), so this is report-only, same as
+    check_feature_test_files: there is no fixer, only a hand-apply repair."""
+    init_path = os.path.join(project_dir, ".harness", "init.sh")
+    if not os.path.isfile(init_path):
+        return []  # already reported by verify-task-quality's own missing-init.sh gate
+    text = open(init_path).read()
+    non_comment = "\n".join(
+        line for line in text.splitlines() if not line.strip().startswith("#")
+    )
+    if "focused_test" not in non_comment:
+        return []  # doesn't support focused_test at all -- nothing to check
+    if "skipped (exit 3)" in text and "run_focused" in text:
+        return []
+    return [Finding(
+        "upgrade available: .harness/init.sh supports focused_test but is missing "
+        "the v5.5.0 exit-3 skip contract (F106) -- no 'skipped (exit 3)' marker "
+        "and/or no run_focused exit-3 remap, so a skip can be reported as a fake green",
+        "hand-apply: compare .harness/init.sh's focused_test block against "
+        "skills/harness-init/init.sh.template's and add the missing skip markers "
+        "and remap by hand -- init.sh is never auto-refreshed by doctor --fix "
+        "since it carries project-specific stack logic (see INSTALL.md's "
+        "'Upgrading an existing harness project' section)",
+    )]
+
+
 def check_mld_non_injection(project_dir, plugin_root):
     mld_dir = os.path.join(project_dir, ".harness", "mld")
     if not os.path.isdir(mld_dir):
@@ -466,6 +499,7 @@ def run_checks(project_dir, plugin_root):
     findings.extend(check_harness_state_files(project_dir, plugin_root))
     findings.extend(check_feature_test_files(project_dir))
     findings.extend(check_version_drift(project_dir, plugin_root))
+    findings.extend(check_focused_test_skip_contract(project_dir))
     findings.extend(check_mld_non_injection(project_dir, plugin_root))
     findings.extend(check_plugin_root_unset(project_dir, plugin_root))
     return findings

--- a/skills/harness-init/check-remaining-tasks.sh.template
+++ b/skills/harness-init/check-remaining-tasks.sh.template
@@ -141,28 +141,38 @@ NEXT=$(printf '%s' "$RESULT" | python3 -c "
 import json
 import sys
 
+# The whole formatter is guarded: a malformed feature entry (e.g. an explicit
+# null description, which f.get('description', '') passes through as None)
+# must degrade to a minimal nudge, never crash the substitution -- under
+# set -euo pipefail a crash here would suppress the exit-2 block verdict
+# entirely (silent fail-open). Mirrors session-start.sh's own try/except
+# around the identical cap logic.
 data = json.load(sys.stdin)
 f = data['next']
-status_note = ' (retry)' if f.get('status') == 'failed' else ''
-scope_list = f.get('scope') or []
-scope = ', '.join(scope_list) or 'no scope defined'
-# F107: description and scope are the same unbounded-field class F071 and
-# F085 already closed for session-start.sh's orientation -- this line goes
-# straight to stderr, into a blocked agent's context, on exit 2. Same
-# truncate-and-point caps and marker wording, so the two hooks stay
-# consistent.
-SCOPE_LIMIT = 150
-if len(scope) > SCOPE_LIMIT:
-    noun = 'path' if len(scope_list) == 1 else 'paths'
-    scope = scope[:SCOPE_LIMIT] + f\"... ({len(scope_list)} {noun} total, see .harness/features.json)\"
-desc = f.get('description', '')
-DESC_LIMIT = 200
-if len(desc) > DESC_LIMIT:
-    full_len = len(desc)
-    desc = desc[:DESC_LIMIT] + f\"... ({full_len} chars total, see .harness/features.json for the full description)\"
-print(f\"{data['count']} claimable feature(s). Next: {f.get('id')}: \"
-      f\"{desc} (priority {f.get('priority', 'unset')})\"
-      f\"{status_note} [scope: {scope}]\")
+try:
+    status_note = ' (retry)' if f.get('status') == 'failed' else ''
+    scope_list = [str(p) for p in (f.get('scope') or [])]
+    scope = ', '.join(scope_list) or 'no scope defined'
+    # F107: description and scope are the same unbounded-field class F071 and
+    # F085 already closed for session-start.sh's orientation -- this line goes
+    # straight to stderr, into a blocked agent's context, on exit 2. Same
+    # truncate-and-point caps and marker wording, so the two hooks stay
+    # consistent.
+    SCOPE_LIMIT = 150
+    if len(scope) > SCOPE_LIMIT:
+        noun = 'path' if len(scope_list) == 1 else 'paths'
+        scope = scope[:SCOPE_LIMIT] + f\"... ({len(scope_list)} {noun} total, see .harness/features.json)\"
+    desc = f.get('description') or ''
+    DESC_LIMIT = 200
+    if len(desc) > DESC_LIMIT:
+        full_len = len(desc)
+        desc = desc[:DESC_LIMIT] + f\"... ({full_len} chars total, see .harness/features.json for the full description)\"
+    print(f\"{data['count']} claimable feature(s). Next: {f.get('id')}: \"
+          f\"{desc} (priority {f.get('priority', 'unset')})\"
+          f\"{status_note} [scope: {scope}]\")
+except Exception:
+    print(f\"{data.get('count', '?')} claimable feature(s). Next: {f.get('id', 'unknown')}\"
+          \" (details unavailable; see .harness/features.json)\")
 ")
 
 echo "$NEXT" >&2

--- a/skills/harness-init/check-remaining-tasks.sh.template
+++ b/skills/harness-init/check-remaining-tasks.sh.template
@@ -144,9 +144,24 @@ import sys
 data = json.load(sys.stdin)
 f = data['next']
 status_note = ' (retry)' if f.get('status') == 'failed' else ''
-scope = ', '.join(f.get('scope') or []) or 'no scope defined'
+scope_list = f.get('scope') or []
+scope = ', '.join(scope_list) or 'no scope defined'
+# F107: description and scope are the same unbounded-field class F071 and
+# F085 already closed for session-start.sh's orientation -- this line goes
+# straight to stderr, into a blocked agent's context, on exit 2. Same
+# truncate-and-point caps and marker wording, so the two hooks stay
+# consistent.
+SCOPE_LIMIT = 150
+if len(scope) > SCOPE_LIMIT:
+    noun = 'path' if len(scope_list) == 1 else 'paths'
+    scope = scope[:SCOPE_LIMIT] + f\"... ({len(scope_list)} {noun} total, see .harness/features.json)\"
+desc = f.get('description', '')
+DESC_LIMIT = 200
+if len(desc) > DESC_LIMIT:
+    full_len = len(desc)
+    desc = desc[:DESC_LIMIT] + f\"... ({full_len} chars total, see .harness/features.json for the full description)\"
 print(f\"{data['count']} claimable feature(s). Next: {f.get('id')}: \"
-      f\"{f.get('description')} (priority {f.get('priority', 'unset')})\"
+      f\"{desc} (priority {f.get('priority', 'unset')})\"
       f\"{status_note} [scope: {scope}]\")
 ")
 

--- a/skills/harness-init/commit-gate.sh.template
+++ b/skills/harness-init/commit-gate.sh.template
@@ -373,7 +373,28 @@ if [ "$COMMAND_RC" -eq 1 ]; then
     deny_json "command could not be safely extracted from tool input (best-effort, pattern-based check; treating as a compound-stage-and-commit risk out of caution)."
 fi
 
-DENY_REASON=$(python3 - "$COMMAND" "$PROJECT_ROOT" <<'PYEOF'
+# F096 (second adversarial review, 2026-08-05): $COMMAND used to be passed
+# to this analysis python3 process via argv (`python3 - "$COMMAND" ...`,
+# reading its own script from the same stdin the heredoc below fed it), the
+# same ARG_MAX-exec-failure class F088-F093 fixed for deny_json()'s
+# payload -- an extremely large Bash command (over ~1MB on macOS, as low as
+# 128KB per-argument on Linux) failed this exec silently, DENY_REASON came
+# back empty, and the caller below fell through to an unintended allow, one
+# call site earlier in the exact same chain deny_json() already guards
+# (mirrors the identical fix in enforce-scope.sh.template, F096). Fixed the
+# same way (F094/F089 round 2's own established pattern): the python source
+# is read into a variable via a heredoc FIRST, then invoked with `-c`,
+# freeing stdin to carry $COMMAND itself -- unbounded in size, unlike
+# $PROJECT_ROOT, which stays on argv since it never grows with attacker
+# input. Unlike enforce-scope.sh.template's analogous fix, no DENY_REASON
+# length cap is added here: every reason this script's own main() can print
+# is either one of its own fixed constants (DENY_COMPOUND et al.) or built
+# from a staged-diff path/line number, never from raw command/segment text
+# reflected back -- so, unlike enforce-scope.sh.template's write-target/
+# segment quoting, DENY_REASON here was never made attacker-sized by this
+# bug in the first place; only the argv-vs-stdin transport of $COMMAND
+# itself needed fixing.
+IFS= read -r -d '' _COMMIT_ANALYSIS_PY <<'PYEOF' || true
 import fnmatch
 import json
 import os
@@ -1322,8 +1343,10 @@ def style_gate_enabled(harness_config):
 
 
 def main():
-    command = sys.argv[1]
-    project_root = sys.argv[2]
+    # F096: read from stdin, not argv[1] -- see the heredoc-assembly comment
+    # above this script's own invocation for why.
+    command = sys.stdin.read()
+    project_root = sys.argv[1]
 
     parsed = parse_command(command)
     if not any(sc == "commit" for _, sc, _, _ in parsed):
@@ -1379,7 +1402,7 @@ def main():
 
 main()
 PYEOF
-)
+    DENY_REASON=$(printf '%s' "$COMMAND" | python3 -c "$_COMMIT_ANALYSIS_PY" "$PROJECT_ROOT")
 
 # Passing-flip full_test gate (F102). Runs only when the python above
 # established "commit, no deny" via the sentinel. The comparison is INDEX

--- a/skills/harness-init/commit-gate.sh.template
+++ b/skills/harness-init/commit-gate.sh.template
@@ -386,14 +386,13 @@ fi
 # is read into a variable via a heredoc FIRST, then invoked with `-c`,
 # freeing stdin to carry $COMMAND itself -- unbounded in size, unlike
 # $PROJECT_ROOT, which stays on argv since it never grows with attacker
-# input. Unlike enforce-scope.sh.template's analogous fix, no DENY_REASON
-# length cap is added here: every reason this script's own main() can print
-# is either one of its own fixed constants (DENY_COMPOUND et al.) or built
-# from a staged-diff path/line number, never from raw command/segment text
-# reflected back -- so, unlike enforce-scope.sh.template's write-target/
-# segment quoting, DENY_REASON here was never made attacker-sized by this
-# bug in the first place; only the argv-vs-stdin transport of $COMMAND
-# itself needed fixing.
+# input. Every reason this script's python main() can print is either one
+# of its own fixed constants (DENY_COMPOUND et al.) or built from a
+# staged-diff path/line number, never from raw command/segment text
+# reflected back -- but the shell-level passing-flip deny reason below is
+# NOT bounded: it interpolates the last 15 lines of full_test output, whose
+# character count is unbounded, so that call site caps its tail to
+# FULL_TAIL_MAX_LEN before it reaches deny_json()'s argv.
 IFS= read -r -d '' _COMMIT_ANALYSIS_PY <<'PYEOF' || true
 import fnmatch
 import json
@@ -1472,8 +1471,12 @@ PYEOF
         if [ -f ".harness/init.sh" ]; then
             echo "commit-gate: staged features.json flips $FLIPPED to passing; running full_test..." >&2
             FULL_OUTPUT=$(bash .harness/init.sh full_test 2>&1) || {
+                # tail -15 bounds the line count but not the character count; an
+                # oversized tail on deny_json's argv would fail the exec (ARG_MAX)
+                # and silently convert this DENY into an allow (rc=0, no output).
+                FULL_TAIL_MAX_LEN=2048
                 FULL_TAIL=$(printf '%s\n' "$FULL_OUTPUT" | tail -15)
-                deny_json "passing-flip-full-test-failed: this commit flips $FLIPPED to 'passing' but the full test suite fails. Fix the failures or keep the feature in-progress. Full test output (last 15 lines): $FULL_TAIL"
+                deny_json "passing-flip-full-test-failed: this commit flips $FLIPPED to 'passing' but the full test suite fails. Fix the failures or keep the feature in-progress. Full test output (last 15 lines): ${FULL_TAIL:0:$FULL_TAIL_MAX_LEN}"
             }
         else
             echo "commit-gate: staged features.json flips $FLIPPED to passing, but .harness/init.sh is" \

--- a/skills/harness-init/enforce-scope.sh.template
+++ b/skills/harness-init/enforce-scope.sh.template
@@ -190,8 +190,19 @@ deny_json() {
     # silently converting a scope-violation DENIAL into an ALLOW (confirmed
     # live: a 1.2MB Write to a lead-owned file that correctly denies under
     # ARG_MAX returns rc=0 with an empty stdout once the payload is large
-    # enough). Only small, bounded values (the reason and finding strings)
-    # stay on argv.
+    # enough). "finding" is a small, fixed, per-call-site literal, genuinely
+    # bounded -- but "reason" is NOT: a second adversarial review (2026-08-05,
+    # F096) found this comment overclaiming boundedness for "reason" too. The
+    # Bash-command scope-violation reasons below quote the offending write
+    # target or raw segment verbatim (see _check_segment()/main()'s own
+    # comments), both derived from $COMMAND, so an attacker-sized $COMMAND
+    # can make "reason" itself attacker-sized -- reaching the exact same
+    # ARG_MAX exec failure this comment already describes for the payload,
+    # one call site later. The Bash-command call site below now caps its
+    # reason to DENY_REASON_MAX_LEN characters before calling this function
+    # (F096) so "reason" stays genuinely bounded by the time it lands here;
+    # the fixed literal reasons the other call sites pass (e.g. "state file
+    # is lead-owned...") were always bounded regardless.
     #
     # The python source is read into a variable via a TOP-LEVEL heredoc
     # (F094 round 2), NOT `python3 -c "$(cat <<'PYEOF' ...)"` -- see
@@ -449,7 +460,21 @@ if [ -n "$COMMAND" ]; then
         SCOPE_PATTERNS+=("$pattern")
     done < "$SCOPE_FILE"
 
-    DENY_REASON=$(python3 - "$COMMAND" "$PROJECT_ROOT" "${SCOPE_PATTERNS[@]}" <<'PYEOF'
+    # F096 (second adversarial review, 2026-08-05): $COMMAND used to be
+    # passed to this analysis python3 process via argv (`python3 -
+    # "$COMMAND" ...`, reading its own script from the same stdin the
+    # heredoc below fed it), the same ARG_MAX-exec-failure class F088-F093
+    # fixed for deny_json()'s payload -- an extremely large Bash command
+    # (over ~1MB on macOS, as low as 128KB per-argument on Linux) failed
+    # this exec silently, DENY_REASON came back empty, and the caller below
+    # (`if [ -n "$DENY_REASON" ]`) then fell through to an unintended allow,
+    # one call site earlier in the exact same chain deny_json() already
+    # guards. Fixed the same way (F094/F089 round 2's own established
+    # pattern): the python source is read into a variable via a heredoc
+    # FIRST, then invoked with `-c`, freeing stdin to carry $COMMAND itself
+    # -- unbounded in size, unlike $PROJECT_ROOT/the scope patterns, which
+    # stay on argv since neither grows with attacker input.
+    IFS= read -r -d '' _SCOPE_ANALYSIS_PY <<'PYEOF' || true
 import os
 import re
 import sys
@@ -1921,9 +1946,11 @@ def normalize(path, project_root):
 
 
 def main():
-    command = sys.argv[1]
-    project_root = sys.argv[2]
-    patterns = sys.argv[3:]
+    # F096: read from stdin, not argv[1] -- see the heredoc-assembly comment
+    # above this script's own invocation for why.
+    command = sys.stdin.read()
+    project_root = sys.argv[1]
+    patterns = sys.argv[2:]
     for segment in segments_of(command):
         try:
             if _check_segment(segment, project_root, patterns):
@@ -2028,10 +2055,20 @@ def _check_segment(segment, project_root, patterns):
 
 main()
 PYEOF
-)
+    DENY_REASON=$(printf '%s' "$COMMAND" | python3 -c "$_SCOPE_ANALYSIS_PY" "$PROJECT_ROOT" "${SCOPE_PATTERNS[@]}")
 
     if [ -n "$DENY_REASON" ]; then
-        deny_json "$DENY_REASON" "scope-violation:out-of-scope-command"
+        # F096: cap DENY_REASON before it reaches deny_json(), whose own
+        # "reason" argument stays on argv (see that function's comment) --
+        # the scope-violation messages above quote the offending write
+        # target or raw segment verbatim, both derived from $COMMAND, so an
+        # attacker-sized $COMMAND can still make DENY_REASON itself
+        # attacker-sized even after the stdin fix above (a huge write
+        # target/segment, not a huge command as a whole). 2048 matches
+        # commit-gate.sh.template's own SECRET_SCAN_MAX_LEN precedent for a
+        # bounded-cap value; well under either OS's ARG_MAX floor.
+        DENY_REASON_MAX_LEN=2048
+        deny_json "${DENY_REASON:0:$DENY_REASON_MAX_LEN}" "scope-violation:out-of-scope-command"
     fi
 fi
 

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -11946,14 +11946,14 @@ assert_not_contains "$DASHBOARD_HTML_SRC" ".teammate_name" \
 # function name, so the second "translate" entry silently overwrote the
 # first, dropping the -50%/-50% centering offset the instant a node
 # animated. Fix: centering moved off `transform` onto the standalone CSS
-# `translate` property, and the ring offset now uses distinct-axis
-# translateX/translateY keys.
+# `translate` property. (F094 later moved the ring offset itself off
+# `transform` entirely too -- see the dedicated F094 section below -- so
+# there is no longer a second transform function to collide with the
+# first at all.)
 assert_not_contains "$DASHBOARD_HTML_SRC" 'translate(-50%, -50%) translate(' \
   "dash-fe: positionRing() no longer packs two translate(...) calls into one transform string (anime.js Map key collision)"
 assert_contains "$DASHBOARD_HTML_SRC" 'translate: -50% -50%;' \
   "dash-fe: .node centers via the standalone CSS translate property (a property anime.js never reads or writes)"
-assert_contains "$DASHBOARD_HTML_SRC" 'translateX(" + x + "px) translateY(' \
-  "dash-fe: positionRing() uses distinct-axis translateX/translateY keys instead of a second bare translate(...)"
 
 # Finding 7: .node.lead had no centering rule of its own (top:50%/left:50%
 # alone puts the node's top-left corner, not its center, at the ring
@@ -13045,6 +13045,38 @@ if grep -qi 'passing' "$REPO_ROOT/README.md" \
 else
   fail "f104: README still describes the retired per-task full-suite gate"
 fi
+
+echo ""
+echo "== F094: dashboard ring positioning off transform =="
+
+# QA binding for F094 is manual (per its own features.json entry): a second
+# adversarial review of the F088-F093 dashboard chain found positionRing()
+# writing directly to style.transform while an animejs animation (pulse() at
+# 280ms, or the entrance/exit animations layoutSpokes() can interrupt) may be
+# mid-flight on the same node -- anime.js v3 rebuilds the whole transform
+# string from its own internal snapshot every animated frame, silently
+# clobbering positionRing()'s write. This repo's dependency-free bash/python3
+# runner has no browser/DOM harness, so these are supplementary structural
+# assertions on the exact source pattern the bug and its fix hinge on, not a
+# rendered/animated result.
+
+DASHBOARD_HTML_SRC=$(cat "$HOOKS_DIR/dashboard/index.html" 2>/dev/null)
+
+assert_not_contains "$DASHBOARD_HTML_SRC" 'rec.el.style.transform =' \
+  "dash-fe: positionRing() no longer writes ring position directly to style.transform (anime.js clobbers it mid-animation)"
+assert_contains "$DASHBOARD_HTML_SRC" 'rec.el.style.left = "calc(50% + " + x + "px)"' \
+  "dash-fe: positionRing() sets ring position via style.left using calc()"
+assert_contains "$DASHBOARD_HTML_SRC" 'rec.el.style.top = "calc(50% + " + y + "px)"' \
+  "dash-fe: positionRing() sets ring position via style.top using calc()"
+assert_contains "$DASHBOARD_HTML_SRC" "rec.x = x;" \
+  "dash-fe: positionRing() stores x on the node record"
+assert_contains "$DASHBOARD_HTML_SRC" "rec.y = y;" \
+  "dash-fe: positionRing() stores y on the node record"
+# The already-fixed standalone-CSS centering offset (first review round) must
+# survive this fix untouched -- transform stays exclusively anime.js's for
+# scale/opacity, never positioning.
+assert_contains "$DASHBOARD_HTML_SRC" 'translate: -50% -50%;' \
+  "dash-fe: .node still centers via the standalone CSS translate property"
 
 echo ""
 echo "== shell syntax =="

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -13098,6 +13098,78 @@ assert_contains "$OUT" "## Harness orientation" \
   "f097: ordinary orientation content still prints in full"
 
 echo ""
+echo "== F098: single features.json load for the remaining session-start checks =="
+
+# Arrange all three checks (spec drift, scope-unarmed, test_file-existence) to
+# fire at once: the base fixture already ships F001/F002 with test_file paths
+# that don't exist on disk (F066's real-world shape), so only spec drift and
+# scope-unarmed need explicit setup.
+DIR_F098="$WORK/f098-single-load"
+make_fixture "$DIR_F098"
+mkdir -p "$DIR_F098/.claude/hooks"
+printf '#!/bin/bash\nexit 0\n' > "$DIR_F098/.claude/hooks/enforce-scope.sh"
+python3 - "$DIR_F098/.harness/features.json" <<'PYEOF'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path) as fh:
+    data = json.load(fh)
+for feature in data["features"]:
+    if feature["id"] == "F002":
+        feature["assigned_to"] = "api"
+    if feature["id"] == "F003":
+        feature["spec"] = {"hash": "0" * 60 + "dead", "verdict": "PASS", "sv_version": "1.0"}
+with open(path, "w") as fh:
+    json.dump(data, fh, indent=2)
+    fh.write("\n")
+PYEOF
+
+# A fake python3 ahead of the real one on PATH logs every invocation's argv and
+# stdin to its own file and forwards to the real interpreter, so the actual
+# process count and per-process content can be inspected after the run --
+# behavioral proof, not just a grep of the script's source text.
+F098_FAKE_DIR="$WORK/f098-fake-python3"
+mkdir -p "$F098_FAKE_DIR"
+F098_LOG_DIR="$WORK/f098-python3-calls"
+mkdir -p "$F098_LOG_DIR"
+F098_REAL_PYTHON3=$(command -v python3)
+cat > "$F098_FAKE_DIR/python3" <<WRAP
+#!/bin/bash
+N=\$(ls "$F098_LOG_DIR" | wc -l | tr -d ' ')
+N=\$((N + 1))
+STDIN_CONTENT=\$(cat)
+printf '%s' "\$STDIN_CONTENT" > "$F098_LOG_DIR/call_\$N.log"
+printf '%s' "\$STDIN_CONTENT" | "$F098_REAL_PYTHON3" "\$@"
+WRAP
+chmod +x "$F098_FAKE_DIR/python3"
+
+OUT=$(cd "$DIR_F098" && printf '%s' '{"source":"startup"}' \
+  | PATH="$F098_FAKE_DIR:$PATH" CLAUDE_PROJECT_DIR="$DIR_F098" env -u CLAUDE_PLUGIN_ROOT \
+    bash "$HOOKS_DIR/session-start.sh")
+RC=$?
+assert_rc0 "$RC" "f098: the triple-warning fixture still exits 0"
+assert_contains "$OUT" "WARNING: spec drift" "f098: spec-drift warning still fires"
+assert_contains "$OUT" "WARNING: scope enforcement unarmed" "f098: scope-unarmed warning still fires"
+assert_contains "$OUT" "WARNING: test_file does not exist for" "f098: test_file-existence warning still fires"
+
+SPEC_DRIFT_CALLS=$(grep -l 'import hashlib' "$F098_LOG_DIR"/*.log 2>/dev/null | wc -l | tr -d ' ')
+SCOPE_CALLS=$(grep -l 'armed_needed' "$F098_LOG_DIR"/*.log 2>/dev/null | wc -l | tr -d ' ')
+TESTFILE_CALLS=$(grep -l 'os.path.isfile(os.path.join(root, test_file))' "$F098_LOG_DIR"/*.log 2>/dev/null | wc -l | tr -d ' ')
+if [ "$SPEC_DRIFT_CALLS" = "1" ] && [ "$SCOPE_CALLS" = "1" ] && [ "$TESTFILE_CALLS" = "1" ]; then
+  pass "f098: each of the three checks appears in exactly one logged python3 invocation"
+else
+  fail "f098: expected each check in exactly 1 invocation, got spec-drift=$SPEC_DRIFT_CALLS scope=$SCOPE_CALLS test_file=$TESTFILE_CALLS"
+fi
+
+SAME_CALL=$(grep -l 'import hashlib' "$F098_LOG_DIR"/*.log 2>/dev/null)
+if [ -n "$SAME_CALL" ] && grep -q 'armed_needed' "$SAME_CALL" && grep -q 'os.path.isfile(os.path.join(root, test_file))' "$SAME_CALL"; then
+  pass "f098: all three checks run inside the SAME python3 invocation (one features.json load)"
+else
+  fail "f098: the three checks are not all in the same python3 invocation -- consolidation regressed"
+fi
+
+echo ""
 echo "== shell syntax =="
 
 for SCRIPT in "$HOOKS_DIR"/*.sh "$SCRIPT_DIR/run-tests.sh" "$REPO_ROOT/scripts/stamp.sh"; do

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -13047,6 +13047,57 @@ else
 fi
 
 echo ""
+echo "== F097: measured-total orientation safety net =="
+
+# The per-section budgets (SESSION_INCOMPLETE/claude-progress.txt/context_summary.md
+# at 2600 chars each, the rule-pointer block echoing CLAUDE_PLUGIN_ROOT six times)
+# each bound one block in isolation, but never the SUM. Force all of them near
+# their own budget AT ONCE plus a pathologically long CLAUDE_PLUGIN_ROOT -- the
+# combination the per-section budgets can't catch since each one individually
+# stays under its own cap.
+F097_LONG_LINE=$(python3 -c "print('z' * 5000)")
+F097_LONG_ROOT=$(python3 -c "print('x' * 1500)")
+
+DIR_F097_OVERFLOW="$WORK/f097-measured-overflow"
+make_fixture "$DIR_F097_OVERFLOW"
+printf '%s\n' "$F097_LONG_LINE" > "$DIR_F097_OVERFLOW/.harness/SESSION_INCOMPLETE"
+printf '%s\n' "$F097_LONG_LINE" > "$DIR_F097_OVERFLOW/.harness/claude-progress.txt"
+cat > "$DIR_F097_OVERFLOW/.harness/context_summary.md" <<EOF
+# Context Summary
+
+## Active Context
+$F097_LONG_LINE
+
+## Cross-Cutting Concerns
+- none
+EOF
+OUT=$(run_session_start_with_root "$DIR_F097_OVERFLOW" '{"source":"startup"}' "$F097_LONG_ROOT")
+RC=$?
+LEN=${#OUT}
+assert_rc0 "$RC" "f097: an overflowing combination still exits 0"
+if [ "$LEN" -lt 10000 ]; then
+  pass "f097: the measured-total safety net keeps final output under the 10k platform cap ($LEN)"
+else
+  fail "f097: final output is $LEN chars, expected under 10000 despite the per-section budgets"
+fi
+assert_contains "$OUT" "orientation truncated:" \
+  "f097: the final safety net marker fires when the accumulated total exceeds its cap"
+assert_contains "$OUT" "chars total, exceeds the" \
+  "f097: the final safety net marker reports the actual accumulated length"
+
+# The safety net is additive, not a replacement: an ordinary session (nothing near
+# any per-section budget) must never show the new marker.
+DIR_F097_NORMAL="$WORK/f097-normal"
+make_fixture "$DIR_F097_NORMAL"
+OUT=$(run_session_start "$DIR_F097_NORMAL" '{"source":"startup"}')
+RC=$?
+assert_rc0 "$RC" "f097: an ordinary session exits 0"
+assert_not_contains "$OUT" "orientation truncated:" \
+  "f097: the final safety net does not fire on ordinary, non-pathological content"
+assert_contains "$OUT" "## Harness orientation" \
+  "f097: ordinary orientation content still prints in full"
+
+echo ""
 echo "== shell syntax =="
 
 for SCRIPT in "$HOOKS_DIR"/*.sh "$SCRIPT_DIR/run-tests.sh" "$REPO_ROOT/scripts/stamp.sh"; do

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -13068,10 +13068,6 @@ assert_contains "$DASHBOARD_HTML_SRC" 'rec.el.style.left = "calc(50% + " + x + "
   "dash-fe: positionRing() sets ring position via style.left using calc()"
 assert_contains "$DASHBOARD_HTML_SRC" 'rec.el.style.top = "calc(50% + " + y + "px)"' \
   "dash-fe: positionRing() sets ring position via style.top using calc()"
-assert_contains "$DASHBOARD_HTML_SRC" "rec.x = x;" \
-  "dash-fe: positionRing() stores x on the node record"
-assert_contains "$DASHBOARD_HTML_SRC" "rec.y = y;" \
-  "dash-fe: positionRing() stores y on the node record"
 # The already-fixed standalone-CSS centering offset (first review round) must
 # survive this fix untouched -- transform stays exclusively anime.js's for
 # scale/opacity, never positioning.
@@ -13149,6 +13145,43 @@ assert_contains "$OUT" "orientation truncated:" \
   "f097: the final safety net marker fires when the accumulated total exceeds its cap"
 assert_contains "$OUT" "chars total, exceeds the" \
   "f097: the final safety net marker reports the actual accumulated length"
+# Review round 1: the first cut trimmed the buffer's TAIL, dropping the rule
+# pointers and the /harness-continue line -- the fixed footer the orientation
+# exists to deliver. The footer is now built separately and survives whenever
+# it fits; only the pathological 1500-char root above (footer alone near the
+# whole cap) falls back to the bare 10k invariant. An 800-char root keeps the
+# footer well inside the cap while still overflowing the body's share.
+DIR_F097_FOOTER="$WORK/f097-footer-survives"
+make_fixture "$DIR_F097_FOOTER"
+printf '%s\n' "$F097_LONG_LINE" > "$DIR_F097_FOOTER/.harness/SESSION_INCOMPLETE"
+printf '%s\n' "$F097_LONG_LINE" > "$DIR_F097_FOOTER/.harness/claude-progress.txt"
+cat > "$DIR_F097_FOOTER/.harness/context_summary.md" <<EOF
+# Context Summary
+
+## Active Context
+$F097_LONG_LINE
+
+## Cross-Cutting Concerns
+- none
+EOF
+F097_MID_ROOT=$(python3 -c "print('x' * 800)")
+OUT=$(run_session_start_with_root "$DIR_F097_FOOTER" '{"source":"startup"}' "$F097_MID_ROOT")
+RC=$?
+LEN=${#OUT}
+assert_rc0 "$RC" "f097: the realistic-root overflow still exits 0"
+if [ "$LEN" -lt 10000 ]; then
+  pass "f097: realistic-root overflow output stays under the 10k platform cap ($LEN)"
+else
+  fail "f097: realistic-root overflow output is $LEN chars, expected under 10000"
+fi
+assert_contains "$OUT" "orientation truncated:" \
+  "f097: the safety net marker fires on the realistic-root overflow"
+assert_contains "$OUT" "rules/tdd.md" \
+  "f097: the rule-pointer footer survives truncation (last pointer present)"
+assert_contains "$OUT" "rules/agent-teams-protocol.md" \
+  "f097: the rule-pointer footer survives truncation (first pointer present)"
+assert_contains "$OUT" "Run /harness-continue" \
+  "f097: the /harness-continue line survives truncation"
 
 # The safety net is additive, not a replacement: an ordinary session (nothing near
 # any per-section budget) must never show the new marker.
@@ -13299,16 +13332,57 @@ assert_deny_json "$OUT" \
 assert_contains "$OUT" "compound-stage-and-commit" \
   "f096-cg: an oversized compound-stage-and-commit Bash command still names the finding class"
 
+# Review round 1: the passing-flip deny path interpolates the last 15 lines of
+# full_test output into its deny reason. tail -15 bounds lines, not characters,
+# so a suite whose failing tail is one huge line put an unbounded string on
+# deny_json's argv -- the same ARG_MAX silent-allow class as above, reproduced
+# live: rc=0 with 0 bytes of stdout, which PreToolUse reads as ALLOW, letting a
+# red-suite passing flip commit. The fix caps the tail (FULL_TAIL_MAX_LEN)
+# before it reaches deny_json.
+DIR_F096_FT="$WORK/f096-argmax-full-tail"
+make_fixture "$DIR_F096_FT"
+install_hooks "$DIR_F096_FT"
+cat > "$DIR_F096_FT/.harness/init.sh" <<'INITEOF'
+#!/bin/bash
+case "$1" in
+  full_test)
+    python3 -c "print('X' * 2000000)"
+    exit 1
+    ;;
+esac
+exit 0
+INITEOF
+chmod +x "$DIR_F096_FT/.harness/init.sh"
+stage_f003_status "$DIR_F096_FT" "passing"
+OUT=$(run_commit_gate "$DIR_F096_FT" 'git commit -m "mark F003 passing"')
+RC=$?
+assert_rc0 "$RC" "f096-ft: a red full_test with a giant one-line tail still exits 0"
+assert_deny_json "$OUT" \
+  "f096-ft: a red full_test with a giant one-line tail still emits deny JSON (not a silent allow)"
+assert_contains "$OUT" "passing-flip-full-test-failed" \
+  "f096-ft: the giant-tail denial still names the finding class"
+F096_FT_REASON_LEN=$(python3 -c "
+import json, sys
+data = json.loads(sys.argv[1])
+print(len(data['hookSpecificOutput']['permissionDecisionReason']))
+" "$OUT" 2>/dev/null || echo 0)
+if [ "$F096_FT_REASON_LEN" -gt 0 ] && [ "$F096_FT_REASON_LEN" -le 4096 ]; then
+  pass "f096-ft: the giant-tail denial's reason string is capped to a bounded length"
+else
+  fail "f096-ft: the giant-tail denial's reason string is NOT capped (length $F096_FT_REASON_LEN)"
+fi
+
 echo "== F087: readiness-stamp HMAC round-trip (env-var key source) =="
 
-# The readiness-stamp HMAC recipe (schemas/readiness-stamp.md) had no round-trip test
-# anywhere in this repo (OVI-45, re-confirmed 2026-08-04): .harness/harness.json carries
-# no `prep` key, so harness-issue-prep's Step 7 never fires here, and no file under
-# .harness/, MAINTENANCE_LOG.md, or docs/ contains the string "vv-harness-readiness-stamp"
-# -- the mint has never actually run in this repo. This fixture exercises the full
-# documented recipe headlessly via the VV_HARNESS_STAMP_KEY env var (resolution source
-# 3 -- no macOS Keychain needed), against the ACTUAL Step 7 snippet extracted from
-# harness-issue-prep/SKILL.md, not a re-implementation.
+# Supplementary to the F012 stamp block earlier in this file (which already
+# extracts and round-trips the same Step 7 snippet against all six consumer
+# rules, keyed via VV_HARNESS_STAMP_KEY_FILE): this section adds the pieces
+# F012 does not cover -- the VV_HARNESS_STAMP_KEY env-var key source as the
+# ONLY available source, a direct base_sha tamper, lane/repo tampers, a
+# wrong-key negative, and an independent oracle recomputing the documented
+# recipe (schemas/readiness-stamp.md: hmac-sha256 over spec_hash|base_sha|
+# lane|repo) so a SKILL.md edit that drifts from the schema's message
+# construction is caught, not mirrored.
 DIR_F087="$WORK/f087-stamp"
 mkdir -p "$DIR_F087"
 python3 - "$REPO_ROOT" "$DIR_F087" <<'PYEOF'
@@ -13384,6 +13458,51 @@ if [ "$HMAC_F087_BAD_BASE" != "$HMAC_F087" ]; then
   pass "f087: a tampered base_sha fails HMAC verification"
 else
   fail "f087: a tampered base_sha should not recompute to the minted HMAC"
+fi
+
+# Review round 1 additions: the assertions above only compared the snippet
+# against itself, so a SKILL.md edit that dropped fields, reordered the
+# message, or ignored the key entirely would still round-trip green.
+
+# Independent oracle: recompute the documented recipe (schemas/readiness-
+# stamp.md -- hmac-sha256 over spec_hash|base_sha|lane|repo, pipe-joined,
+# that order) WITHOUT the snippet, and require the snippet's output to match.
+HMAC_F087_ORACLE=$(python3 -c "
+import hashlib, hmac, sys
+key, spec, base, lane, repo = sys.argv[1:6]
+msg = '|'.join([spec, base, lane, repo]).encode('utf-8')
+print(hmac.new(key.encode('utf-8'), msg, hashlib.sha256).hexdigest())
+" "$STAMP_KEY_F087" "$SPEC_HASH_F087" "$BASE_SHA_F087" "$LANE_F087" "$REPO_F087")
+if [ -n "$HMAC_F087" ] && [ "$HMAC_F087" = "$HMAC_F087_ORACLE" ]; then
+  pass "f087: the snippet's HMAC matches an independent recomputation of the documented recipe"
+else
+  fail "f087: snippet HMAC '$HMAC_F087' diverges from the schema-recipe oracle '$HMAC_F087_ORACLE'"
+fi
+
+# Negative: lane and repo tampers each change the HMAC (the message carries
+# all four fields, not just the first two).
+HMAC_F087_BAD_LANE=$(run_stamp_f087 "$SPEC_HASH_F087" "$BASE_SHA_F087" "docs" "$REPO_F087")
+if [ "$HMAC_F087_BAD_LANE" != "$HMAC_F087" ]; then
+  pass "f087: a tampered lane fails HMAC verification"
+else
+  fail "f087: a tampered lane should not recompute to the minted HMAC"
+fi
+HMAC_F087_BAD_REPO=$(run_stamp_f087 "$SPEC_HASH_F087" "$BASE_SHA_F087" "$LANE_F087" "attacker/other-repo")
+if [ "$HMAC_F087_BAD_REPO" != "$HMAC_F087" ]; then
+  pass "f087: a tampered repo fails HMAC verification"
+else
+  fail "f087: a tampered repo should not recompute to the minted HMAC"
+fi
+
+# Negative: a different key produces a different HMAC (the key is not ignored).
+HMAC_F087_OTHER_KEY=$(env -i PATH="$NOBIN_F087" HOME="$HOME" \
+  VV_HARNESS_STAMP_KEY="f087-a-completely-different-key" \
+  "$PYTHON3_BIN_F087" "$DIR_F087/resolve_and_hmac.py" \
+  "$SPEC_HASH_F087" "$BASE_SHA_F087" "$LANE_F087" "$REPO_F087")
+if [ -n "$HMAC_F087_OTHER_KEY" ] && [ "$HMAC_F087_OTHER_KEY" != "$HMAC_F087" ]; then
+  pass "f087: a different VV_HARNESS_STAMP_KEY produces a different HMAC (key is not ignored)"
+else
+  fail "f087: changing the key must change the HMAC, got '$HMAC_F087_OTHER_KEY'"
 fi
 
 echo ""
@@ -13572,6 +13691,117 @@ FIX_OUT=$(run_doctor "$DIR_DOC_FOCUSED_FIX" --fix)
 assert_contains "$FIX_OUT" "exit-3 skip contract (F106)" \
   "hd (F108): --fix leaves the init.sh finding in place unfixed"
 
+# Review round 1: a PARTIALLY hand-applied repair (the missing-file arm
+# upgraded to the exit-3 contract and run_focused defined, but another arm
+# still 'treating as pass' and falling through to exit 0) satisfied the
+# original markers-only check while two fake-green paths stayed live. The
+# check now also positively detects the pre-F106 fake-green wording.
+DIR_DOC_FOCUSED_PART="$WORK/doctor-focused-partial"
+make_healthy_doctor_fixture "$DIR_DOC_FOCUSED_PART"
+cat > "$DIR_DOC_FOCUSED_PART/.harness/init.sh" <<'INITEOF'
+#!/bin/bash
+TARGET=${1:-full_test}
+FOCUS_FILE="${2:-}"
+if [ "$TARGET" = "focused_test" ]; then
+    if [ ! -f "$FOCUS_FILE" ]; then
+        echo "focused_test: test file '$FOCUS_FILE' does not exist -- skipped (exit 3)."
+        exit 3
+    fi
+    run_focused() {
+        local rc=0
+        "$@" || rc=$?
+        if [ "$rc" -eq 3 ]; then
+            rc=1
+        fi
+        return $rc
+    }
+    if command -v pytest &>/dev/null; then
+        run_focused pytest --tb=short "$FOCUS_FILE"
+    else
+        echo "focused_test: pytest not available; no per-file runner -- treating as pass (smoke_test already ran)."
+    fi
+    exit 0
+fi
+echo "full test"
+INITEOF
+chmod +x "$DIR_DOC_FOCUSED_PART/.harness/init.sh"
+git -C "$DIR_DOC_FOCUSED_PART" add -A
+git -C "$DIR_DOC_FOCUSED_PART" commit -q -m "init.sh with a partially hand-applied F106 repair"
+OUT=$(run_doctor "$DIR_DOC_FOCUSED_PART")
+assert_contains "$OUT" "exit-3 skip contract (F106)" \
+  "hd (F108): a partially hand-applied repair (markers present, 'treating as pass' arm remains) is still flagged"
+
+# Review round 1: the markers were checked against the RAW file text, so a
+# comment quoting them (a TODO note deferring the hand-apply, or the doctor's
+# own finding text pasted as a reminder) cleared a genuinely pre-F106 body.
+# Markers are now checked against non-comment lines only.
+DIR_DOC_FOCUSED_CMT="$WORK/doctor-focused-comment"
+make_healthy_doctor_fixture "$DIR_DOC_FOCUSED_CMT"
+cat > "$DIR_DOC_FOCUSED_CMT/.harness/init.sh" <<'INITEOF'
+#!/bin/bash
+# TODO: add run_focused / skipped (exit 3) per the F106 contract
+TARGET=${1:-full_test}
+FOCUS_FILE="${2:-}"
+if [ "$TARGET" = "focused_test" ]; then
+    pytest --tb=short "$FOCUS_FILE" || echo "no runner; treating as pass"
+    exit 0
+fi
+echo "full test"
+INITEOF
+chmod +x "$DIR_DOC_FOCUSED_CMT/.harness/init.sh"
+git -C "$DIR_DOC_FOCUSED_CMT" add -A
+git -C "$DIR_DOC_FOCUSED_CMT" commit -q -m "init.sh with comment-quoted markers over a pre-F106 body"
+OUT=$(run_doctor "$DIR_DOC_FOCUSED_CMT")
+assert_contains "$OUT" "exit-3 skip contract (F106)" \
+  "hd (F108): comment-quoted markers do not clear a pre-F106 fake-green body"
+
+# The documented no-finding branches (SKILL.md check 10): an init.sh with no
+# focused_test support at all, and one mentioning focused_test only inside a
+# comment, both produce no finding.
+DIR_DOC_FOCUSED_NONE="$WORK/doctor-focused-none"
+make_healthy_doctor_fixture "$DIR_DOC_FOCUSED_NONE"
+cat > "$DIR_DOC_FOCUSED_NONE/.harness/init.sh" <<'INITEOF'
+#!/bin/bash
+TARGET=${1:-full_test}
+case "$TARGET" in
+  smoke_test) echo "smoke" ;;
+  full_test) echo "full test" ;;
+esac
+INITEOF
+chmod +x "$DIR_DOC_FOCUSED_NONE/.harness/init.sh"
+git -C "$DIR_DOC_FOCUSED_NONE" add -A
+git -C "$DIR_DOC_FOCUSED_NONE" commit -q -m "init.sh without focused_test support"
+OUT=$(run_doctor "$DIR_DOC_FOCUSED_NONE")
+assert_not_contains "$OUT" "exit-3 skip contract" \
+  "hd (F108): an init.sh with no focused_test support produces no finding"
+
+DIR_DOC_FOCUSED_CMTONLY="$WORK/doctor-focused-comment-only"
+make_healthy_doctor_fixture "$DIR_DOC_FOCUSED_CMTONLY"
+cat > "$DIR_DOC_FOCUSED_CMTONLY/.harness/init.sh" <<'INITEOF'
+#!/bin/bash
+# focused_test is not supported by this project's init.sh
+TARGET=${1:-full_test}
+echo "full test"
+INITEOF
+chmod +x "$DIR_DOC_FOCUSED_CMTONLY/.harness/init.sh"
+git -C "$DIR_DOC_FOCUSED_CMTONLY" add -A
+git -C "$DIR_DOC_FOCUSED_CMTONLY" commit -q -m "init.sh mentioning focused_test only in a comment"
+OUT=$(run_doctor "$DIR_DOC_FOCUSED_CMTONLY")
+assert_not_contains "$OUT" "exit-3 skip contract" \
+  "hd (F108): focused_test mentioned only in a comment produces no finding"
+
+# Drift guard: the doctor's marker strings must keep matching the shipped
+# template -- both markers on non-comment lines, and no pre-F106 fake-green
+# wording anywhere in the current template.
+TPL_INIT="$REPO_ROOT/skills/harness-init/init.sh.template"
+TPL_NON_COMMENT=$(grep -v '^[[:space:]]*#' "$TPL_INIT")
+assert_contains "$TPL_NON_COMMENT" "skipped (exit 3)" \
+  "hd (F108): shipped init.sh.template carries the 'skipped (exit 3)' marker on a non-comment line"
+assert_contains "$TPL_NON_COMMENT" "run_focused" \
+  "hd (F108): shipped init.sh.template carries run_focused on a non-comment line"
+assert_not_contains "$(cat "$TPL_INIT")" "treating as pass" \
+  "hd (F108): shipped init.sh.template carries no pre-F106 'treating as pass' wording"
+
 echo ""
 echo "== F107: check-remaining-tasks.sh reassignment message field caps =="
 # check-remaining-tasks.sh's "Next: <id>: <description> (priority N) [scope: ...]"
@@ -13667,6 +13897,40 @@ PYEOF
 STDERR_F107_EMPTY=$(run_hook "$DIR_F107_EMPTY_SCOPE" check-remaining-tasks.sh '{}' 2>&1 1>/dev/null)
 assert_contains "$STDERR_F107_EMPTY" "[scope: no scope defined]" \
   "f107 (empty scope): the pre-existing empty-scope fallback text is unchanged"
+
+# Review round 1: an explicitly-null description crashed the formatter
+# (f.get('description', '') returns None for a present-but-null key, then
+# len(None) raises), and under set -euo pipefail the failed command
+# substitution suppressed the exit-2 nudge entirely -- a silent fail-open.
+# The formatter is now null-safe and try/except-guarded, so the block
+# verdict survives any malformed feature entry.
+DIR_F107_NULL="$WORK/f107-null-description"
+make_fixture "$DIR_F107_NULL"
+install_hooks "$DIR_F107_NULL"
+python3 - "$DIR_F107_NULL/.harness/features.json" <<'PYEOF'
+import json
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    data = json.load(fh)
+for feature in data["features"]:
+    if feature["id"] == "F003":
+        feature["description"] = None
+with open(path, "w") as fh:
+    json.dump(data, fh, indent=2)
+    fh.write("\n")
+PYEOF
+STDERR_F107_NULL=$(run_hook "$DIR_F107_NULL" check-remaining-tasks.sh '{}' 2>&1 1>/dev/null)
+RC=$?
+if [ "$RC" -eq 2 ]; then
+  pass "f107 (null description): the hook still exits 2 (nudge not suppressed)"
+else
+  fail "f107 (null description): hook exited $RC, expected 2 -- the nudge was suppressed"
+fi
+assert_contains "$STDERR_F107_NULL" "Next: F003" \
+  "f107 (null description): the feature id still appears with a null description"
+assert_not_contains "$STDERR_F107_NULL" "TypeError" \
+  "f107 (null description): no python traceback reaches stderr"
 
 echo ""
 TOTAL=$((PASS_COUNT + FAIL_COUNT))

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -13047,6 +13047,72 @@ else
 fi
 
 echo ""
+echo "== F096: \$COMMAND/DENY_REASON ARG_MAX bypass (one call site earlier than F088-F093) =="
+
+# A second adversarial review (2026-08-05) found that enforce-scope.sh's own
+# scope-analysis python3 process, and commit-gate.sh's own analysis python3
+# process, still took $COMMAND via argv rather than stdin -- the same
+# ARG_MAX-exec-failure class F088-F093 fixed for deny_json()'s payload, one
+# call site earlier in the chain. An extremely large Bash command failed
+# that analysis step silently (E2BIG) and DENY_REASON came back empty,
+# falling through to an unintended allow -- confirmed live against the
+# pre-fix hooks before this fix (rc=0, empty stdout, same as the F089 round
+# 2 incident these tests mirror).
+
+DIR_F096_ES="$WORK/f096-argmax-enforce-scope"
+make_fixture "$DIR_F096_ES"
+install_hooks "$DIR_F096_ES"
+printf 'src/parser/\n' > "$DIR_F096_ES/.claude/teammate-scope.txt"
+F096_ES_PAYLOAD=$(python3 -c "
+import json
+cmd = 'echo x > src/other/' + ('A' * 2000000) + '.txt'
+print(json.dumps({
+    'hook_event_name': 'PreToolUse',
+    'session_id': 'f096sess',
+    'tool_input': {'command': cmd},
+}))
+")
+OUT=$(run_hook_dashboard "$DIR_F096_ES" enforce-scope.sh "$F096_ES_PAYLOAD")
+RC=$?
+assert_rc0 "$RC" "f096-es: an oversized out-of-scope Bash command still exits 0"
+assert_deny_json "$OUT" \
+  "f096-es: an oversized out-of-scope Bash command still emits deny JSON (not a silent allow)"
+# The write target enforce-scope.sh quotes into its own reason string is the
+# same oversized text, so DENY_REASON itself is oversized here too -- it
+# must be capped before reaching deny_json()'s own argv-carried "reason",
+# or that exec fails the identical way, one call site later still.
+REASON_LEN=$(python3 -c "
+import json, sys
+data = json.loads(sys.argv[1])
+print(len(data['hookSpecificOutput']['permissionDecisionReason']))
+" "$OUT")
+if [ "$REASON_LEN" -gt 0 ] && [ "$REASON_LEN" -le 2048 ]; then
+  pass "f096-es: the oversized denial's own reason string is capped to a bounded length"
+else
+  fail "f096-es: the oversized denial's own reason string is NOT capped (length $REASON_LEN)"
+fi
+
+DIR_F096_CG="$WORK/f096-argmax-commit-gate"
+make_fixture "$DIR_F096_CG"
+install_hooks "$DIR_F096_CG"
+F096_CG_PAYLOAD=$(python3 -c "
+import json
+cmd = 'git commit -a -m \"test\" --author=\"' + ('A' * 2000000) + '\"'
+print(json.dumps({
+    'hook_event_name': 'PreToolUse',
+    'session_id': 'f096sess',
+    'tool_input': {'command': cmd},
+}))
+")
+OUT=$(run_hook_dashboard "$DIR_F096_CG" commit-gate.sh "$F096_CG_PAYLOAD")
+RC=$?
+assert_rc0 "$RC" "f096-cg: an oversized compound-stage-and-commit Bash command still exits 0"
+assert_deny_json "$OUT" \
+  "f096-cg: an oversized compound-stage-and-commit Bash command still emits deny JSON (not a silent allow)"
+assert_contains "$OUT" "compound-stage-and-commit" \
+  "f096-cg: an oversized compound-stage-and-commit Bash command still names the finding class"
+
+echo ""
 echo "== shell syntax =="
 
 for SCRIPT in "$HOOKS_DIR"/*.sh "$SCRIPT_DIR/run-tests.sh" "$REPO_ROOT/scripts/stamp.sh"; do

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -13143,6 +13143,95 @@ for TPL in "$TEMPLATES_DIR"/*.sh.template; do
   fi
 done
 
+echo "== harness-doctor: focused_test skip contract (F108) =="
+
+# .harness/init.sh is a per-project copy made at init time -- v5.5.0's
+# focused_test exit-code contract (F106: exit 3 reserved for skips, a
+# runner's own exit 3 remapped to 1, a missing test file skipped rather
+# than faked green) never reaches a project that adopted focused_test
+# under v5.4.0. This mirrors the pre-F106/post-F106 shapes of
+# skills/harness-init/init.sh.template's focused_test block (see git log
+# 78087c5/912bc3c) rather than inventing a synthetic contract.
+DIR_DOC_FOCUSED_OK="$WORK/doctor-focused-ok"
+make_healthy_doctor_fixture "$DIR_DOC_FOCUSED_OK"
+cat > "$DIR_DOC_FOCUSED_OK/.harness/init.sh" <<'INITEOF'
+#!/bin/bash
+TARGET=${1:-full_test}
+FOCUS_FILE="${2:-}"
+if [ "$TARGET" = "focused_test" ]; then
+    if [ ! -f "$FOCUS_FILE" ]; then
+        echo "focused_test: test file '$FOCUS_FILE' does not exist -- skipped (exit 3)."
+        exit 3
+    fi
+    run_focused() {
+        local rc=0
+        "$@" || rc=$?
+        if [ "$rc" -eq 3 ]; then
+            rc=1
+        fi
+        return $rc
+    }
+    run_focused pytest --tb=short "$FOCUS_FILE"
+    exit 0
+fi
+echo "full test"
+INITEOF
+chmod +x "$DIR_DOC_FOCUSED_OK/.harness/init.sh"
+git -C "$DIR_DOC_FOCUSED_OK" add -A
+git -C "$DIR_DOC_FOCUSED_OK" commit -q -m "init.sh at v5.5.0 focused_test contract"
+OUT=$(run_doctor "$DIR_DOC_FOCUSED_OK")
+assert_not_contains "$OUT" "exit-3 skip contract" \
+  "hd (F108): an init.sh already at the v5.5.0 focused_test contract produces no finding"
+
+DIR_DOC_FOCUSED_STALE="$WORK/doctor-focused-stale"
+make_healthy_doctor_fixture "$DIR_DOC_FOCUSED_STALE"
+cat > "$DIR_DOC_FOCUSED_STALE/.harness/init.sh" <<'INITEOF'
+#!/bin/bash
+TARGET=${1:-full_test}
+FOCUS_FILE="${2:-}"
+STACK=python
+if [ "$TARGET" = "focused_test" ]; then
+    case "$STACK" in
+        python)
+            if command -v pytest &>/dev/null; then
+                pytest --tb=short "$FOCUS_FILE"
+            else
+                echo "focused_test: pytest not available; no per-file runner -- treating as pass (smoke_test already ran)."
+            fi
+            ;;
+        *)
+            echo "focused_test: no focused runner for stack '$STACK'; treating as pass (smoke_test already ran)."
+            ;;
+    esac
+    exit 0
+fi
+echo "full test"
+INITEOF
+chmod +x "$DIR_DOC_FOCUSED_STALE/.harness/init.sh"
+git -C "$DIR_DOC_FOCUSED_STALE" add -A
+git -C "$DIR_DOC_FOCUSED_STALE" commit -q -m "init.sh at pre-F106 focused_test contract"
+OUT=$(run_doctor "$DIR_DOC_FOCUSED_STALE")
+RC=$?
+assert_rc_nonzero "$RC" "hd (F108): a pre-F106 focused_test init.sh exits non-zero"
+assert_contains "$OUT" "upgrade available: .harness/init.sh supports focused_test but is missing" \
+  "hd (F108): pre-F106 init.sh is reported as upgrade-available"
+assert_contains "$OUT" "exit-3 skip contract (F106)" \
+  "hd (F108): finding names the F106 exit-3 skip contract"
+assert_contains "$OUT" "hand-apply" \
+  "hd (F108): repair is a hand-apply instruction, not an automatic fix"
+
+# --fix never touches init.sh (the one genuinely decision-shaped per-project
+# file): the finding must survive a --fix pass unchanged.
+DIR_DOC_FOCUSED_FIX="$WORK/doctor-focused-fix"
+make_healthy_doctor_fixture "$DIR_DOC_FOCUSED_FIX"
+cp "$DIR_DOC_FOCUSED_STALE/.harness/init.sh" "$DIR_DOC_FOCUSED_FIX/.harness/init.sh"
+chmod +x "$DIR_DOC_FOCUSED_FIX/.harness/init.sh"
+git -C "$DIR_DOC_FOCUSED_FIX" add -A
+git -C "$DIR_DOC_FOCUSED_FIX" commit -q -m "init.sh at pre-F106 focused_test contract"
+FIX_OUT=$(run_doctor "$DIR_DOC_FOCUSED_FIX" --fix)
+assert_contains "$FIX_OUT" "exit-3 skip contract (F106)" \
+  "hd (F108): --fix leaves the init.sh finding in place unfixed"
+
 echo ""
 TOTAL=$((PASS_COUNT + FAIL_COUNT))
 echo "Summary: $PASS_COUNT/$TOTAL assertions passed, $FAIL_COUNT failed"

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -13144,6 +13144,102 @@ for TPL in "$TEMPLATES_DIR"/*.sh.template; do
 done
 
 echo ""
+echo "== F107: check-remaining-tasks.sh reassignment message field caps =="
+# check-remaining-tasks.sh's "Next: <id>: <description> (priority N) [scope: ...]"
+# line goes straight to stderr and into a blocked agent's context on exit 2
+# (F046). Its description and scope fields were the same unbounded-field
+# class F071 and F085 already closed for session-start.sh's orientation --
+# missed here because F085's own spec named only session-start.sh. Reuse the
+# same truncate-and-point caps and marker wording (DESC_LIMIT=200,
+# SCOPE_LIMIT=150) so the two hooks stay consistent.
+F107_LONG_DESC_LEN=13222
+F107_LONG_DESC=$(python3 -c "print('X' * $F107_LONG_DESC_LEN)")
+
+DIR_F107_DESC="$WORK/f107-long-description"
+make_fixture "$DIR_F107_DESC"
+install_hooks "$DIR_F107_DESC"
+python3 - "$DIR_F107_DESC/.harness/features.json" "$F107_LONG_DESC" <<'PYEOF'
+import json
+import sys
+path, long_desc = sys.argv[1], sys.argv[2]
+with open(path) as fh:
+    data = json.load(fh)
+for feature in data["features"]:
+    if feature["id"] == "F003":
+        feature["description"] = long_desc
+with open(path, "w") as fh:
+    json.dump(data, fh, indent=2)
+    fh.write("\n")
+PYEOF
+STDERR_F107_DESC=$(run_hook "$DIR_F107_DESC" check-remaining-tasks.sh '{}' 2>&1 1>/dev/null)
+assert_contains "$STDERR_F107_DESC" "Next: F003" \
+  "f107 (description): the feature id still appears when its description is truncated"
+assert_contains "$STDERR_F107_DESC" "$F107_LONG_DESC_LEN chars total, see .harness/features.json for the full description" \
+  "f107 (description): the truncation marker names the real length and points at the full text"
+assert_not_contains "$STDERR_F107_DESC" "$F107_LONG_DESC" \
+  "f107 (description): the full 13222-char description no longer reaches stderr whole"
+
+F107_LONG_SCOPE_JSON=$(python3 -c "
+import json
+paths = [f'src/deeply/nested/module_{i:02d}/submodule/implementation/' for i in range(12)]
+print(json.dumps(paths))")
+F107_LONG_SCOPE_LAST="module_11"
+
+DIR_F107_SCOPE="$WORK/f107-long-scope"
+make_fixture "$DIR_F107_SCOPE"
+install_hooks "$DIR_F107_SCOPE"
+python3 - "$DIR_F107_SCOPE/.harness/features.json" "$F107_LONG_SCOPE_JSON" <<'PYEOF'
+import json
+import sys
+path, scope_json = sys.argv[1], sys.argv[2]
+with open(path) as fh:
+    data = json.load(fh)
+for feature in data["features"]:
+    if feature["id"] == "F003":
+        feature["scope"] = json.loads(scope_json)
+with open(path, "w") as fh:
+    json.dump(data, fh, indent=2)
+    fh.write("\n")
+PYEOF
+STDERR_F107_SCOPE=$(run_hook "$DIR_F107_SCOPE" check-remaining-tasks.sh '{}' 2>&1 1>/dev/null)
+assert_contains "$STDERR_F107_SCOPE" "Next: F003" \
+  "f107 (scope): the feature id still appears with an oversized scope"
+assert_contains "$STDERR_F107_SCOPE" "12 paths total, see .harness/features.json" \
+  "f107 (scope): the scope truncation marker names the path count and points at the full list"
+assert_not_contains "$STDERR_F107_SCOPE" "$F107_LONG_SCOPE_LAST" \
+  "f107 (scope): the tail of the oversized scope no longer reaches stderr"
+F107_NEXT_LINE=$(printf '%s\n' "$STDERR_F107_SCOPE" | grep "Next: F003")
+if [ "${#F107_NEXT_LINE}" -lt 450 ]; then
+  pass "f107 (scope): the Next line stays bounded (${#F107_NEXT_LINE} chars)"
+else
+  fail "f107 (scope): the Next line is ${#F107_NEXT_LINE} chars, expected under 450"
+fi
+
+# No-scope path (F003's default fixture scope is small but non-empty; a
+# feature with an empty scope list must still read "no scope defined", not
+# an empty or truncated-looking string) -- guards the caps above from
+# breaking the pre-existing empty-scope fallback.
+DIR_F107_EMPTY_SCOPE="$WORK/f107-empty-scope"
+make_fixture "$DIR_F107_EMPTY_SCOPE"
+install_hooks "$DIR_F107_EMPTY_SCOPE"
+python3 - "$DIR_F107_EMPTY_SCOPE/.harness/features.json" <<'PYEOF'
+import json
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    data = json.load(fh)
+for feature in data["features"]:
+    if feature["id"] == "F003":
+        feature["scope"] = []
+with open(path, "w") as fh:
+    json.dump(data, fh, indent=2)
+    fh.write("\n")
+PYEOF
+STDERR_F107_EMPTY=$(run_hook "$DIR_F107_EMPTY_SCOPE" check-remaining-tasks.sh '{}' 2>&1 1>/dev/null)
+assert_contains "$STDERR_F107_EMPTY" "[scope: no scope defined]" \
+  "f107 (empty scope): the pre-existing empty-scope fallback text is unchanged"
+
+echo ""
 TOTAL=$((PASS_COUNT + FAIL_COUNT))
 echo "Summary: $PASS_COUNT/$TOTAL assertions passed, $FAIL_COUNT failed"
 if [ "$FAIL_COUNT" -gt 0 ]; then

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -11967,10 +11967,10 @@ assert_contains "$DASHBOARD_HTML_SRC" 'translate: -50% -50%;' \
 # block verdict's badge is never displaced by an unrelated allow verdict.
 assert_not_contains "$DASHBOARD_HTML_SRC" 'addBadge(node.badgesEl, "gate", text)' \
   "dash-fe: gate badges are no longer added under one shared \"gate\" kind (a block verdict badge could be silently overwritten by the next allow)"
-assert_contains "$DASHBOARD_HTML_SRC" "function gateBadgeKind(verdict)" \
-  "dash-fe: a gateBadgeKind() function derives a verdict-specific badge kind"
-assert_contains "$DASHBOARD_HTML_SRC" "badge-gate-block" \
-  "dash-fe: page source defines a distinct badge-gate-block kind so a block verdict cannot be silently overwritten by an allow"
+assert_contains "$DASHBOARD_HTML_SRC" "function gateBadgeKind(gate, verdict)" \
+  "dash-fe: a gateBadgeKind() function derives a gate-and-verdict-specific badge kind (F095: keyed on both, not verdict alone)"
+assert_contains "$DASHBOARD_HTML_SRC" '[class$="-block"]' \
+  "dash-fe: page source defines a distinct block-verdict CSS rule so a block verdict cannot be silently overwritten by an allow"
 assert_not_contains "$DASHBOARD_HTML_SRC" ".badge-gate {" \
   "dash-fe: no single shared .badge-gate CSS rule remains (verdict-specific rules replace it)"
 
@@ -13077,6 +13077,40 @@ assert_contains "$DASHBOARD_HTML_SRC" "rec.y = y;" \
 # scale/opacity, never positioning.
 assert_contains "$DASHBOARD_HTML_SRC" 'translate: -50% -50%;' \
   "dash-fe: .node still centers via the standalone CSS translate property"
+
+echo ""
+echo "== F095: dashboard gate badges keyed on gate and verdict =="
+
+# QA binding for F095 is manual (per its own features.json entry): a second
+# adversarial review of the F088-F093 dashboard chain found gate badges keyed
+# on verdict only (gate-<verdict>), so multiple gate scripts (enforce-scope,
+# commit-gate, check-remaining-tasks, verify-task-quality) logging the same
+# verdict in one session share a single DOM badge element and silently
+# overwrite each other's title/finding. This repo's dependency-free
+# bash/python3 runner has no browser/DOM harness, so these are supplementary
+# structural assertions on the exact source pattern, not a rendered result.
+
+assert_contains "$DASHBOARD_HTML_SRC" "function gateBadgeKind(gate, verdict)" \
+  "dash-fe: gateBadgeKind() now takes both gate and verdict"
+assert_contains "$DASHBOARD_HTML_SRC" "gateBadgeKind(payload.gate, payload.verdict)" \
+  "dash-fe: handleGateEvent() passes both payload.gate and payload.verdict to gateBadgeKind()"
+assert_not_contains "$DASHBOARD_HTML_SRC" "gateBadgeKind(verdict)" \
+  "dash-fe: gateBadgeKind() no longer takes verdict alone"
+# The gate name is data from a hook payload, not a fixed enum this page
+# controls, so it must be sanitized the same way verdict already is before
+# becoming part of a class name.
+assert_contains "$DASHBOARD_HTML_SRC" "sanitizeClassFragment(gate)" \
+  "dash-fe: gateBadgeKind() sanitizes the gate name against arbitrary payload data (same routine verdict already uses)"
+assert_contains "$DASHBOARD_HTML_SRC" "sanitizeClassFragment(verdict)" \
+  "dash-fe: gateBadgeKind() sanitizes the verdict through the same routine as the gate name"
+assert_not_contains "$DASHBOARD_HTML_SRC" '.badge.badge-gate-block {' \
+  "dash-fe: no gate-name-agnostic .badge-gate-block CSS rule remains"
+assert_not_contains "$DASHBOARD_HTML_SRC" '.badge.badge-gate-skipped {' \
+  "dash-fe: no gate-name-agnostic .badge-gate-skipped CSS rule remains"
+assert_contains "$DASHBOARD_HTML_SRC" '[class$="-block"]' \
+  "dash-fe: block-verdict CSS rule matches any gate name via a suffix selector"
+assert_contains "$DASHBOARD_HTML_SRC" '[class$="-skipped"]' \
+  "dash-fe: skipped-verdict CSS rule matches any gate name via a suffix selector"
 
 echo ""
 echo "== shell syntax =="

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -13047,6 +13047,94 @@ else
 fi
 
 echo ""
+echo "== F087: readiness-stamp HMAC round-trip (env-var key source) =="
+
+# The readiness-stamp HMAC recipe (schemas/readiness-stamp.md) had no round-trip test
+# anywhere in this repo (OVI-45, re-confirmed 2026-08-04): .harness/harness.json carries
+# no `prep` key, so harness-issue-prep's Step 7 never fires here, and no file under
+# .harness/, MAINTENANCE_LOG.md, or docs/ contains the string "vv-harness-readiness-stamp"
+# -- the mint has never actually run in this repo. This fixture exercises the full
+# documented recipe headlessly via the VV_HARNESS_STAMP_KEY env var (resolution source
+# 3 -- no macOS Keychain needed), against the ACTUAL Step 7 snippet extracted from
+# harness-issue-prep/SKILL.md, not a re-implementation.
+DIR_F087="$WORK/f087-stamp"
+mkdir -p "$DIR_F087"
+python3 - "$REPO_ROOT" "$DIR_F087" <<'PYEOF'
+import re
+import sys
+
+repo_root, work = sys.argv[1], sys.argv[2]
+text = open(f"{repo_root}/skills/harness-issue-prep/SKILL.md").read()
+match = re.search(
+    r'python3 - "\$SPEC_HASH" "\$BASE_SHA" "\$LANE" "\$REPO" <<\'PYEOF\'\n(.*?)\nPYEOF',
+    text, re.DOTALL,
+)
+if not match:
+    print("STEP7_EXTRACT_FAILED")
+    sys.exit(0)
+with open(f"{work}/resolve_and_hmac.py", "w") as fh:
+    fh.write(match.group(1))
+PYEOF
+if [ -f "$DIR_F087/resolve_and_hmac.py" ]; then
+  pass "f087: Step 7's key-resolution+HMAC snippet extracted from harness-issue-prep/SKILL.md"
+else
+  fail "f087: could not extract Step 7's snippet from harness-issue-prep/SKILL.md"
+fi
+
+# env -i with PATH pointed at an empty dir means no `security` binary is reachable --
+# genuinely no Keychain source available, same neutralization as F012's fixture. No
+# VV_HARNESS_STAMP_KEY_FILE is set either, so only source 3 (the env var) can yield a key.
+NOBIN_F087="$DIR_F087/nobin"
+mkdir -p "$NOBIN_F087"
+PYTHON3_BIN_F087=$(command -v python3)
+STAMP_KEY_F087="f087-env-var-key-only-source"
+
+run_stamp_f087() {
+  env -i PATH="$NOBIN_F087" HOME="$HOME" VV_HARNESS_STAMP_KEY="$STAMP_KEY_F087" \
+    "$PYTHON3_BIN_F087" "$DIR_F087/resolve_and_hmac.py" "$@"
+}
+
+# Canonical hashing per schemas/readiness-stamp.md: sha256(title + "\n" + description).
+SPEC_HASH_F087=$(printf 'F087 fixture title\nF087 fixture description' \
+  | python3 -c 'import sys, hashlib; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest())')
+BASE_SHA_F087="f087f087f087f087f087f087f087f087f087f087"
+TAMPERED_BASE_SHA_F087="0000000000000000000000000000000000f087"
+LANE_F087="code"
+REPO_F087="eovidiu/vv-claude-harness"
+
+HMAC_F087=$(run_stamp_f087 "$SPEC_HASH_F087" "$BASE_SHA_F087" "$LANE_F087" "$REPO_F087")
+assert_rc0 "$?" "f087: minting via the real Step 7 snippet with VV_HARNESS_STAMP_KEY (source 3, no Keychain) succeeds"
+
+# Positive round trip: a consumer re-running the identical documented recipe (message
+# spec_hash|base_sha|lane|repo, same key) recomputes the identical HMAC -- consumer
+# verification rule 2 in schemas/readiness-stamp.md.
+HMAC_F087_VERIFY=$(run_stamp_f087 "$SPEC_HASH_F087" "$BASE_SHA_F087" "$LANE_F087" "$REPO_F087")
+if [ -n "$HMAC_F087" ] && [ "$HMAC_F087" = "$HMAC_F087_VERIFY" ]; then
+  pass "f087: minted HMAC round-trips -- recomputing over the same fields and key verifies clean"
+else
+  fail "f087: expected the recomputed HMAC to match the minted one, got '$HMAC_F087' vs '$HMAC_F087_VERIFY'"
+fi
+
+# Negative: spec_hash tampered post-mint (e.g. a post-stamp issue edit) no longer
+# recomputes to the minted HMAC -- consumer rule 2 rejects it.
+BAD_SPEC_HASH_F087=$(printf 'F087 fixture title\nF087 fixture description EDITED' \
+  | python3 -c 'import sys, hashlib; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest())')
+HMAC_F087_BAD_SPEC=$(run_stamp_f087 "$BAD_SPEC_HASH_F087" "$BASE_SHA_F087" "$LANE_F087" "$REPO_F087")
+if [ "$HMAC_F087_BAD_SPEC" != "$HMAC_F087" ]; then
+  pass "f087: a tampered spec_hash fails HMAC verification"
+else
+  fail "f087: a tampered spec_hash should not recompute to the minted HMAC"
+fi
+
+# Negative: base_sha tampered post-mint likewise fails.
+HMAC_F087_BAD_BASE=$(run_stamp_f087 "$SPEC_HASH_F087" "$TAMPERED_BASE_SHA_F087" "$LANE_F087" "$REPO_F087")
+if [ "$HMAC_F087_BAD_BASE" != "$HMAC_F087" ]; then
+  pass "f087: a tampered base_sha fails HMAC verification"
+else
+  fail "f087: a tampered base_sha should not recompute to the minted HMAC"
+fi
+
+echo ""
 echo "== shell syntax =="
 
 for SCRIPT in "$HOOKS_DIR"/*.sh "$SCRIPT_DIR/run-tests.sh" "$REPO_ROOT/scripts/stamp.sh"; do


### PR DESCRIPTION
## What changed

All 8 remaining pending features, implemented by 6 parallel worktree agents and merged sequentially, plus one adversarial-review round over the combined diff (16 confirmed findings, all fixed).

- **F108** — harness-doctor detects a `focused_test`-supporting `init.sh` that predates the v5.5.0 exit-3 skip contract; report-only, hand-apply repair. Review round hardened it: markers checked on non-comment lines, leftover `treating as pass` arms positively detected (partial hand-apply no longer clears). SKILL.md + INSTALL.md updated.
- **F096** — `enforce-scope.sh`/`commit-gate.sh` (and templates) feed `$COMMAND` to the analysis python via stdin (remaining ARG_MAX call site); `DENY_REASON` capped. Review round found and fixed a third instance: commit-gate's passing-flip deny reason interpolated an unbounded `full_test` tail, which could blow argv and silently convert the DENY into an ALLOW (live-reproduced).
- **F097** — `session-start.sh` measures its actual total orientation length against the 10k platform cap (additive to per-section budgets); the rule-pointer footer is built separately so truncation can't drop it.
- **F107** — `check-remaining-tasks.sh` reassignment message gets the F071/F085 description/scope caps; review round made the formatter null-safe (an explicitly-null description previously crashed it and suppressed the exit-2 nudge).
- **F094/F095** — dashboard ring positioning moved off `transform` (anime.js owns it exclusively now); gate badges keyed per gate+verdict so findings stop overwriting each other.
- **F087** — readiness-stamp HMAC round-trip test via the `VV_HARNESS_STAMP_KEY` env-var source, with an independent schema-recipe oracle and spec_hash/base_sha/lane/repo/key tamper negatives. `prep.stamp` deliberately left unconfigured.
- **F098** — no source change needed (consolidation had already landed in 6f85267); a behavioral test now pins the single-spawn property via a PATH-shimmed python3 logger.

Version bumped to 5.6.0 with a CHANGELOG entry; features.json flipped to passing with per-feature coverage notes.

## Testing

Full suite green after every merge and after the review round: 2059/2059 assertions (from 1979 on main). Every feature was TDD'd red-then-green in its worktree; review-round fixes each carry their own regression test.