### PR TITLE
v5.7.0: OVI-140 Agent Teams → Dynamic Workflows migration, Phases 0–2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vv-harness",
   "displayName": "VV Claude Code Harness",
-  "version": "5.6.1",
+  "version": "5.7.0",
   "description": "Multi-session continuity, parallel Agent Teams coordination, and mechanical quality enforcement for Claude Code.",
   "author": {
     "name": "oeftimie",

--- a/.harness/claude-progress.txt
+++ b/.harness/claude-progress.txt
@@ -1110,3 +1110,20 @@ Session 2026-08-08 (F100-F104, v5.4.0 release):
   positive filed as its own candidate row (not fixed).
 - Next: nothing pending. The push-guard row is the only open candidate.
 - Blockers: none.
+
+## Session 2026-08-10 (OVI-140 Phases 0-2 -> v5.7.0)
+- Feature: F110 (Phase 0 spikes + eval), F111/F112 (workflow scripts),
+  F113 (harness-continue workflow mode). Roles per Ovidiu: Fable planner,
+  Opus review, Sonnet execute.
+- Status: complete; suite 2144/2144; v5.7.0.
+- Decisions: workflow mode primary, Teams demoted to Step 5c (not
+  retired -- Phases 3-6 remain). args is a JSON string. Reviewer runs
+  Opus + reads diff (reviewer.md wins over OVI-142's Sonnet/spec-only
+  wording; F017 is the conformance-tester's). Adversarial review fixed
+  20 confirmed findings pre-release; added the suite's first executable
+  (node-guarded) coverage after a review found grep-only tests let script
+  bugs ship green. Details in context_summary.md Meta-Session 2026-08-10.
+- Next: OVI-140 Phase 3 (retire Teams machinery) onward -- a fresh
+  session, after this release. Open backlog item: lint for grep-only
+  tests over executable code.
+- Blockers: none.

--- a/.harness/context_summary.md
+++ b/.harness/context_summary.md
@@ -4,6 +4,7 @@ Persistent record of architectural decisions, discovered patterns, gotchas, and 
 This file is referenced in CLAUDE.md and loaded every session.
 
 ## Active Context
+- **v5.7.0 released 2026-08-10 (F110-F113): OVI-140 Agent Teams -> Dynamic Workflows migration, Phases 0-2.** Workflow mode is now the primary parallel path in harness-continue; Agent Teams demoted to legacy Step 5c (retirement is a later phase, the rollback boundary). Phase 0 empirically de-risked the swap (evals/workflow-gate-verification.md, 8 grounded verdicts): hooks fire for worktree workflow agents via the CLAUDE_PROJECT_DIR-unset git-toplevel fallback (flagged fragile for doctor), args arrives as a JSON STRING (scripts JSON.parse). Shipped workflows/implement-features.js + review-branch.js. One adversarial-review round fixed 20 confirmed findings BEFORE release -- the load-bearing lesson: the first test pass was 100% source greps and let a severity-rank inversion and an un-interpolated <mergeBase> ship green; now backed by node-guarded EXECUTABLE helper coverage. Suite 2144/2144. Phases 3-6 (retire Teams, rules/docs rewrite, dashboard, field validation) remain in OVI-140.
 - **v5.6.1 released 2026-08-09 (F109): commit-gate redirection fix.** The F052 bare-pathspec rule misread unquoted shell redirections after `git commit` as pathspecs (`git commit --no-edit 2>&1` denied as compound-stage-and-commit -- the false positive logged during the v5.6.0 merges; the initial backlog diagnosis blaming && chains was wrong and is corrected there). Fix skips genuine redirections deciding on the RAW token only (quoted `'2>&1'` still denies; F034 bypass shapes still deny); raw tokens now ride through parse_command for that one decision. Suite 2070/2070. The push guard's tag-push-while-on-main block is a separate, still-open backlog row.
 - **v5.6.0 released 2026-08-09 (F087, F094-F098, F107, F108): the ENTIRE remaining backlog cleared in one dynamic-workflow batch.** Six worktree-isolated implementer agents in parallel (one Workflow call), lead merged their branches sequentially into eovidiu/remaining-8 with union conflict resolution on test/run-tests.sh, then a 3-reviewer + adversarial-verify workflow over the combined diff found 16 confirmed findings (all fixed in one review-round commit): the standouts were commit-gate's unbounded $FULL_TAIL converting a passing-flip DENY into a silent ALLOW (live-reproduced), F107's null-description crash suppressing the exit-2 nudge, and F097's truncation cutting the very rule pointers it protects. F098 needed no source change (commit 6f85267 had already landed the consolidation; a behavioral spawn-count test now pins it). F087's prep.stamp config remains deliberately unconfigured (Ovidiu's 2026-08-04 deferral stands). Suite 2059/2059. ZERO pending features remain in features.json -- new work needs fresh scoping. portage-curator still needs `/plugin` update + `/harness-doctor --fix` in its own session.
 - **v5.5.0 released 2026-08-09 (F085, F105, F106): review follow-through.** Exit-3 skip protocol for focused_test (a skip is never a green), not-run baseline keys dropped from last_gate.json (reached-and-unconfigured only; ordering skips preserve), orientation scope field capped. F086 was found already passing (stale handoff). NO pending features remain in features.json -- per the standing guidance below, new work needs fresh scoping, not an assumed queue. portage-curator still needs `/plugin` update + `/harness-doctor --fix` in its own session.
@@ -1795,3 +1796,45 @@ session-end.sh at the next SessionStart.
 - Plan approval: none used (standing "work the remaining items" instruction);
   self-serve resolution disclosed per-feature in features.json notes.
 - Test growth: 1979 -> 2059 assertions across eight features + one review round.
+
+## Meta-Session 2026-08-10 (OVI-140 Phases 0-2 -> v5.7.0)
+- Scope accuracy: authoring the two workflow scripts DIRECTLY (not via
+  implementer subagents) was right -- they are single-file artifacts that
+  encode all the spec-gate resolutions and Phase 0 constraints at once;
+  a subagent would have lost that cross-cutting context. But it removed
+  the built-in review a delegated implementer's own TDD provides, which
+  is exactly why the adversarial-review round found 20 real bugs.
+- Model calibration: Fable planner / Opus review / Sonnet execute worked
+  as instructed. The Opus review pair (+ verify) was the entire quality
+  buy: every one of the 20 confirmed defects was in code the planner
+  wrote and the grep-tests passed. Reviewers >> author self-review.
+- Discovery lineage: the biggest finding (no executable coverage) was
+  META -- it explained WHY the other script bugs shipped green. Fixing it
+  (node-guarded prefix-slice execution of the pure helpers) retroactively
+  catches the severity-inversion and classification bugs. When a review
+  finds "the tests can't catch this class," fix the test harness first.
+- Approach patterns: (1) spec-verification returned ASK on both phase
+  specs; self-resolving under the standing instruction and recording each
+  resolution in the feature's own notes kept the trail auditable. (2)
+  Two grep assertions straddled a line-wrap and failed -- the recurring
+  wrapped-phrase gotcha; matched un-wrapped fragments instead. (3) A
+  `git worktree remove` deleted the shell's own cwd mid-command; cd back
+  to repo root to recover.
+- Plan-vs-reviewer.md conflict: OVI-142 said "Sonnet reviewer, spec-only
+  (F017)"; reviewer.md says model:opus and the reviewer legitimately
+  reads the diff (F017 author-blindness is the conformance-tester's).
+  Resolved in favor of reviewer.md -- reviewer runs Opus, reads the diff,
+  never the implementer's notes. Documented in F111 notes.
+- Test growth: 2070 -> 2144 assertions (incl. 15 node-executed helper
+  assertions -- the suite's first executable coverage of JS, node-guarded
+  so the dependency-free contract holds when node is absent).
+
+## Meta-Patterns
+- Source-grep-only tests for executable code are a false safety net: they
+  pass against inverted logic and syntax errors. When a diff adds a real
+  program (not just prose/config), add executed coverage of its pure
+  helpers, guarded on the interpreter's presence so the dependency-free
+  contract survives. (backlog)
+- When an adversarial review finds "the test suite structurally cannot
+  detect this defect class," that meta-finding outranks the individual
+  bugs -- fix the harness before re-verifying. (backlog)

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -3056,6 +3056,86 @@
       "approaches_tried": [
         "Bisected the live denial to the redirection token (chains/pipes were innocent -- segmentation handles them). _flag_view strips quotes, so the quoted-pathspec vs redirection distinction required threading raw_tokens through parse_command's tuples into has_staging_flag."
       ]
+    },
+    {
+      "id": "F110",
+      "priority": 110,
+      "status": "in-progress",
+      "description": "Phase 0 (OVI-141): empirically verify gate/hook/worktree behavior under Dynamic Workflow agents before any migration code. Deliverable: evals/workflow-gate-verification.md with a grounded verdict (VERIFIED-YES/NO/PARTIAL) + reproduction for all 8 questions, and a go/no-go. Acceptance: no plugin-source changes (evals/ + .harness/ only); probe worktrees cleaned up.",
+      "scope": [
+        "evals/workflow-gate-verification.md",
+        ".harness/context_summary.md"
+      ],
+      "depends_on": [],
+      "assigned_to": "single-session",
+      "test_file": "evals/workflow-gate-verification.md",
+      "coverage": null,
+      "discovered_via": null,
+      "linear": "OVI-141",
+      "approaches_tried": [],
+      "notes": "Spikes ran against this repo with worktree isolation (a toy project can't exercise the launch project's hooks from this session). GO verdict: enforcement hooks fire for workflow agents, so OVI-140's hard-gate escape (move enforcement into script verify phases) is NOT triggered."
+    },
+    {
+      "id": "F111",
+      "priority": 111,
+      "status": "pending",
+      "description": "Phase 1a (OVI-142 WP1.1): ship workflows/implement-features.js in the plugin. Parameterized by args (JSON-STRING per Phase 0 Q7 -- script MUST JSON.parse defensively). meta pure-literal {name,description,phases}; no Date.now/Math.random/new Date/import. Preflight (no agent): parse args, validate features is a non-empty array, fail fast otherwise. Implement phase: pipeline over features, one implementer per feature, model sonnet, isolation worktree, prompt carries the feature's spec+scope+TDD+deliverable contract; structured schema {feature_id,status(implemented|blocked),files_changed[],test_file,tests_run{passed,failed},worktree_branch,notes}. Review phase (same pipeline, next stage): reviewer per feature reading spec + the worktree branch's own diff but NEVER the implementer's notes/approaches (author-blindness applies to the implementer's RATIONALE, not the code -- the reviewer legitimately reads the diff); returns {feature_id,verdict(APPROVE|REVISE|REJECT),findings[],rounds_used}. The script NEVER merges/commits/edits features.json -- integration is the lead's so gates fire in the lead session. Run-continuity per OVI-140: agent() null -> filter(Boolean), return a structured partial naming unfinished feature IDs; prompts derived from args only (resume cache-stability).",
+      "scope": [
+        "workflows/implement-features.js",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F110"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "discovered_via": null,
+      "linear": "OVI-142",
+      "approaches_tried": [],
+      "notes": "SPEC RESOLUTIONS (spec-verification returned ASK; resolved under the standing don't-stop instruction, disclosed here): (Q-args) args is a JSON string -> JSON.parse. (Q-reviewer-input) reviewer gets spec+diff, not implementer notes; OVI-142's 'spec-only, preserves F017' mis-attributed -- F017 author-blindness is the CONFORMANCE-tester's, not the reviewer's. (Q-reviewer-model) reviewer runs opus via agentType frontmatter (reviewer.md model:opus), NOT sonnet -- resolves the OVI-142-vs-reviewer.md conflict in favor of reviewer.md and Ovidiu's 'opus-as-orchestrator' mapping; reviewModel arg is an optional downgrade knob. (Q-fix-step) the review loop RETURNS verdicts; FIXES are applied by the lead, not by in-workflow agents editing merged code in parallel worktrees (per OVI-140's corrected review-loop row) -- supersedes OVI-142's 'loop review->fix->re-review' wording. (Q-blocked) a blocked implementer short-circuits its own review; other features proceed. (Q-concurrency) platform caps at min(16,cores-2); batches sized <15. (Q-spec-source) each feature's spec text is passed IN via args by the lead (script gets no file access it needs); args.featureSpecs maps id->{spec,scope,risk}."
+    },
+    {
+      "id": "F112",
+      "priority": 112,
+      "status": "pending",
+      "description": "Phase 1b (OVI-142 WP1.2): ship workflows/review-branch.js -- a thin review-only workflow for re-reviewing an existing branch/diff. args (JSON-string, parsed): {diffScope|branch, features?[], conformance?:bool}. Fan a reviewer over the diff scope, optionally a conformance-tester per feature (spec-only, author-blind per F017), dedup findings by file+line+claim at a barrier BEFORE an adversarial-verify fan-out (OVI-140 improvement), return ranked verdicts {file,line,claim,severity,verdict}. Same meta/forbidden-call conventions and structured-output schemas as F111. Used by Phase 6 field validation and the lead's fix-and-recheck loop.",
+      "scope": [
+        "workflows/review-branch.js",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F111"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "discovered_via": null,
+      "linear": "OVI-142",
+      "approaches_tried": [],
+      "notes": "Dedup-before-verify barrier is the concrete lesson from the 2026-08-09 review run (wf_62aae2ac-e3b) where 3 dimensions re-reported the same defects and each copy was verified separately."
+    },
+    {
+      "id": "F113",
+      "priority": 113,
+      "status": "pending",
+      "description": "Phase 2 (OVI-143): rewire skills/harness-continue/SKILL.md so the parallel path orchestrates via the implement-features workflow, Teams demoted-not-deleted (removed in Phase 3). Step 4 becomes a THREE-way mode decision: single-session (default; 1 feature / sequential / <5 files); workflow mode (new primary parallel: 2+ independent verified features, where independent = empty depends_on AND non-overlapping scope); peer-debate exception (competing-hypothesis research -> plain parallel subagents). Availability probe (Phase 0 Q8): on version<2.1.154 or Workflow tool absent, fall back to the existing worktree-isolated plain-subagent path (repoint the current graceful-degradation clause, don't duplicate). Step 5b workflow orchestration flow (lead, in ORDER): confirm each candidate has a verified spec (exclude unverified); mirror each feature into TaskCreate WITH metadata.feature_id (mandatory -- arms the TaskCompleted focused/coverage stages per Phase 0 Q2); launch with args carrying feature specs; on return integrate PER FEATURE in the order run-focused+smoke -> merge -> flip features.json status -> mark task complete (gate fires) -> commit (add+commit separate calls); remove the changed worktree after merge before any repo-wide suite (Phase 0 Q4); blocked/REJECT/rounds-exhausted results surfaced to Ovidiu, never auto-merged. WP2.3: replace team-spawn-prompts.md content with workflow prompt+schema templates and a pre-LAUNCH checklist (specs verified, tasks mirrored WITH feature_id, branch clean, git fetch+rebase). Tests: doc-assertions for the three-way decision, mandatory feature_id mirroring, the integration ORDER (test before merge before status-flip before task-complete before commit), fallback-to-plain-subagents, and NO instruction to edit features.json before tests pass; existing Teams assertions updated not deleted.",
+      "scope": [
+        "skills/harness-continue/SKILL.md",
+        "skills/harness-continue/team-spawn-prompts.md",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [
+        "F111",
+        "F112"
+      ],
+      "assigned_to": null,
+      "test_file": null,
+      "coverage": null,
+      "discovered_via": null,
+      "linear": "OVI-143",
+      "approaches_tried": [],
+      "notes": "SPEC RESOLUTIONS (spec-verification ASK, self-resolved+disclosed): line refs 104-148 drifted -> locate by heading not number. 'independent' := empty depends_on AND non-overlapping scope. single-vs-workflow tie (2 independent <5-file features): workflow mode wins (parallel gain > single-session simplicity once 2 verified independent features exist). AC1 'both gates' = commit-gate.sh + verify-task-quality.sh, observed on the Phase-2 toy run (also closes Phase 0 Q2's focused-stage PARTIAL on a focused_test-capable project). team-spawn-prompts.md keeps a Teams section until Phase 3; SKILL.md's Step 5b Teams pointer stays valid. teammate-scope.txt NOT needed in workflow mode (worktree isolation is physical)."
     }
   ]
 }

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -3060,25 +3060,27 @@
     {
       "id": "F110",
       "priority": 110,
-      "status": "in-progress",
+      "status": "passing",
       "description": "Phase 0 (OVI-141): empirically verify gate/hook/worktree behavior under Dynamic Workflow agents before any migration code. Deliverable: evals/workflow-gate-verification.md with a grounded verdict (VERIFIED-YES/NO/PARTIAL) + reproduction for all 8 questions, and a go/no-go. Acceptance: no plugin-source changes (evals/ + .harness/ only); probe worktrees cleaned up.",
       "scope": [
         "evals/workflow-gate-verification.md",
         ".harness/context_summary.md"
       ],
       "depends_on": [],
-      "assigned_to": "single-session",
+      "assigned_to": null,
       "test_file": "evals/workflow-gate-verification.md",
-      "coverage": null,
+      "coverage": "Deliverable is evals/workflow-gate-verification.md: all 8 Phase 0 questions carry grounded verdicts (VERIFIED-YES/PARTIAL) with cited workflow-run IDs; probe worktrees cleaned up; GO recorded. Context persisted in this session's Meta-Session + the eval doc.",
       "discovered_via": null,
       "linear": "OVI-141",
-      "approaches_tried": [],
+      "approaches_tried": [
+        "Spikes ran against this repo with worktree isolation (a toy project can't exercise the launch project's hooks from this session); disclosed as a deviation in the eval doc."
+      ],
       "notes": "Spikes ran against this repo with worktree isolation (a toy project can't exercise the launch project's hooks from this session). GO verdict: enforcement hooks fire for workflow agents, so OVI-140's hard-gate escape (move enforcement into script verify phases) is NOT triggered."
     },
     {
       "id": "F111",
       "priority": 111,
-      "status": "pending",
+      "status": "passing",
       "description": "Phase 1a (OVI-142 WP1.1): ship workflows/implement-features.js in the plugin. Parameterized by args (JSON-STRING per Phase 0 Q7 -- script MUST JSON.parse defensively). meta pure-literal {name,description,phases}; no Date.now/Math.random/new Date/import. Preflight (no agent): parse args, validate features is a non-empty array, fail fast otherwise. Implement phase: pipeline over features, one implementer per feature, model sonnet, isolation worktree, prompt carries the feature's spec+scope+TDD+deliverable contract; structured schema {feature_id,status(implemented|blocked),files_changed[],test_file,tests_run{passed,failed},worktree_branch,notes}. Review phase (same pipeline, next stage): reviewer per feature reading spec + the worktree branch's own diff but NEVER the implementer's notes/approaches (author-blindness applies to the implementer's RATIONALE, not the code -- the reviewer legitimately reads the diff); returns {feature_id,verdict(APPROVE|REVISE|REJECT),findings[],rounds_used}. The script NEVER merges/commits/edits features.json -- integration is the lead's so gates fire in the lead session. Run-continuity per OVI-140: agent() null -> filter(Boolean), return a structured partial naming unfinished feature IDs; prompts derived from args only (resume cache-stability).",
       "scope": [
         "workflows/implement-features.js",
@@ -3088,17 +3090,19 @@
         "F110"
       ],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
+      "test_file": "test/run-tests.sh",
+      "coverage": "Structural assertions + node-guarded EXECUTABLE tests of the pure helpers (parseArgs, classifyOutcome) proven to catch the classification bugs; node --check + node execution both green. Full suite 2144/2144. Review round 1 fixed 6 confirmed script bugs (mergeBase placeholder, inert maxReviewRounds removed, risk made live, dead-reviewer unreviewed outcome) -- see the review-round commit.",
       "discovered_via": null,
       "linear": "OVI-142",
-      "approaches_tried": [],
+      "approaches_tried": [
+        "Authored directly (single-file artifact holding all spec resolutions + Phase 0 constraints); adversarial review caught bugs the grep-only tests missed, motivating the executable-coverage harness."
+      ],
       "notes": "SPEC RESOLUTIONS (spec-verification returned ASK; resolved under the standing don't-stop instruction, disclosed here): (Q-args) args is a JSON string -> JSON.parse. (Q-reviewer-input) reviewer gets spec+diff, not implementer notes; OVI-142's 'spec-only, preserves F017' mis-attributed -- F017 author-blindness is the CONFORMANCE-tester's, not the reviewer's. (Q-reviewer-model) reviewer runs opus via agentType frontmatter (reviewer.md model:opus), NOT sonnet -- resolves the OVI-142-vs-reviewer.md conflict in favor of reviewer.md and Ovidiu's 'opus-as-orchestrator' mapping; reviewModel arg is an optional downgrade knob. (Q-fix-step) the review loop RETURNS verdicts; FIXES are applied by the lead, not by in-workflow agents editing merged code in parallel worktrees (per OVI-140's corrected review-loop row) -- supersedes OVI-142's 'loop review->fix->re-review' wording. (Q-blocked) a blocked implementer short-circuits its own review; other features proceed. (Q-concurrency) platform caps at min(16,cores-2); batches sized <15. (Q-spec-source) each feature's spec text is passed IN via args by the lead (script gets no file access it needs); args.featureSpecs maps id->{spec,scope,risk}."
     },
     {
       "id": "F112",
       "priority": 112,
-      "status": "pending",
+      "status": "passing",
       "description": "Phase 1b (OVI-142 WP1.2): ship workflows/review-branch.js -- a thin review-only workflow for re-reviewing an existing branch/diff. args (JSON-string, parsed): {diffScope|branch, features?[], conformance?:bool}. Fan a reviewer over the diff scope, optionally a conformance-tester per feature (spec-only, author-blind per F017), dedup findings by file+line+claim at a barrier BEFORE an adversarial-verify fan-out (OVI-140 improvement), return ranked verdicts {file,line,claim,severity,verdict}. Same meta/forbidden-call conventions and structured-output schemas as F111. Used by Phase 6 field validation and the lead's fix-and-recheck loop.",
       "scope": [
         "workflows/review-branch.js",
@@ -3108,8 +3112,8 @@
         "F111"
       ],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
+      "test_file": "test/run-tests.sh",
+      "coverage": "Structural + node-executed helper tests (severityScore ordering, dedupeKey/mergeFindings). The executable severity test demonstrably fails on the original (rank || 3) bug. Review round 1 fixed the severity inversion, conformance silent-no-op, read-only-vs-write-capable-conformance, partial-result contract, dedup-keeps-max-severity, and dimensions validation.",
       "discovered_via": null,
       "linear": "OVI-142",
       "approaches_tried": [],
@@ -3118,7 +3122,7 @@
     {
       "id": "F113",
       "priority": 113,
-      "status": "pending",
+      "status": "passing",
       "description": "Phase 2 (OVI-143): rewire skills/harness-continue/SKILL.md so the parallel path orchestrates via the implement-features workflow, Teams demoted-not-deleted (removed in Phase 3). Step 4 becomes a THREE-way mode decision: single-session (default; 1 feature / sequential / <5 files); workflow mode (new primary parallel: 2+ independent verified features, where independent = empty depends_on AND non-overlapping scope); peer-debate exception (competing-hypothesis research -> plain parallel subagents). Availability probe (Phase 0 Q8): on version<2.1.154 or Workflow tool absent, fall back to the existing worktree-isolated plain-subagent path (repoint the current graceful-degradation clause, don't duplicate). Step 5b workflow orchestration flow (lead, in ORDER): confirm each candidate has a verified spec (exclude unverified); mirror each feature into TaskCreate WITH metadata.feature_id (mandatory -- arms the TaskCompleted focused/coverage stages per Phase 0 Q2); launch with args carrying feature specs; on return integrate PER FEATURE in the order run-focused+smoke -> merge -> flip features.json status -> mark task complete (gate fires) -> commit (add+commit separate calls); remove the changed worktree after merge before any repo-wide suite (Phase 0 Q4); blocked/REJECT/rounds-exhausted results surfaced to Ovidiu, never auto-merged. WP2.3: replace team-spawn-prompts.md content with workflow prompt+schema templates and a pre-LAUNCH checklist (specs verified, tasks mirrored WITH feature_id, branch clean, git fetch+rebase). Tests: doc-assertions for the three-way decision, mandatory feature_id mirroring, the integration ORDER (test before merge before status-flip before task-complete before commit), fallback-to-plain-subagents, and NO instruction to edit features.json before tests pass; existing Teams assertions updated not deleted.",
       "scope": [
         "skills/harness-continue/SKILL.md",
@@ -3130,8 +3134,8 @@
         "F112"
       ],
       "assigned_to": null,
-      "test_file": null,
-      "coverage": null,
+      "test_file": "test/run-tests.sh",
+      "coverage": "16 doc-assertions incl. a python token-order check pinning all five integration steps (test -> merge -> status -> task-complete -> commit). Review round 1 corrected the 'feature_id or stages go inert' overclaim (subject-prefix fallback exists but is fragile).",
       "discovered_via": null,
       "linear": "OVI-143",
       "approaches_tried": [],

--- a/.harness/mld/2026-08-10-cc88f3b9-bfd7-40cb-be41-c54a79e95581.md
+++ b/.harness/mld/2026-08-10-cc88f3b9-bfd7-40cb-be41-c54a79e95581.md
@@ -1,0 +1,38 @@
+# MLD 2026-08-10 (session cc88f3b9-bfd7-40cb-be41-c54a79e95581)
+
+Continuation of the 2026-08-09 session (same session id) — OVI-140 Phases 0–2.
+
+## Mistakes
+- Shipped both workflow scripts with a test pass that was 100% source greps; an
+  adversarial review then found 20 confirmed bugs in that same code, including a
+  severity-rank inversion (`rank || 3` maps critical→3) and an un-interpolated
+  `<mergeBase>` placeholder in the reviewer prompt. The tests passed against all of it.
+- Two doc-assertions matched phrases that straddle a line-wrap and failed on first run
+  (the recurring wrapped-phrase gotcha — already a known memory).
+- A `git worktree remove` of the probe worktrees deleted the shell's own cwd mid-command,
+  orphaning it (`fatal: Unable to read current working directory`); had to cd back.
+- First tried a `VV_WORKFLOW_EXPORT` sentinel to make the scripts importable for tests;
+  it can't work — the scripts' required top-level `return` makes them un-importable as
+  plain ESM regardless. Switched to slicing the helper prefix (above the run marker) into
+  a temp module.
+
+## Learnings
+- The Opus review + adversarial-verify pass was the entire quality buy this session:
+  every confirmed defect was in code the planner authored and the grep-tests passed.
+  Author self-review does not substitute for an independent adversarial reviewer.
+- A meta-finding ("the tests structurally can't catch this class") outranks the
+  individual bugs — fixing the harness (executable helper coverage) retroactively catches
+  them and prevents recurrence.
+- Workflow scripts must use top-level `return` (the runtime wraps them), which makes them
+  invalid as standalone ESM/CJS. To unit-test their pure helpers, slice the prefix above
+  the `// ---- run` marker (declarations only, no return/await) into a temp `.mjs`.
+- args reaches a workflow script as a JSON **string** on CLI 2.1.226 — confirmed by a
+  one-line probe workflow. Design around it (`JSON.parse` defensively).
+
+## Desires
+- A lint/CI step that flags a test block asserting only `assert_contains`/`grep` over a
+  file that is executable code — the exact gap that let the script bugs ship green.
+- A way to run a plugin `workflows/` script by its `/vv-harness:<name>` command in-repo
+  before release, to close Phase 0 Q7's PARTIAL (auto-discovery) without a full install.
+- The commit-gate's `full_test` timeout budget surfaced to the lead — an N-feature
+  passing-flip run invokes the whole suite N times inside a fail-open PreToolUse hook.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 Version history for the VV Claude Code Harness. The current version lives in `.claude-plugin/plugin.json`.
 
+### v5.7.0 (2026-08-10)
+
+**Agent Teams → Dynamic Workflows migration, Phases 0–2 (OVI-140).** Workflow mode
+becomes the primary parallel path; Agent Teams is demoted, not yet removed (its
+retirement is a later phase — this release is additive and the rollback boundary holds).
+
+1. **Phase 0 verification (F110/OVI-141)** — `evals/workflow-gate-verification.md`
+   records grounded verdicts for all 8 spike questions. Established empirically:
+   PreToolUse gates and the secret scan fire for worktree workflow agents (via the
+   `CLAUDE_PROJECT_DIR`-unset git-toplevel fallback — a fragility flagged for doctor);
+   `TaskCompleted` fires on lead self-completion; `SubagentStart`/`Stop` reach hooks
+   with `agent_id`/`agent_type`; unchanged worktrees auto-remove while changed ones need
+   lead cleanup; `acceptEdits` coexists with exit-2 denies; and `args` arrives as a
+   JSON **string** (scripts must `JSON.parse`).
+2. **Workflow scripts (F111/F112/OVI-142)** — `workflows/implement-features.js` (one
+   Sonnet implementer per feature in an isolated worktree, then an Opus reviewer over
+   the branch diff; returns per-feature results with a partial-result/`unfinished`
+   contract; never merges, commits, or edits `features.json`) and
+   `workflows/review-branch.js` (fan reviewers, dedup findings before an adversarial
+   verify pass, ranked confirmed verdicts, optional author-blind conformance). Covered
+   by structural assertions plus node-guarded **executable** tests of the pure helpers.
+3. **harness-continue workflow mode (F113/OVI-143)** — Step 4 is now a three-way mode
+   decision (single-session / workflow / peer-debate) with an availability probe and a
+   plain-subagent fallback; a new Step 5b orchestration flow pins the integration order
+   (local tests → merge → status flip → task complete → commit), mandatory
+   `feature_id`-carrying task mirroring, worktree hygiene, and resume of unfinished
+   runs. Agent Teams is retained as Step 5c (legacy).
+
+One adversarial-review round over the combined diff fixed 20 confirmed findings in the
+new scripts and tests before release (severity-rank inversion, an un-interpolated
+`<mergeBase>`, silent conformance no-ops, dead-agent accounting, and the grep-only tests
+that let those ship green — now backed by executed helper coverage).
+
 ### v5.6.1 (2026-08-09)
 
 One commit-gate fix (F109): shell redirections after `git commit` are no longer

--- a/evals/workflow-gate-verification.md
+++ b/evals/workflow-gate-verification.md
@@ -57,10 +57,12 @@ self-completed task in a non-Teams session and ran `smoke_test`.
   the Phase 2 toy-project run (OVI-143 AC1). The gate mechanism itself is VERIFIED-YES;
   only the focused branch is unexercised on this repo.
 - **Correlation caveat (grounds a Phase 2 test)**: the focused/coverage stages key on
-  `metadata.task.metadata.feature_id` (`verify-task-quality.sh:143-145`). A mirrored
-  task created *without* `feature_id` passes the "one task per feature" instruction
-  while leaving those stages inert — so "mirror with `feature_id`" must be a hard,
-  tested step in the workflow-protocol rule, not prose.
+  the task's `feature_id` (`verify-task-quality.sh` reads `task.metadata.feature_id`,
+  then falls back to parsing an `FXXX:` prefix off the task subject). A mirrored task
+  with neither an explicit `feature_id` nor a house-style `FXXX:` subject skips those
+  stages — so "mirror with an explicit `feature_id`" must be a documented step, with the
+  subject fallback called out as fragile (not relied on). This is a design caveat, not a
+  Phase-0 empirical result: Q2 exercised only the with-`feature_id` case (F109).
 
 ## Q3 — SubagentStart/SubagentStop reach plugin hooks · VERIFIED-YES
 
@@ -136,8 +138,9 @@ into OVI-140's improved plan and carried into the Phase-1 feature specs):
 1. Scripts `JSON.parse(args)` defensively (Q7) — non-negotiable.
 2. Worktree hygiene (lead removes changed worktrees post-merge, before suite) is a
    written rule step, not tribal knowledge (Q4).
-3. Mirrored tasks must carry `metadata.feature_id` or the focused/coverage gate stages
-   go inert (Q2) — a tested requirement.
+3. Mirrored tasks should carry an explicit `metadata.feature_id` to arm the
+   focused/coverage gate stages (Q2); the `FXXX:` task-subject fallback exists but is
+   fragile, so the requirement is documented, not relied on.
 4. Enforcement (Q1) is confirmed present, so OVI-140's hard-gate condition ("if Q1 or
    Q2 is VERIFIED-NO, move enforcement into script verify phases") is **not** triggered
    — hooks stay the enforcement layer. Flag the `CLAUDE_PROJECT_DIR`-unset dependency

--- a/evals/workflow-gate-verification.md
+++ b/evals/workflow-gate-verification.md
@@ -1,0 +1,147 @@
+# Eval: Workflow-mode gate & hook verification (OVI-141, Phase 0)
+
+Empirical de-risking of the Agent Teams → Dynamic Workflows migration (OVI-140).
+Every verdict below is grounded in an observed run this session (workflow run IDs
+cited), not in documentation. Where a claim could not be exercised from a plugin-repo
+session, it is marked PARTIAL with the reason and the deferred validation point.
+
+**Environment**: Claude Code 2.1.226, macOS, `/bin/bash` 3.2 for hooks. Spikes ran as
+`Workflow` runs against this repo itself with `isolation: 'worktree'` as the disposable
+surface. A separate `/harness-init` toy project was **not** used: PreToolUse/TaskCompleted
+hooks bind to the *launch* project (`CLAUDE_PROJECT_DIR` / settings.json of the session
+that started), so a toy project opened from this session cannot exercise this session's
+hooks — the plugin repo's own live hooks are the correct surface, and worktree isolation
+kept every probe write off the main checkout. Deviation from OVI-141's "toy project"
+instruction, recorded here per the grounding rule.
+
+## Q1 — PreToolUse gates fire for workflow-spawned subagents · VERIFIED-YES
+
+Run `wf_fb726f39-06a` (3 parallel probes) and `wf_07bd5d47-c4e` (secret-scan probe).
+
+- **commit-gate.sh**: a compound `git add X && git commit` was **DENIED** with the
+  `compound-stage-and-commit` reason both in an isolated worktree agent and in a
+  main-checkout agent. The split form (`git add` then a separate `git commit`)
+  **succeeded** in the worktree (commit `94b56d3`). So the gate fires for workflow
+  agents and its exit-2 deny blocks the tool call (also answers Q5).
+- **Secret scan sees the correct index**: a worktree agent staged a synthetic
+  `sk-ant-` + 20×`a` fixture line and attempted commit → **DENIED**, "anthropic key
+  (sk-ant-) (staged diff line 7)". The gate scanned the *worktree's* index, not the
+  launch checkout's.
+- **`CLAUDE_PROJECT_DIR` is empty inside workflow agents** (confirmed via
+  `printenv CLAUDE_PROJECT_DIR` → exit 1). The hooks resolve
+  `PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"`
+  (`commit-gate.sh:179`, `verify-task-quality.sh:30`), so with the env unset the
+  git-toplevel fallback resolves to the **worktree** — which is why the worktree index
+  was the one scanned.
+
+  **Load-bearing fragility (flag for the workflow-protocol rule)**: this correct
+  behavior depends on `CLAUDE_PROJECT_DIR` being *unset* for workflow agents. A manual
+  control — invoking `commit-gate.sh` with `CLAUDE_PROJECT_DIR` **set** to the launch
+  root while cwd was the worktree — returned `rc=0` (allow), because `PROJECT_ROOT`
+  then pointed at the clean launch index. If a future CLI sets `CLAUDE_PROJECT_DIR` to
+  the launch root for workflow agents, the commit gate would scan the wrong index and
+  silently allow a worktree secret. Doctor/version probe (Q8) should watch for this.
+
+## Q2 — TaskCompleted gate fires on lead self-completion · VERIFIED-YES (focused stage PARTIAL)
+
+Mirrored passing feature F109 as a TaskCreate task (`metadata.feature_id: F109`) and
+marked it complete. `.harness/last_gate.json` was **rewritten** (mtime 19:35 → 22:32,
+content `{"smoke":"pass"}`), proving `verify-task-quality.sh` fired for a lead
+self-completed task in a non-Teams session and ran `smoke_test`.
+
+- **Focused-test stage: PARTIAL, and correctly so.** No `focused:F109` entry appeared
+  because *this repo's own* `.harness/init.sh` has no `focused_test` target (this is
+  exactly the F108 condition). So "smoke ran, focused skipped" is the correct,
+  expected result here — but it means the *focused* stage firing under workflow
+  orchestration is confirmable only on a `focused_test`-capable project. Deferred to
+  the Phase 2 toy-project run (OVI-143 AC1). The gate mechanism itself is VERIFIED-YES;
+  only the focused branch is unexercised on this repo.
+- **Correlation caveat (grounds a Phase 2 test)**: the focused/coverage stages key on
+  `metadata.task.metadata.feature_id` (`verify-task-quality.sh:143-145`). A mirrored
+  task created *without* `feature_id` passes the "one task per feature" instruction
+  while leaving those stages inert — so "mirror with `feature_id`" must be a hard,
+  tested step in the workflow-protocol rule, not prose.
+
+## Q3 — SubagentStart/SubagentStop reach plugin hooks · VERIFIED-YES
+
+Temporarily wired logging `SubagentStart`/`SubagentStop` hooks (restored to committed
+state afterward — `git status` clean). A trivial workflow agent (`wf_830369ee-070`)
+produced both events. Payload carries `agent_id` (always present) and `agent_type`:
+
+- plain workflow agent → `agent_type: "workflow-subagent"` (generic);
+- typed Agent-tool subagents → their real type (`vv-harness:spec-verification`).
+
+The dashboard graph keys on `agent_id` (present for all), so Phase 5 rendering is
+viable. Caveat: some `SubagentStop` lines carried an empty `agent_type` with no paired
+`Start` (orchestration/fork agents) — Phase 5 must tolerate Stop-without-Start and a
+blank type (it already labels a missing type "(unknown agent)").
+
+## Q4 — Worktree lifecycle · VERIFIED-YES
+
+- Location: `.claude/worktrees/wf_<runId>-<n>`; branch `worktree-wf_<runId>-<n>`.
+- **Unchanged worktree is auto-removed**: probe 3 made no writes; its worktree
+  (`wf_fb726f39-06a-3`) was gone after the run. **Changed worktrees persist** until the
+  lead removes them (probes that committed remained). → the lead **must** remove changed
+  worktrees after merge, before any repo-wide suite run (the F094/F108-session bug where
+  leftover worktrees gave 7 copies of every `*.md`; also cost a cwd-orphaned shell this
+  session when a `git worktree remove` deleted the dir under an active `cd`). Written
+  rule step, per OVI-140's run-continuity/worktree-hygiene additions.
+- No clobber: two parallel implementers got distinct worktrees/branches; the lead
+  stayed on its own branch (`eovidiu/ovi-140-phases-0-2`) throughout — the shared-checkout
+  hazard that motivated the migration does not occur.
+
+## Q5 — acceptEdits + deny still blocks · VERIFIED-YES
+
+Worktree agents wrote files via the Write tool with no permission prompt (acceptEdits
+in effect) yet the exit-2 commit-gate deny still blocked their compound commit (Q1). So
+"agents auto-accept edits" and "PreToolUse denies still bind" hold simultaneously.
+
+## Q6 — Structured-output reliability · VERIFIED-YES
+
+Every schema in every spike this session validated and returned the declared object
+shape. `null` semantics on kill/error are established from the prior session's review
+workflow (`wf_62aae2ac-e3b`): 11 of 34 agents hit a session rate limit and their
+`agent()` calls resolved to `null`, survivors returned intact — the exact contract the
+run-continuity protocol (OVI-140) is built on.
+
+## Q7 — args marshalling & plugin discovery · VERIFIED-YES (discovery PARTIAL)
+
+- **`args` arrives as a JSON-ENCODED STRING, not a parsed object** (`wf_42a89151-b5e`:
+  passed `{features:[...]}`, script observed `typeof args === "string"`,
+  `Array.isArray(args.features) === false`). **Hard constraint for Phase 1**: scripts
+  must `JSON.parse(args)` (guarded) before any field access. OVI-142 Preflight as
+  written ("validate `args.features` is a non-empty array") would reject every valid
+  call without the parse.
+- **Plugin-root `workflows/` auto-discovery as `/vv-harness:<name>`: PARTIAL** — cannot
+  be exercised until a build ships and is installed. Deferred to the Phase 1 release +
+  a post-install manual check (OVI-142 AC1). Mitigation: keep the scripts invocable by
+  path (`Workflow({scriptPath})`) regardless, so the feature is testable pre-discovery.
+
+## Q8 — version / availability probing · VERIFIED-YES (org-disable PARTIAL)
+
+- `claude --version` → `2.1.226` ≥ the 2.1.154 workflows floor. Parse the first token,
+  compare minor — the same defensive pattern the worker-epoch check already uses.
+- **`disableWorkflows` (org/settings): PARTIAL** — cannot be force-tested from here.
+  Runtime detection is by capability, not by reading the flag: if the `Workflow` tool
+  is absent, fall back to the worktree-isolated plain-subagent path. Doctor records the
+  version; the skill degrades on tool-absence.
+
+---
+
+## Go / No-Go
+
+**GO for Phase 1**, with the design amendments the spikes force (all already folded
+into OVI-140's improved plan and carried into the Phase-1 feature specs):
+
+1. Scripts `JSON.parse(args)` defensively (Q7) — non-negotiable.
+2. Worktree hygiene (lead removes changed worktrees post-merge, before suite) is a
+   written rule step, not tribal knowledge (Q4).
+3. Mirrored tasks must carry `metadata.feature_id` or the focused/coverage gate stages
+   go inert (Q2) — a tested requirement.
+4. Enforcement (Q1) is confirmed present, so OVI-140's hard-gate condition ("if Q1 or
+   Q2 is VERIFIED-NO, move enforcement into script verify phases") is **not** triggered
+   — hooks stay the enforcement layer. Flag the `CLAUDE_PROJECT_DIR`-unset dependency
+   for doctor.
+5. Focused-stage firing and plugin auto-discovery are the two PARTIALs; both are
+   release-/toy-gated and owned by the Phase 2 (OVI-143) end-to-end run, not blockers
+   for shipping Phase 1 scripts.

--- a/skills/harness-continue/SKILL.md
+++ b/skills/harness-continue/SKILL.md
@@ -277,8 +277,10 @@ the `TaskCompleted` and commit gates fire in the lead session. Run these steps *
    from the batch, never silently included.
 2. **Mirror tasks — mandatory.** `TaskCreate` one task per feature, **each carrying
    `metadata.feature_id`** (dependencies via `addBlockedBy`). This is what arms the
-   `TaskCompleted` gate's focused-test and coverage stages — a mirrored task *without*
-   `feature_id` leaves those stages inert (verified in Phase 0). Not optional.
+   `TaskCompleted` gate's focused-test and coverage stages. The hook has a task-subject
+   `FXXX:` fallback (`verify-task-quality.sh` parses the ID off the subject when
+   `feature_id` is absent), but do not rely on it — a subject without the exact `FXXX:`
+   prefix, or a mismatched ID, silently skips those stages. Set `feature_id` explicitly.
 3. **Launch.** Call the workflow with `args` carrying the feature IDs **and each
    feature's verified spec text** (the script has no way to read `features.json` from
    inside a workflow): `{ features: [...], featureSpecs: { F0NN: { spec, scope, risk,

--- a/skills/harness-continue/SKILL.md
+++ b/skills/harness-continue/SKILL.md
@@ -111,35 +111,53 @@ Adjust as you transition between phases during the session.
 
 When choosing single-session, explicitly declare it: "Running in single-session mode — I'm both lead and implementer." This makes the decision conscious and documented, preventing ambiguity between "I forgot plan mode" and "plan mode doesn't apply here."
 
-**Choose Agent Teams if:**
-- Multiple independent features are ready
-- The next feature has clearly independent components
-- `harness.json` has a team_structure defined
-- User explicitly asks for parallel work
+**Choose Workflow mode (the primary parallel path) if:**
+- Two or more **independent, spec-verified** features are ready, where independent means
+  **empty `depends_on` AND non-overlapping `scope`**. (When two verified independent
+  features each touch fewer than 5 files, workflow mode still wins over single-session —
+  the parallel gain outweighs single-session's simplicity once two independent verified
+  features exist.)
+- User explicitly asks for parallel work.
 
-**Graceful degradation — Agent Teams unavailable:**
+Workflow mode orchestrates via the plugin's `/vv-harness:implement-features` workflow
+(Step 5b) instead of spawning teammates: one Sonnet implementer per feature in an
+isolated worktree, then a reviewer per feature, returning structured per-feature results
+the lead integrates. `agent()` returns are runtime-guaranteed and schema-validated (no
+`SendMessage` delivery protocol), worktree isolation is first-class, and a run is
+resumable in-session — the structural fixes for the Teams failure classes this project hit.
 
-Agent Teams is gated by `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`; the implicit team,
-`SendMessage`, and the `TaskCompleted`/`TeammateIdle` coordination hooks are active only
-when it is set. If the variable is unset or team coordination is unavailable, do NOT
-abort parallel work. Fall back to direct subagents spawned via the Agent tool using the
-same vv-harness agent types
+**Availability probe.** Workflow mode needs Claude Code ≥ 2.1.154 and the `Workflow`
+tool present (not org-disabled via `disableWorkflows`). Probe by capability: parse
+`claude --version` and confirm the `Workflow` tool is available. **If unavailable**
+(older CLI, `disableWorkflows`, or a plan without it), fall back to the
+worktree-isolated plain-subagent path below — this is the same degradation path Agent
+Teams unavailability uses, repointed, not duplicated.
+
+**Peer-debate exception:** research or competing-hypothesis work that genuinely needs
+inter-agent discussion is *not* what the implement→review pipeline does. For that, spawn
+plain parallel subagents (or legacy Agent Teams while it still exists).
+
+**Fallback / legacy — plain subagents or Agent Teams:**
+
+When workflow mode is unavailable, do NOT abort parallel work. Fall back to direct
+subagents spawned via the Agent tool using the same vv-harness agent types
 (`vv-harness:feature-implementer`, `vv-harness:layer-implementer`,
 `vv-harness:researcher`, `vv-harness:reviewer`), passing `isolation: "worktree"` at
 spawn time for independent feature scopes — worktree isolation is documented platform
-behavior for subagents. The lead merges the worktree branches at synthesis (Phase 4).
-
-This is the supported, non-experimental path. Team-only machinery does not apply in
-this mode: no SendMessage interface negotiation, no TeammateIdle reassignment —
+behavior for subagents. The lead merges the worktree branches at synthesis. Legacy Agent
+Teams (gated by `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`; the `SendMessage`/`TeammateIdle`
+coordination path) remains available until it is retired in a later migration phase, but
+is no longer the default parallel mode. Team-only machinery does not apply to the
+subagent fallback: no SendMessage interface negotiation, no TeammateIdle reassignment —
 sequencing falls back to the lead, which spawns dependent work only after its
 prerequisites are merged.
 
 Ask the user if it's ambiguous:
 
 ```
-I see [N] features ready. I can either:
+I see [N] verified features ready. I can either:
 1. Work on F00X in a focused single session
-2. Spawn a team to work on F00X and F00Y in parallel
+2. Launch the implement-features workflow on F00X and F00Y in parallel
 
 Which do you prefer?
 ```
@@ -248,7 +266,51 @@ Before declaring the session complete, work through the full checklist in `${CLA
 
 ---
 
-## Step 5b: Agent Teams Workflow
+## Step 5b: Workflow Orchestration (primary parallel mode)
+
+The lead (an Opus 5 session) never edits feature code directly in this mode — it prepares
+inputs, launches `/vv-harness:implement-features`, and integrates the returned results so
+the `TaskCompleted` and commit gates fire in the lead session. Run these steps **in order**:
+
+1. **Verify specs.** Confirm every candidate feature has a verified spec (`spec.verdict:
+   "PASS"`, or a fresh `harness-issue-prep` pass). Unverified features are **excluded**
+   from the batch, never silently included.
+2. **Mirror tasks — mandatory.** `TaskCreate` one task per feature, **each carrying
+   `metadata.feature_id`** (dependencies via `addBlockedBy`). This is what arms the
+   `TaskCompleted` gate's focused-test and coverage stages — a mirrored task *without*
+   `feature_id` leaves those stages inert (verified in Phase 0). Not optional.
+3. **Launch.** Call the workflow with `args` carrying the feature IDs **and each
+   feature's verified spec text** (the script has no way to read `features.json` from
+   inside a workflow): `{ features: [...], featureSpecs: { F0NN: { spec, scope, risk,
+   mergeBase } }, maxReviewRounds: 3 }`. Set `reviewModel: 'opus'` explicitly only if you
+   need to force it; the reviewer already runs Opus by its agent definition. Size the
+   batch under the platform concurrency cap (min(16, cores−2); guideline < 15) — chain
+   multiple runs rather than one oversized batch.
+4. **Integrate per feature, in this order** (only for features the workflow returned as
+   approved): **run the feature's focused test + smoke locally → merge its
+   `worktree_branch` → flip `features.json` status to passing → mark the mirrored task
+   complete (gate fires) → commit (commit gate fires; `git add` and `git commit` as
+   SEPARATE calls)**. Never flip status or mark a task complete before its tests pass on
+   the merged code. After merging, **remove the changed worktree before any repo-wide
+   suite run** (a leftover worktree gives duplicate copies of every file to repo-wide
+   assertions — verified in Phase 0).
+5. **Surface, never auto-merge, the rest.** A feature returned `status: blocked`, verdict
+   `REJECT`/`REVISE`, or in the workflow's `unfinished` list is reported to the user with
+   its structured findings. For `unfinished` features (an agent died — e.g. a session
+   rate limit), either resume the run (`Workflow({scriptPath, resumeFromRunId})`, which
+   replays completed agents from cache) after the reset, or reconcile from the committed
+   worktree branches; do not silently drop them.
+6. **Retrospective.** The Phase 5.5 retrospective/promotion/ablation passes and the MLD
+   telemetry below apply unchanged.
+
+The prompt and structured-output schema templates for this flow live in
+`team-spawn-prompts.md` (this skill's directory). The pre-launch checklist there is:
+specs verified, tasks mirrored **with `feature_id`**, branch state clean, `git fetch` +
+rebase done.
+
+---
+
+## Step 5c: Agent Teams Workflow (legacy)
 
 Before any team coordination, Read the Agent Teams protocol at
 `${CLAUDE_PLUGIN_ROOT}/rules/agent-teams-protocol.md`. Agent Teams is experimental and

--- a/skills/harness-continue/team-spawn-prompts.md
+++ b/skills/harness-continue/team-spawn-prompts.md
@@ -1,4 +1,54 @@
-# Agent Teams Spawn Prompt Templates
+# Spawn & Launch Prompt Templates
+
+This file has two parts: the **Workflow launch templates** (the primary parallel mode,
+Step 5b) and the **Agent Teams spawn templates** (legacy, Step 5c — retained until Agent
+Teams is retired in a later migration phase).
+
+---
+
+## Workflow launch (primary — `/vv-harness:implement-features`)
+
+### Pre-launch checklist
+
+Before launching the workflow, confirm all of:
+
+- **Specs verified** — every feature in the batch has `spec.verdict: "PASS"` (or a fresh
+  `harness-issue-prep` pass). Unverified features are excluded from the batch.
+- **Tasks mirrored WITH `feature_id`** — one `TaskCreate` per feature, each carrying
+  `metadata.feature_id`. This arms the `TaskCompleted` gate's focused-test/coverage
+  stages; a mirrored task without `feature_id` leaves them inert.
+- **Branch clean, rebased** — `git fetch` + rebase on the integration branch; working
+  tree clean before launch.
+
+Worktree isolation is physical, so **`.claude/teammate-scope.txt` is NOT written for
+workflow mode** — it belongs to the shared-branch Teams path only.
+
+### `args` shape
+
+```
+{
+  features: ["F0NN", "F0MM"],
+  featureSpecs: {
+    F0NN: { spec: "<the verified spec text, verbatim>", scope: ["path/…"], risk: "standard|elevated", mergeBase: "<sha or branch>" },
+    F0MM: { … }
+  },
+  maxReviewRounds: 3,
+  reviewModel: "opus"   // optional; omit to use the reviewer agent's own model
+}
+```
+
+### Structured-output schemas (single source of truth is the script; mirror here for the lead)
+
+- **Implement**: `{ feature_id, status: implemented|blocked, files_changed[], test_file, tests_run: {passed, failed}, worktree_branch, head_sha, notes, blocker }`
+- **Review**: `{ feature_id, verdict: APPROVE|REVISE|REJECT, findings[], rounds_used }`
+- **Workflow return**: `{ per_feature: [{ feature_id, implement, review, outcome: approved|blocked|needs-lead|died }], unfinished: [ids], complete: bool }`
+
+The lead integrates approved features per Step 5b's ordered flow; `blocked` / non-APPROVE
+/ `unfinished` features are surfaced to the user, never auto-merged.
+
+---
+
+# Agent Teams Spawn Prompt Templates (legacy)
 
 Per-feature spawn prompts for the vv-harness plugin agents. The lead fills in the
 placeholders and passes the result as the `prompt` parameter in Agent tool calls, with

--- a/skills/harness-continue/team-spawn-prompts.md
+++ b/skills/harness-continue/team-spawn-prompts.md
@@ -16,7 +16,8 @@ Before launching the workflow, confirm all of:
   `harness-issue-prep` pass). Unverified features are excluded from the batch.
 - **Tasks mirrored WITH `feature_id`** — one `TaskCreate` per feature, each carrying
   `metadata.feature_id`. This arms the `TaskCompleted` gate's focused-test/coverage
-  stages; a mirrored task without `feature_id` leaves them inert.
+  stages. A task-subject `FXXX:` fallback exists but is fragile (a subject without the
+  exact prefix, or a mismatched ID, silently skips the stages) — set `feature_id`.
 - **Branch clean, rebased** — `git fetch` + rebase on the integration branch; working
   tree clean before launch.
 

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -13988,6 +13988,67 @@ assert_not_contains "$STDERR_F107_NULL" "TypeError" \
   "f107 (null description): no python traceback reaches stderr"
 
 echo ""
+echo "== F111/F112: plugin workflow scripts (OVI-142) =="
+
+# Phase 1 of the OVI-140 Agent Teams -> Dynamic Workflows migration ships two
+# workflow scripts at plugin root. The runner is dependency-free (no node), so
+# these are structural assertions on the scripts' source text -- the same style
+# the suite uses for the bash hooks. They pin the load-bearing invariants the
+# spec-verification pass surfaced: defensive args parsing, no non-deterministic
+# calls, per-agent model, author-blind reviewer, bounded/lead-owned integration.
+
+for WF in implement-features review-branch; do
+  WF_PATH="$REPO_ROOT/workflows/$WF.js"
+  if [ -f "$WF_PATH" ]; then
+    pass "wf ($WF): workflows/$WF.js exists at plugin root"
+  else
+    fail "wf ($WF): workflows/$WF.js is missing"
+    continue
+  fi
+  WF_SRC=$(cat "$WF_PATH")
+
+  # meta must be a pure literal with the required fields.
+  assert_contains "$WF_SRC" "export const meta = {" "wf ($WF): exports a meta block"
+  assert_contains "$WF_SRC" "name: '$WF'" "wf ($WF): meta.name matches the file"
+  assert_contains "$WF_SRC" "phases: [" "wf ($WF): meta declares phases"
+
+  # No non-deterministic or dynamic-import calls (would break resume/replay).
+  assert_not_contains "$WF_SRC" "Date.now(" "wf ($WF): no Date.now()"
+  assert_not_contains "$WF_SRC" "Math.random(" "wf ($WF): no Math.random()"
+  assert_not_contains "$WF_SRC" "new Date(" "wf ($WF): no new Date()"
+  assert_not_contains "$WF_SRC" "import(" "wf ($WF): no dynamic import()"
+
+  # args arrives as a JSON string (Phase 0 Q7) -> must be parsed defensively.
+  assert_contains "$WF_SRC" "JSON.parse" "wf ($WF): parses args defensively (JSON string per Phase 0)"
+  assert_contains "$WF_SRC" "function parseArgs" "wf ($WF): has a guarded parseArgs helper"
+done
+
+# implement-features specifics.
+IF_SRC=$(cat "$REPO_ROOT/workflows/implement-features.js" 2>/dev/null)
+# Every agent() spawn in the implement path carries an explicit model or agentType.
+assert_contains "$IF_SRC" "model: 'sonnet'" "wf (impl): implementer runs Sonnet"
+assert_contains "$IF_SRC" "agentType: 'vv-harness:feature-implementer'" "wf (impl): implementer uses the plugin agent type"
+assert_contains "$IF_SRC" "agentType: 'vv-harness:reviewer'" "wf (impl): reviewer uses the plugin agent type (Opus by definition)"
+assert_contains "$IF_SRC" "isolation: 'worktree'" "wf (impl): implementers run in isolated worktrees"
+# Reviewer must not be fed the implementer's own notes/approach (author-blind to rationale).
+assert_not_contains "$IF_SRC" "impl.notes" "wf (impl): reviewer prompt never interpolates the implementer's notes"
+assert_contains "$IF_SRC" "ask for the implementer" "wf (impl): reviewer prompt states it must not read the implementer's notes"
+# The script must NOT integrate -- no merge inside the workflow (integration is the lead's).
+assert_not_contains "$IF_SRC" "git merge" "wf (impl): the script never merges (integration is the lead's)"
+assert_contains "$IF_SRC" "The lead integrates" "wf (impl): documents that integration/features.json edits are the lead's job"
+# Run-continuity: partial-result contract.
+assert_contains "$IF_SRC" "unfinished" "wf (impl): returns an unfinished-feature list (partial-result contract)"
+assert_contains "$IF_SRC" "maxReviewRounds" "wf (impl): honors a maxReviewRounds bound"
+# A feature with no supplied spec is a hard error, never implemented from its ID alone.
+assert_contains "$IF_SRC" "no verified spec supplied" "wf (impl): errors when a feature has no supplied spec"
+
+# review-branch specifics: dedup barrier before the verify fan-out.
+RB_SRC=$(cat "$REPO_ROOT/workflows/review-branch.js" 2>/dev/null)
+assert_contains "$RB_SRC" "function dedupeKey" "wf (review): dedups findings before verify"
+assert_contains "$RB_SRC" "phase('Verify')" "wf (review): has an adversarial verify phase"
+assert_not_contains "$RB_SRC" "Write" "wf (review): review-only, never writes"
+
+echo ""
 TOTAL=$((PASS_COUNT + FAIL_COUNT))
 echo "Summary: $PASS_COUNT/$TOTAL assertions passed, $FAIL_COUNT failed"
 if [ "$FAIL_COUNT" -gt 0 ]; then

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -14012,11 +14012,34 @@ assert_contains "$HC_SKILL_SRC" "Step 5b: Workflow Orchestration" \
 # Mandatory task mirroring WITH feature_id (Phase 0 Q2: arms the focused/coverage stages).
 assert_contains "$HC_SKILL_SRC" "metadata.feature_id" \
   "f113: task mirroring is mandatory and carries metadata.feature_id"
-# Integration order, stated as a single ordered clause.
-assert_contains "$HC_SKILL_SRC" "run the feature's focused test + smoke locally → merge its" \
-  "f113: integration runs local tests before merging"
-assert_contains "$HC_SKILL_SRC" "complete (gate fires) → commit (commit gate fires" \
-  "f113: task-complete precedes commit in the integration order"
+# Integration order: assert ALL FIVE tokens appear in the required order (test ->
+# merge -> flip status -> task complete -> commit), not just two disjoint transitions,
+# so a reorder that flips features.json before the merge is caught.
+F113_ORDER_OK=$(python3 - "$HC_SKILL_F113" <<'PYEOF'
+import re, sys
+text = open(sys.argv[1]).read()
+# The Step 5b integration bullet (item 4). Restrict to that region to avoid matching
+# the same words elsewhere in the skill.
+m = re.search(r"Integrate per feature, in this order.*?(?=\n5\. )", text, re.DOTALL)
+region = m.group(0) if m else ""
+tokens = ["focused test + smoke", "merge its", "flip `features.json` status",
+          "mark the mirrored task", "commit (commit gate fires"]
+pos = -1
+ok = True
+for t in tokens:
+    i = region.find(t)
+    if i == -1 or i < pos:
+        ok = False
+        break
+    pos = i
+print("OK" if ok else "BAD")
+PYEOF
+)
+if [ "$F113_ORDER_OK" = "OK" ]; then
+  pass "f113: integration order pins all five steps (test -> merge -> status -> task-complete -> commit)"
+else
+  fail "f113: the five integration steps are missing or out of order in Step 5b"
+fi
 assert_contains "$HC_SKILL_SRC" "Never flip status or mark a task" \
   "f113: never flip status / complete a task before tests pass on merged code"
 assert_contains "$HC_SKILL_SRC" "remove the changed worktree before any repo-wide" \
@@ -14085,18 +14108,81 @@ assert_not_contains "$IF_SRC" "impl.notes" "wf (impl): reviewer prompt never int
 assert_contains "$IF_SRC" "ask for the implementer" "wf (impl): reviewer prompt states it must not read the implementer's notes"
 # The script must NOT integrate -- no merge inside the workflow (integration is the lead's).
 assert_not_contains "$IF_SRC" "git merge" "wf (impl): the script never merges (integration is the lead's)"
-assert_contains "$IF_SRC" "The lead integrates" "wf (impl): documents that integration/features.json edits are the lead's job"
-# Run-continuity: partial-result contract.
-assert_contains "$IF_SRC" "unfinished" "wf (impl): returns an unfinished-feature list (partial-result contract)"
-assert_contains "$IF_SRC" "maxReviewRounds" "wf (impl): honors a maxReviewRounds bound"
+# Run-continuity: a dead implementer OR a dead reviewer both land on the unfinished list.
+assert_contains "$IF_SRC" "unfinished.push(id)" "wf (impl): pushes died/unreviewed features onto the unfinished list"
+assert_contains "$IF_SRC" "'unreviewed'" "wf (impl): a dead reviewer yields an 'unreviewed' outcome, not a false needs-lead"
 # A feature with no supplied spec is a hard error, never implemented from its ID alone.
 assert_contains "$IF_SRC" "no verified spec supplied" "wf (impl): errors when a feature has no supplied spec"
+# mergeBase must be interpolated into the reviewer prompt, not a literal placeholder.
+assert_not_contains "$IF_SRC" "git diff <mergeBase>" "wf (impl): reviewer prompt has no literal <mergeBase> placeholder"
+assert_contains "$IF_SRC" "spec.mergeBase + '...' + branch" "wf (impl): reviewer prompt interpolates the real merge base"
+# risk is live, not a dead arg: an elevated feature escalates the review effort.
+assert_contains "$IF_SRC" "spec.risk === 'elevated') reviewOpts.effort" "wf (impl): elevated risk escalates the review pass"
 
-# review-branch specifics: dedup barrier before the verify fan-out.
+# review-branch specifics.
 RB_SRC=$(cat "$REPO_ROOT/workflows/review-branch.js" 2>/dev/null)
 assert_contains "$RB_SRC" "function dedupeKey" "wf (review): dedups findings before verify"
 assert_contains "$RB_SRC" "phase('Verify')" "wf (review): has an adversarial verify phase"
-assert_not_contains "$RB_SRC" "Write" "wf (review): review-only, never writes"
+# Severity comparator uses ?? not || so critical (0) is not pushed last.
+assert_not_contains "$RB_SRC" "|| 3" "wf (review): severity score does not use || (which mis-ranks critical)"
+assert_contains "$RB_SRC" "=== undefined ? 3" "wf (review): severity score treats only unknown as 3"
+# Partial-result contract: dead verifiers are unverified, never counted as refuted.
+assert_contains "$RB_SRC" "unverified" "wf (review): reports an unverified list (dead verifiers not counted as refuted)"
+assert_contains "$RB_SRC" "dropped:" "wf (review): reports dropped reviewer/verifier counts"
+# Read-only invariant: every agent() call carries a read-only agentType (reviewer), and
+# the write-capable conformance agent is worktree-isolated off the lead's checkout.
+assert_not_contains "$RB_SRC" "conformance-tester', model: 'sonnet' }" "wf (review): conformance agent is not spawned without isolation"
+assert_contains "$RB_SRC" "conformance-tester', model: 'sonnet', isolation: 'worktree'" "wf (review): the write-capable conformance agent runs in an isolated worktree"
+assert_contains "$RB_SRC" "phase: 'Verify', schema: VERDICT_SCHEMA, agentType: 'vv-harness:reviewer'" "wf (review): verify agents carry the read-only reviewer agentType"
+# Conformance without featureSpecs is a hard error, not a silent no-op.
+assert_contains "$RB_SRC" "conformance requires \`featureSpecs\`" "wf (review): conformance throws when featureSpecs is missing"
+# Custom dimensions are validated, not silently degraded to 'dimension: undefined'.
+assert_contains "$RB_SRC" "must be an object with a non-empty" "wf (review): custom dimensions are validated"
+
+# Executable coverage of the pure helpers (node-guarded; SKIP visibly when node is
+# absent, like the suite's other optional-tool checks). Slices the helper prefix (above
+# the run marker -- no top-level return/await there) into temp modules and runs them.
+if command -v node >/dev/null 2>&1; then
+  WF_HELP_DIR="$WORK/wf-helpers"
+  mkdir -p "$WF_HELP_DIR"
+  python3 - "$REPO_ROOT" "$WF_HELP_DIR" <<'PYEOF'
+import sys
+repo, out = sys.argv[1], sys.argv[2]
+def prefix(path):
+    return open(path).read().split('// ---- run')[0]
+open(out + '/if_helpers.mjs', 'w').write(prefix(repo + '/workflows/implement-features.js') + '\nexport {parseArgs, classifyOutcome};\n')
+open(out + '/rb_helpers.mjs', 'w').write(prefix(repo + '/workflows/review-branch.js') + '\nexport {parseArgs, severityScore, dedupeKey, mergeFindings};\n')
+PYEOF
+  WF_HELP_OUT=$(node --input-type=module -e '
+import * as IF from "'"$WF_HELP_DIR"'/if_helpers.mjs";
+import * as RB from "'"$WF_HELP_DIR"'/rb_helpers.mjs";
+const chk=(c,m)=>console.log((c?"OK":"BAD")+" "+m);
+chk(IF.parseArgs("")===null,"parseArgs-empty");
+chk(Array.isArray(IF.parseArgs("[1,2]")),"parseArgs-array");
+chk(IF.parseArgs("{\"features\":[\"F1\"]}").features[0]==="F1","parseArgs-json");
+chk(IF.parseArgs({x:1}).x===1,"parseArgs-obj");
+chk(IF.classifyOutcome(null).outcome==="died","classify-died");
+chk(IF.classifyOutcome({implement:{status:"blocked"}}).outcome==="blocked","classify-blocked");
+chk(IF.classifyOutcome({implement:{status:"implemented"},review:null}).outcome==="unreviewed","classify-unreviewed");
+chk(IF.classifyOutcome({implement:{status:"implemented"},review:{verdict:"APPROVE"}}).outcome==="approved","classify-approved");
+chk(IF.classifyOutcome({implement:{status:"implemented"},review:{verdict:"REVISE"}}).outcome==="needs-lead","classify-needslead");
+chk(RB.severityScore("critical")<RB.severityScore("minor"),"critical-lt-minor");
+chk(RB.severityScore("critical")<RB.severityScore("major"),"critical-lt-major");
+chk(RB.severityScore(undefined)===3,"unknown-sev-3");
+const m=RB.mergeFindings([{file:"a",line:1,claim:"x",severity:"minor",dimension:"t"},{file:"a",line:1,claim:"x",severity:"critical",dimension:"c"}]);
+chk(m.length===1,"dedup-collapses");
+chk(m[0].severity==="critical","dedup-keeps-max-severity");
+chk(m[0].dimensions.length===2,"dedup-unions-dimensions");
+' 2>&1)
+  for CASE in parseArgs-empty parseArgs-array parseArgs-json parseArgs-obj classify-died classify-blocked classify-unreviewed classify-approved classify-needslead critical-lt-minor critical-lt-major unknown-sev-3 dedup-collapses dedup-keeps-max-severity dedup-unions-dimensions; do
+    case "$WF_HELP_OUT" in
+      *"OK $CASE"*) pass "wf-exec: $CASE" ;;
+      *) fail "wf-exec: $CASE -- node output: $WF_HELP_OUT" ;;
+    esac
+  done
+else
+  echo "SKIP: node not available -- workflow helper execution tests skipped"
+fi
 
 echo ""
 TOTAL=$((PASS_COUNT + FAIL_COUNT))

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -13988,6 +13988,56 @@ assert_not_contains "$STDERR_F107_NULL" "TypeError" \
   "f107 (null description): no python traceback reaches stderr"
 
 echo ""
+echo "== F113: harness-continue workflow mode (OVI-143) =="
+
+# Phase 2 rewires the parallel path to orchestrate via the implement-features
+# workflow. These assertions pin the load-bearing decisions from the spec gate:
+# the three-way mode decision, mandatory feature_id-carrying task mirroring, the
+# integration ORDER (tests before merge before status-flip before task-complete
+# before commit), the fallback pointer, and that no step tells the lead to edit
+# features.json before tests pass. Teams text is demoted, not deleted.
+HC_SKILL_F113="$REPO_ROOT/skills/harness-continue/SKILL.md"
+HC_SKILL_SRC=$(cat "$HC_SKILL_F113")
+
+assert_contains "$HC_SKILL_SRC" "Choose Workflow mode (the primary parallel path)" \
+  "f113: Step 4 presents workflow mode as the primary parallel path"
+assert_contains "$HC_SKILL_SRC" "empty \`depends_on\` AND non-overlapping \`scope\`" \
+  "f113: 'independent' is defined operationally (empty depends_on AND non-overlapping scope)"
+assert_contains "$HC_SKILL_SRC" "Peer-debate exception" \
+  "f113: the peer-debate exception routes to plain subagents"
+assert_contains "$HC_SKILL_SRC" "Availability probe" \
+  "f113: an availability probe gates workflow mode with a fallback"
+assert_contains "$HC_SKILL_SRC" "Step 5b: Workflow Orchestration" \
+  "f113: Step 5b is the workflow orchestration flow"
+# Mandatory task mirroring WITH feature_id (Phase 0 Q2: arms the focused/coverage stages).
+assert_contains "$HC_SKILL_SRC" "metadata.feature_id" \
+  "f113: task mirroring is mandatory and carries metadata.feature_id"
+# Integration order, stated as a single ordered clause.
+assert_contains "$HC_SKILL_SRC" "run the feature's focused test + smoke locally → merge its" \
+  "f113: integration runs local tests before merging"
+assert_contains "$HC_SKILL_SRC" "complete (gate fires) → commit (commit gate fires" \
+  "f113: task-complete precedes commit in the integration order"
+assert_contains "$HC_SKILL_SRC" "Never flip status or mark a task" \
+  "f113: never flip status / complete a task before tests pass on merged code"
+assert_contains "$HC_SKILL_SRC" "remove the changed worktree before any repo-wide" \
+  "f113: leftover-worktree hygiene step is present (Phase 0 Q4)"
+assert_contains "$HC_SKILL_SRC" "resumeFromRunId" \
+  "f113: unfinished features are resumed/reconciled, not dropped (run-continuity)"
+# Legacy Teams text demoted but retained.
+assert_contains "$HC_SKILL_SRC" "Step 5c: Agent Teams Workflow (legacy)" \
+  "f113: Agent Teams flow is demoted to Step 5c (legacy), not deleted"
+assert_contains "$HC_SKILL_SRC" "no longer the default parallel mode" \
+  "f113: the fallback clause states Teams is no longer the default"
+# team-spawn-prompts.md gains the workflow launch templates + pre-launch checklist.
+TSP_SRC=$(cat "$REPO_ROOT/skills/harness-continue/team-spawn-prompts.md")
+assert_contains "$TSP_SRC" "Workflow launch (primary" \
+  "f113: team-spawn-prompts.md carries the workflow launch template"
+assert_contains "$TSP_SRC" "Pre-launch checklist" \
+  "f113: the pre-launch checklist replaces the pre-spawn checklist for workflow mode"
+assert_contains "$TSP_SRC" "Tasks mirrored WITH \`feature_id\`" \
+  "f113: the pre-launch checklist requires feature_id-carrying task mirroring"
+
+echo ""
 echo "== F111/F112: plugin workflow scripts (OVI-142) =="
 
 # Phase 1 of the OVI-140 Agent Teams -> Dynamic Workflows migration ships two

--- a/workflows/implement-features.js
+++ b/workflows/implement-features.js
@@ -1,0 +1,213 @@
+export const meta = {
+  name: 'implement-features',
+  description: 'Implement a batch of verified features in parallel worktree agents, then review each; return per-feature results for the lead to integrate. Never merges, commits, or edits features.json.',
+  phases: [
+    { title: 'Implement', detail: 'one Sonnet implementer per feature, isolated worktree, strict TDD' },
+    { title: 'Review', detail: 'one reviewer per feature over the branch diff, spec-derived, author-blind to the implementer rationale' },
+  ],
+}
+
+// args arrives as a JSON-ENCODED STRING on the current CLI, not a parsed object
+// (Phase 0 / OVI-141 Q7). Parse defensively; a bare object is tolerated too so the
+// script stays correct if a future CLI marshals args as an object.
+function parseArgs(raw) {
+  if (raw && typeof raw === 'object') return raw
+  if (typeof raw !== 'string' || raw.length === 0) return null
+  try {
+    return JSON.parse(raw)
+  } catch (e) {
+    return null
+  }
+}
+
+const IMPLEMENT_SCHEMA = {
+  type: 'object',
+  required: ['feature_id', 'status', 'files_changed', 'worktree_branch'],
+  properties: {
+    feature_id: { type: 'string' },
+    status: { type: 'string', enum: ['implemented', 'blocked'] },
+    files_changed: { type: 'array', items: { type: 'string' } },
+    test_file: { type: 'string' },
+    tests_run: {
+      type: 'object',
+      properties: { passed: { type: 'integer' }, failed: { type: 'integer' } },
+    },
+    worktree_branch: { type: 'string' },
+    head_sha: { type: 'string' },
+    notes: { type: 'string' },
+    blocker: { type: 'string', description: 'why it is blocked, when status is blocked' },
+  },
+}
+
+const REVIEW_SCHEMA = {
+  type: 'object',
+  required: ['feature_id', 'verdict', 'findings', 'rounds_used'],
+  properties: {
+    feature_id: { type: 'string' },
+    verdict: { type: 'string', enum: ['APPROVE', 'REVISE', 'REJECT'] },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['summary'],
+        properties: {
+          summary: { type: 'string' },
+          file: { type: 'string' },
+          line: { type: 'integer' },
+          severity: { type: 'string', enum: ['critical', 'major', 'minor'] },
+        },
+      },
+    },
+    rounds_used: { type: 'integer' },
+  },
+}
+
+// The implementer receives the feature's own verified spec. It never sees the other
+// features, and its committed worktree branch is the durable deliverable (so a dead
+// run's work survives — OVI-140 run-continuity). Prompt text derives only from `spec`
+// so a resume replays it byte-for-byte from cache.
+function implementPrompt(spec) {
+  return [
+    'You are a feature implementer in an ISOLATED GIT WORKTREE of a harness-managed repo.',
+    'Confirm your location with `git rev-parse --show-toplevel` and record your branch with `git branch --show-current`.',
+    '',
+    '## Feature ' + spec.id,
+    'Scope (stay within these paths plus the test file): ' + (spec.scope || []).join(', '),
+    '',
+    'Verified specification:',
+    spec.spec,
+    '',
+    '## Process (strict TDD)',
+    '1. Read the existing code and the project test conventions.',
+    '2. Write the failing test(s) that define done; run them to confirm they fail (RED).',
+    '3. Implement the minimum to pass; confirm GREEN. Commit at RED and again at GREEN as TDD checkpoints (a `git add <files>` call, then a SEPARATE `git commit` call — repo hooks reject compound stage-and-commit) so your branch survives even if this agent is interrupted.',
+    '4. Run the full project test suite; it must end fully green.',
+    '',
+    '## Deliverable',
+    'Your committed worktree branch IS the deliverable — do not leave work uncommitted. Do NOT merge, do NOT edit features.json, do NOT touch any branch but your own. Report the structured result: status implemented (green) or blocked (with a blocker reason), files changed, test file, pass/fail counts, your branch name, and HEAD sha.',
+  ].join('\n')
+}
+
+// The reviewer reads the feature's spec and the branch's own diff (`git diff` against
+// the merge base) — that is its job. It is NOT given the implementer's completion notes
+// or approach rationale: the author-blindness that matters here is to the implementer's
+// REASONING, so the review can't be talked into agreeing. (Full spec-only author-
+// blindness to the code itself is the conformance-tester's job, not the reviewer's.)
+function reviewPrompt(spec, branch) {
+  return [
+    'You are a senior code reviewer. Review the work on git branch `' + branch + '` for feature ' + spec.id + '.',
+    'Inspect it with read-only git only: `git diff <mergeBase>...' + branch + '`, `git show`, and file reads. You may run the test suite. Do NOT edit files. Do NOT read or ask for the implementer\'s own notes, approach, or completion message — judge the code and tests against the spec alone.',
+    '',
+    '## The verified specification (your only source of truth for intent)',
+    spec.spec,
+    '',
+    '## Judge',
+    'Correctness against the spec, scope adherence, test quality (do the tests actually pin the behavior, or would they pass against broken code?), and the coverage bar. Return verdict APPROVE (ship it), REVISE (fixable findings), or REJECT (wrong approach), with concrete findings (file, line, severity). Set rounds_used to 1 — the lead owns any fix-and-recheck loop, you do a single pass.',
+  ].join('\n')
+}
+
+// ---- run --------------------------------------------------------------------
+const parsed = parseArgs(args)
+
+// Preflight (no agent): fail fast and clearly on bad input.
+if (!parsed || typeof parsed !== 'object') {
+  throw new Error('implement-features: args did not parse to an object. Pass {features:[...], featureSpecs:{id:{spec,scope,risk}}} (JSON).')
+}
+const featureIds = parsed.features
+if (!Array.isArray(featureIds) || featureIds.length === 0) {
+  throw new Error('implement-features: args.features must be a non-empty array of feature IDs.')
+}
+const featureSpecs = parsed.featureSpecs || {}
+const maxReviewRounds = typeof parsed.maxReviewRounds === 'number' ? parsed.maxReviewRounds : 3
+
+// Build one spec object per feature. The lead passes the verified spec text in via
+// args (the script has no sanctioned way to read project state from inside a workflow,
+// and dynamic module loading is forbidden) — a feature with no supplied spec is a hard
+// error, never silently implemented from its ID alone.
+const specs = featureIds.map((id) => {
+  const fs = featureSpecs[id] || {}
+  if (!fs.spec) {
+    throw new Error('implement-features: no verified spec supplied for ' + id + ' in args.featureSpecs.')
+  }
+  return { id: id, spec: fs.spec, scope: fs.scope || [], risk: fs.risk || 'standard', mergeBase: fs.mergeBase || parsed.mergeBase || 'HEAD' }
+})
+
+phase('Implement')
+
+// pipeline: each feature flows Implement -> Review independently (no barrier), so a
+// fast feature is reviewed while a slow one still implements. A thrown stage drops that
+// item to null; survivors are never discarded (OVI-140 partial-result contract).
+const results = await pipeline(
+  specs,
+  (spec) => agent(implementPrompt(spec), {
+    label: 'impl:' + spec.id,
+    phase: 'Implement',
+    schema: IMPLEMENT_SCHEMA,
+    isolation: 'worktree',
+    agentType: 'vv-harness:feature-implementer',
+    model: 'sonnet',
+  }),
+  (impl, spec) => {
+    // A blocked implementer short-circuits its own review — nothing to review.
+    if (!impl || impl.status === 'blocked') {
+      return { feature_id: spec.id, implement: impl, review: null }
+    }
+    // Reviewer runs on its agentType's own model (reviewer = Opus per its definition);
+    // an explicit reviewModel override downgrades it (e.g. 'sonnet' for a cheap pass).
+    const reviewOpts = {
+      label: 'review:' + spec.id,
+      phase: 'Review',
+      schema: REVIEW_SCHEMA,
+      agentType: 'vv-harness:reviewer',
+    }
+    if (parsed.reviewModel) reviewOpts.model = parsed.reviewModel
+    return agent(reviewPrompt(spec, impl.worktree_branch), reviewOpts)
+      .then((review) => ({ feature_id: spec.id, implement: impl, review: review }))
+  }
+)
+
+// Classify. `results` entries are null only if BOTH stages threw for that item.
+const perFeature = []
+const unfinished = []
+for (let i = 0; i < specs.length; i++) {
+  const id = specs[i].id
+  const r = results[i]
+  if (!r) {
+    unfinished.push(id)
+    perFeature.push({ feature_id: id, implement: null, review: null, outcome: 'died' })
+    continue
+  }
+  const impl = r.implement
+  if (!impl) {
+    unfinished.push(id)
+    perFeature.push({ feature_id: id, implement: null, review: null, outcome: 'died' })
+    continue
+  }
+  if (impl.status === 'blocked') {
+    perFeature.push({ feature_id: id, implement: impl, review: null, outcome: 'blocked' })
+    continue
+  }
+  const verdict = r.review && r.review.verdict
+  perFeature.push({
+    feature_id: id,
+    implement: impl,
+    review: r.review,
+    outcome: verdict === 'APPROVE' ? 'approved' : 'needs-lead',
+  })
+}
+
+log('implement-features: ' + perFeature.filter((f) => f.outcome === 'approved').length + ' approved, '
+  + perFeature.filter((f) => f.outcome === 'blocked').length + ' blocked, '
+  + unfinished.length + ' unfinished (died) — ' + (unfinished.length ? unfinished.join(',') : 'none'))
+
+// The lead integrates: for each approved feature, run its focused test + smoke, merge
+// its worktree_branch, flip features.json, mark the mirrored task complete, commit.
+// blocked / non-APPROVE / unfinished features are surfaced, never auto-merged. A
+// non-empty `unfinished` means the lead should resume this run (resumeFromRunId) or
+// reconcile from the committed branches after the rate window resets.
+return {
+  maxReviewRounds: maxReviewRounds,
+  per_feature: perFeature,
+  unfinished: unfinished,
+  complete: unfinished.length === 0,
+}

--- a/workflows/implement-features.js
+++ b/workflows/implement-features.js
@@ -9,7 +9,9 @@ export const meta = {
 
 // args arrives as a JSON-ENCODED STRING on the current CLI, not a parsed object
 // (Phase 0 / OVI-141 Q7). Parse defensively; a bare object is tolerated too so the
-// script stays correct if a future CLI marshals args as an object.
+// script stays correct if a future CLI marshals args as an object. Exported-by-name
+// via a sentinel so test/run-tests.sh can execute this pure helper (see the
+// node-guarded workflow-helper tests).
 function parseArgs(raw) {
   if (raw && typeof raw === 'object') return raw
   if (typeof raw !== 'string' || raw.length === 0) return null
@@ -18,6 +20,18 @@ function parseArgs(raw) {
   } catch (e) {
     return null
   }
+}
+
+// Classify one pipeline result into the lead-facing outcome. Pure and total: every
+// input shape maps to exactly one of died | blocked | unreviewed | needs-lead |
+// approved. `result` is the pipeline entry (null if BOTH stages threw); `impl`/`review`
+// are its stages (either may be null if that stage's agent died — agent() resolves to
+// null on skip/terminal error, e.g. a rate limit).
+function classifyOutcome(result) {
+  if (!result || !result.implement) return { outcome: 'died', reviewed: false }
+  if (result.implement.status === 'blocked') return { outcome: 'blocked', reviewed: true }
+  if (!result.review) return { outcome: 'unreviewed', reviewed: false } // reviewer died
+  return { outcome: result.review.verdict === 'APPROVE' ? 'approved' : 'needs-lead', reviewed: true }
 }
 
 const IMPLEMENT_SCHEMA = {
@@ -88,15 +102,15 @@ function implementPrompt(spec) {
   ].join('\n')
 }
 
-// The reviewer reads the feature's spec and the branch's own diff (`git diff` against
-// the merge base) — that is its job. It is NOT given the implementer's completion notes
-// or approach rationale: the author-blindness that matters here is to the implementer's
+// The reviewer reads the feature's spec and the branch's own diff against the supplied
+// merge base — that is its job. It is NOT given the implementer's completion notes or
+// approach rationale: the author-blindness that matters here is to the implementer's
 // REASONING, so the review can't be talked into agreeing. (Full spec-only author-
 // blindness to the code itself is the conformance-tester's job, not the reviewer's.)
 function reviewPrompt(spec, branch) {
   return [
     'You are a senior code reviewer. Review the work on git branch `' + branch + '` for feature ' + spec.id + '.',
-    'Inspect it with read-only git only: `git diff <mergeBase>...' + branch + '`, `git show`, and file reads. You may run the test suite. Do NOT edit files. Do NOT read or ask for the implementer\'s own notes, approach, or completion message — judge the code and tests against the spec alone.',
+    'Inspect it with read-only git only: `git diff ' + spec.mergeBase + '...' + branch + '`, `git show`, and file reads. You may run the test suite. Do NOT edit files. Do NOT read or ask for the implementer\'s own notes, approach, or completion message — judge the code and tests against the spec alone.',
     '',
     '## The verified specification (your only source of truth for intent)',
     spec.spec,
@@ -106,6 +120,10 @@ function reviewPrompt(spec, branch) {
   ].join('\n')
 }
 
+// The pure helpers above (parseArgs, classifyOutcome) are defined before this marker
+// and depend on no workflow globals — test/run-tests.sh slices everything above the
+// marker into a temp module and executes them directly (node-guarded), so the
+// classification and arg-parsing logic has real coverage, not just source greps.
 // ---- run --------------------------------------------------------------------
 const parsed = parseArgs(args)
 
@@ -118,7 +136,6 @@ if (!Array.isArray(featureIds) || featureIds.length === 0) {
   throw new Error('implement-features: args.features must be a non-empty array of feature IDs.')
 }
 const featureSpecs = parsed.featureSpecs || {}
-const maxReviewRounds = typeof parsed.maxReviewRounds === 'number' ? parsed.maxReviewRounds : 3
 
 // Build one spec object per feature. The lead passes the verified spec text in via
 // args (the script has no sanctioned way to read project state from inside a workflow,
@@ -129,7 +146,13 @@ const specs = featureIds.map((id) => {
   if (!fs.spec) {
     throw new Error('implement-features: no verified spec supplied for ' + id + ' in args.featureSpecs.')
   }
-  return { id: id, spec: fs.spec, scope: fs.scope || [], risk: fs.risk || 'standard', mergeBase: fs.mergeBase || parsed.mergeBase || 'HEAD' }
+  return {
+    id: id,
+    spec: fs.spec,
+    scope: fs.scope || [],
+    risk: fs.risk === 'elevated' ? 'elevated' : 'standard',
+    mergeBase: fs.mergeBase || parsed.mergeBase || 'HEAD',
+  }
 })
 
 phase('Implement')
@@ -154,6 +177,7 @@ const results = await pipeline(
     }
     // Reviewer runs on its agentType's own model (reviewer = Opus per its definition);
     // an explicit reviewModel override downgrades it (e.g. 'sonnet' for a cheap pass).
+    // An elevated-risk feature gets a higher-effort review pass.
     const reviewOpts = {
       label: 'review:' + spec.id,
       phase: 'Review',
@@ -161,44 +185,35 @@ const results = await pipeline(
       agentType: 'vv-harness:reviewer',
     }
     if (parsed.reviewModel) reviewOpts.model = parsed.reviewModel
+    if (spec.risk === 'elevated') reviewOpts.effort = 'high'
     return agent(reviewPrompt(spec, impl.worktree_branch), reviewOpts)
       .then((review) => ({ feature_id: spec.id, implement: impl, review: review }))
   }
 )
 
-// Classify. `results` entries are null only if BOTH stages threw for that item.
+// Classify. Every feature that did not reach an approved+reviewed state and is not a
+// clean `blocked` (which the lead surfaces intentionally) goes on `unfinished`, so the
+// lead's resume/reconcile path fires — a dead implementer OR a dead reviewer both count.
 const perFeature = []
 const unfinished = []
 for (let i = 0; i < specs.length; i++) {
   const id = specs[i].id
   const r = results[i]
-  if (!r) {
-    unfinished.push(id)
-    perFeature.push({ feature_id: id, implement: null, review: null, outcome: 'died' })
-    continue
-  }
-  const impl = r.implement
-  if (!impl) {
-    unfinished.push(id)
-    perFeature.push({ feature_id: id, implement: null, review: null, outcome: 'died' })
-    continue
-  }
-  if (impl.status === 'blocked') {
-    perFeature.push({ feature_id: id, implement: impl, review: null, outcome: 'blocked' })
-    continue
-  }
-  const verdict = r.review && r.review.verdict
+  const c = classifyOutcome(r)
   perFeature.push({
     feature_id: id,
-    implement: impl,
-    review: r.review,
-    outcome: verdict === 'APPROVE' ? 'approved' : 'needs-lead',
+    implement: r ? r.implement : null,
+    review: r ? r.review : null,
+    outcome: c.outcome,
   })
+  if (c.outcome === 'died' || c.outcome === 'unreviewed') unfinished.push(id)
 }
 
-log('implement-features: ' + perFeature.filter((f) => f.outcome === 'approved').length + ' approved, '
+log('implement-features: '
+  + perFeature.filter((f) => f.outcome === 'approved').length + ' approved, '
   + perFeature.filter((f) => f.outcome === 'blocked').length + ' blocked, '
-  + unfinished.length + ' unfinished (died) — ' + (unfinished.length ? unfinished.join(',') : 'none'))
+  + perFeature.filter((f) => f.outcome === 'needs-lead').length + ' needs-lead, '
+  + unfinished.length + ' unfinished — ' + (unfinished.length ? unfinished.join(',') : 'none'))
 
 // The lead integrates: for each approved feature, run its focused test + smoke, merge
 // its worktree_branch, flip features.json, mark the mirrored task complete, commit.
@@ -206,7 +221,6 @@ log('implement-features: ' + perFeature.filter((f) => f.outcome === 'approved').
 // non-empty `unfinished` means the lead should resume this run (resumeFromRunId) or
 // reconcile from the committed branches after the rate window resets.
 return {
-  maxReviewRounds: maxReviewRounds,
   per_feature: perFeature,
   unfinished: unfinished,
   complete: unfinished.length === 0,

--- a/workflows/review-branch.js
+++ b/workflows/review-branch.js
@@ -1,0 +1,151 @@
+export const meta = {
+  name: 'review-branch',
+  description: 'Re-review an existing branch or diff scope: fan reviewers over it, dedup findings before an adversarial-verify pass, return ranked verdicts. Read-only; never edits, merges, or commits.',
+  phases: [
+    { title: 'Review', detail: 'reviewers (and optional conformance testers) over the diff scope' },
+    { title: 'Verify', detail: 'adversarial skeptic per deduped finding' },
+  ],
+}
+
+function parseArgs(raw) {
+  if (raw && typeof raw === 'object') return raw
+  if (typeof raw !== 'string' || raw.length === 0) return null
+  try {
+    return JSON.parse(raw)
+  } catch (e) {
+    return null
+  }
+}
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  required: ['findings'],
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['summary', 'file'],
+        properties: {
+          summary: { type: 'string' },
+          file: { type: 'string' },
+          line: { type: 'integer' },
+          severity: { type: 'string', enum: ['critical', 'major', 'minor'] },
+          claim: { type: 'string', description: 'the one-line defect claim, used for dedup' },
+        },
+      },
+    },
+  },
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  required: ['is_real', 'reasoning'],
+  properties: {
+    is_real: { type: 'boolean' },
+    reasoning: { type: 'string' },
+  },
+}
+
+const CONFORMANCE_SCHEMA = {
+  type: 'object',
+  required: ['feature_id', 'criteria'],
+  properties: {
+    feature_id: { type: 'string' },
+    criteria: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['criterion', 'result'],
+        properties: {
+          criterion: { type: 'string' },
+          result: { type: 'string', enum: ['PASS', 'FAIL', 'NOT-TESTABLE'] },
+          note: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+function reviewPrompt(dimension, scope) {
+  return [
+    'You are a senior code reviewer. Review the changes described by this scope: ' + scope + '.',
+    'Use read-only git (`git diff`, `git show`, `git log`) and file reads only; you may run the test suite. Do NOT edit anything.',
+    'Your review dimension: ' + dimension.prompt,
+    'Report only defects you can tie to a concrete failure scenario. For each finding set a one-line `claim` — the defect stated in a single sentence — used to deduplicate against other reviewers.',
+  ].join('\n')
+}
+
+// dedup key: same file + same line-ish + same claim collapses to one finding. Plain
+// code, at a barrier — the whole point is to fan verification over UNIQUE findings, not
+// re-verify the same defect three reviewers each reported (OVI-140 review-loop lesson).
+function dedupeKey(f) {
+  return (f.file || '') + '|' + (f.line || '') + '|' + (f.claim || f.summary || '').slice(0, 80).toLowerCase()
+}
+
+// ---- run --------------------------------------------------------------------
+const parsed = parseArgs(args)
+if (!parsed || typeof parsed !== 'object') {
+  throw new Error('review-branch: args did not parse to an object. Pass {scope, dimensions?, features?, conformance?} (JSON).')
+}
+const scope = parsed.scope || parsed.branch || parsed.diffScope
+if (!scope) {
+  throw new Error('review-branch: args must name a `scope` (or `branch`/`diffScope`) to review.')
+}
+const DIMENSIONS = Array.isArray(parsed.dimensions) && parsed.dimensions.length
+  ? parsed.dimensions
+  : [
+    { key: 'correctness', prompt: 'correctness and security — logic errors, unhandled inputs, silent failures.' },
+    { key: 'tests', prompt: 'test quality and specification-gaming — assertions that would pass against broken code, hardcoded outputs, suppressed errors.' },
+  ]
+
+phase('Review')
+// Barrier here is intentional: dedup needs ALL reviewers' findings together before the
+// verify fan-out, so the fan-out runs over unique findings only.
+const reviewResults = await parallel(DIMENSIONS.map((d) => () =>
+  agent(reviewPrompt(d, scope), { label: 'review:' + d.key, phase: 'Review', schema: FINDINGS_SCHEMA, agentType: 'vv-harness:reviewer' })
+))
+
+// Optional author-blind conformance pass, spec-only, per feature (F017 pattern).
+let conformance = []
+if (parsed.conformance && Array.isArray(parsed.features) && parsed.featureSpecs) {
+  const confResults = await parallel(parsed.features.map((id) => () => {
+    const fs = parsed.featureSpecs[id] || {}
+    if (!fs.spec) return Promise.resolve(null)
+    return agent(
+      'You write author-blind conformance tests. From this verified spec ALONE — never read the implementation diff, the implementer\'s tests, or any completion message — derive tests for feature ' + id + ' and report PASS/FAIL/NOT-TESTABLE per acceptance criterion.\n\nSpec:\n' + fs.spec,
+      { label: 'conformance:' + id, phase: 'Review', schema: CONFORMANCE_SCHEMA, agentType: 'vv-harness:conformance-tester', model: 'sonnet' }
+    )
+  }))
+  conformance = confResults.filter(Boolean)
+}
+
+const allFindings = reviewResults.filter(Boolean).flatMap((r) => r.findings || [])
+const seen = new Set()
+const unique = []
+for (const f of allFindings) {
+  const k = dedupeKey(f)
+  if (seen.has(k)) continue
+  seen.add(k)
+  unique.push(f)
+}
+log('review-branch: ' + allFindings.length + ' raw findings, ' + unique.length + ' unique after dedup')
+
+phase('Verify')
+const verified = await parallel(unique.map((f) => () =>
+  agent(
+    'A reviewer reported this finding on ' + scope + ':\n\n' + (f.summary || f.claim) + '\nFile: ' + (f.file || '?') + (f.line ? (' line ' + f.line) : '') + '\n\nTry to REFUTE it. Reproduce the claimed failure against the actual code (read-only git + file reads; you may run tests). If you cannot demonstrate it concretely, is_real=false. Default to false when uncertain.',
+    { label: 'verify:' + (f.file || 'finding'), phase: 'Verify', schema: VERDICT_SCHEMA }
+  ).then((v) => ({ finding: f, verdict: v }))
+))
+
+const confirmed = verified.filter(Boolean).filter((v) => v.verdict && v.verdict.is_real)
+const rank = { critical: 0, major: 1, minor: 2 }
+confirmed.sort((a, b) => (rank[a.finding.severity] || 3) - (rank[b.finding.severity] || 3))
+
+return {
+  scope: scope,
+  confirmed: confirmed.map((v) => ({ ...v.finding, reasoning: v.verdict.reasoning })),
+  rejected_count: verified.filter(Boolean).length - confirmed.length,
+  conformance: conformance,
+}

--- a/workflows/review-branch.js
+++ b/workflows/review-branch.js
@@ -17,6 +17,40 @@ function parseArgs(raw) {
   }
 }
 
+// Severity rank: lower = more severe, sorted first. Uses ?? (not ||) so `critical`'s
+// legitimate 0 is not treated as "missing" and pushed to the bottom.
+const SEVERITY_RANK = { critical: 0, major: 1, minor: 2 }
+function severityScore(sev) {
+  const r = SEVERITY_RANK[sev]
+  return r === undefined ? 3 : r
+}
+
+// dedup key: same file + same line + same claim collapses to one finding. Severity is
+// deliberately NOT part of the key — duplicates are MERGED keeping the highest severity
+// and the union of reporting dimensions, so a critical reported by a later dimension is
+// never demoted to a minor reported first (OVI-140 review-loop lesson).
+function dedupeKey(f) {
+  return (f.file || '') + '|' + (f.line == null ? '' : f.line) + '|' + (f.claim || f.summary || '').slice(0, 80).toLowerCase()
+}
+
+function mergeFindings(findings) {
+  const byKey = new Map()
+  for (const f of findings) {
+    const k = dedupeKey(f)
+    const prev = byKey.get(k)
+    if (!prev) {
+      byKey.set(k, Object.assign({}, f, { dimensions: f.dimension ? [f.dimension] : [] }))
+      continue
+    }
+    if (severityScore(f.severity) < severityScore(prev.severity)) {
+      prev.severity = f.severity
+      prev.summary = f.summary || prev.summary
+    }
+    if (f.dimension && prev.dimensions.indexOf(f.dimension) === -1) prev.dimensions.push(f.dimension)
+  }
+  return Array.from(byKey.values())
+}
+
 const FINDINGS_SCHEMA = {
   type: 'object',
   required: ['findings'],
@@ -76,17 +110,14 @@ function reviewPrompt(dimension, scope) {
   ].join('\n')
 }
 
-// dedup key: same file + same line-ish + same claim collapses to one finding. Plain
-// code, at a barrier — the whole point is to fan verification over UNIQUE findings, not
-// re-verify the same defect three reviewers each reported (OVI-140 review-loop lesson).
-function dedupeKey(f) {
-  return (f.file || '') + '|' + (f.line || '') + '|' + (f.claim || f.summary || '').slice(0, 80).toLowerCase()
-}
-
+// The pure helpers above (parseArgs, severityScore, dedupeKey, mergeFindings) are
+// defined before this marker and depend on no workflow globals — test/run-tests.sh
+// slices everything above the marker into a temp module and executes them directly
+// (node-guarded), so the severity ordering and dedup/merge logic has real coverage.
 // ---- run --------------------------------------------------------------------
 const parsed = parseArgs(args)
 if (!parsed || typeof parsed !== 'object') {
-  throw new Error('review-branch: args did not parse to an object. Pass {scope, dimensions?, features?, conformance?} (JSON).')
+  throw new Error('review-branch: args did not parse to an object. Pass {scope, dimensions?, features?, conformance?, featureSpecs?} (JSON).')
 }
 const scope = parsed.scope || parsed.branch || parsed.diffScope
 if (!scope) {
@@ -98,54 +129,85 @@ const DIMENSIONS = Array.isArray(parsed.dimensions) && parsed.dimensions.length
     { key: 'correctness', prompt: 'correctness and security — logic errors, unhandled inputs, silent failures.' },
     { key: 'tests', prompt: 'test quality and specification-gaming — assertions that would pass against broken code, hardcoded outputs, suppressed errors.' },
   ]
+// Validate custom dimensions rather than degrade to "dimension: undefined" prompts.
+DIMENSIONS.forEach((d, i) => {
+  if (!d || typeof d !== 'object' || typeof d.prompt !== 'string' || !d.prompt || !d.key) {
+    throw new Error('review-branch: dimensions[' + i + '] must be an object with a non-empty `prompt` and a `key`.')
+  }
+})
+// Conformance requires per-feature specs; fail fast rather than silently skipping the
+// requested author-blind pass (a false clean result on a safety check otherwise).
+if (parsed.conformance) {
+  if (!Array.isArray(parsed.features) || !parsed.features.length) {
+    throw new Error('review-branch: conformance requires a non-empty `features` array.')
+  }
+  if (!parsed.featureSpecs) {
+    throw new Error('review-branch: conformance requires `featureSpecs` mapping each feature ID to its verified spec.')
+  }
+}
 
 phase('Review')
 // Barrier here is intentional: dedup needs ALL reviewers' findings together before the
 // verify fan-out, so the fan-out runs over unique findings only.
 const reviewResults = await parallel(DIMENSIONS.map((d) => () =>
   agent(reviewPrompt(d, scope), { label: 'review:' + d.key, phase: 'Review', schema: FINDINGS_SCHEMA, agentType: 'vv-harness:reviewer' })
+    .then((r) => ({ key: d.key, findings: (r && r.findings) || [] }))
 ))
+const deadReviewers = reviewResults.filter((r) => !r).length
 
-// Optional author-blind conformance pass, spec-only, per feature (F017 pattern).
+// Optional author-blind conformance pass, spec-only, per feature (F017 pattern). Runs
+// in isolated worktrees so these WRITE-capable agents never touch the lead's checkout.
 let conformance = []
-if (parsed.conformance && Array.isArray(parsed.features) && parsed.featureSpecs) {
+if (parsed.conformance) {
   const confResults = await parallel(parsed.features.map((id) => () => {
     const fs = parsed.featureSpecs[id] || {}
-    if (!fs.spec) return Promise.resolve(null)
+    if (!fs.spec) {
+      // Surface the gap explicitly — never silently drop a requested feature.
+      return Promise.resolve({ feature_id: id, criteria: [], skipped: 'no spec supplied in featureSpecs' })
+    }
     return agent(
-      'You write author-blind conformance tests. From this verified spec ALONE — never read the implementation diff, the implementer\'s tests, or any completion message — derive tests for feature ' + id + ' and report PASS/FAIL/NOT-TESTABLE per acceptance criterion.\n\nSpec:\n' + fs.spec,
-      { label: 'conformance:' + id, phase: 'Review', schema: CONFORMANCE_SCHEMA, agentType: 'vv-harness:conformance-tester', model: 'sonnet' }
+      'You write author-blind conformance tests. From this verified spec ALONE — never read the implementation diff, any existing test file for this feature, or any completion message — derive tests for feature ' + id + ' and report PASS/FAIL/NOT-TESTABLE per acceptance criterion.\n\nSpec:\n' + fs.spec,
+      { label: 'conformance:' + id, phase: 'Review', schema: CONFORMANCE_SCHEMA, agentType: 'vv-harness:conformance-tester', model: 'sonnet', isolation: 'worktree' }
     )
   }))
   conformance = confResults.filter(Boolean)
 }
 
-const allFindings = reviewResults.filter(Boolean).flatMap((r) => r.findings || [])
-const seen = new Set()
-const unique = []
-for (const f of allFindings) {
-  const k = dedupeKey(f)
-  if (seen.has(k)) continue
-  seen.add(k)
-  unique.push(f)
-}
-log('review-branch: ' + allFindings.length + ' raw findings, ' + unique.length + ' unique after dedup')
+const allFindings = reviewResults.filter(Boolean).flatMap((r) =>
+  (r.findings || []).map((f) => Object.assign({}, f, { dimension: r.key }))
+)
+const unique = mergeFindings(allFindings)
+log('review-branch: ' + allFindings.length + ' raw findings, ' + unique.length + ' unique after dedup'
+  + (deadReviewers ? (', ' + deadReviewers + ' reviewer(s) died') : ''))
 
 phase('Verify')
+// Verify agents are read-only (vv-harness:reviewer) so the "Read-only" contract holds.
 const verified = await parallel(unique.map((f) => () =>
   agent(
-    'A reviewer reported this finding on ' + scope + ':\n\n' + (f.summary || f.claim) + '\nFile: ' + (f.file || '?') + (f.line ? (' line ' + f.line) : '') + '\n\nTry to REFUTE it. Reproduce the claimed failure against the actual code (read-only git + file reads; you may run tests). If you cannot demonstrate it concretely, is_real=false. Default to false when uncertain.',
-    { label: 'verify:' + (f.file || 'finding'), phase: 'Verify', schema: VERDICT_SCHEMA }
+    'A reviewer reported this finding on ' + scope + ':\n\n' + (f.summary || f.claim) + '\nFile: ' + (f.file || '?') + (f.line ? (' line ' + f.line) : '') + '\n\nTry to REFUTE it against the actual code (read-only git + file reads; you may run tests). If you cannot demonstrate it concretely, is_real=false. Default to false when uncertain.',
+    { label: 'verify:' + (f.file || 'finding'), phase: 'Verify', schema: VERDICT_SCHEMA, agentType: 'vv-harness:reviewer' }
   ).then((v) => ({ finding: f, verdict: v }))
 ))
 
-const confirmed = verified.filter(Boolean).filter((v) => v.verdict && v.verdict.is_real)
-const rank = { critical: 0, major: 1, minor: 2 }
-confirmed.sort((a, b) => (rank[a.finding.severity] || 3) - (rank[b.finding.severity] || 3))
+// Partition honestly: a null verify result (agent died — e.g. rate limit) is UNVERIFIED,
+// not refuted. Never report a branch clean because its verifiers were killed.
+const confirmed = []
+const refuted = []
+const unverified = []
+for (let i = 0; i < unique.length; i++) {
+  const v = verified[i]
+  if (!v || !v.verdict) { unverified.push(unique[i]); continue }
+  if (v.verdict.is_real) confirmed.push(Object.assign({}, v.finding, { reasoning: v.verdict.reasoning }))
+  else refuted.push(unique[i])
+}
+confirmed.sort((a, b) => severityScore(a.severity) - severityScore(b.severity))
 
 return {
   scope: scope,
-  confirmed: confirmed.map((v) => ({ ...v.finding, reasoning: v.verdict.reasoning })),
-  rejected_count: verified.filter(Boolean).length - confirmed.length,
+  confirmed: confirmed,
+  refuted_count: refuted.length,
+  unverified: unverified,
   conformance: conformance,
+  dropped: { reviewers: deadReviewers, verifiers: unverified.length },
+  complete: deadReviewers === 0 && unverified.length === 0,
 }


### PR DESCRIPTION
Implements the first three phases of OVI-140. Workflow mode becomes the primary parallel path; Agent Teams is demoted (Step 5c, legacy), not yet retired — this release is additive and holds the rollback boundary.

## Phase 0 — verification (F110/OVI-141)
`evals/workflow-gate-verification.md`: grounded verdicts for all 8 spike questions, run empirically as workflow agents. Established: PreToolUse gates + the secret scan fire for worktree workflow agents (via the `CLAUDE_PROJECT_DIR`-unset git-toplevel fallback — flagged fragile for doctor), `TaskCompleted` fires on lead self-completion, Subagent events reach hooks, changed worktrees need lead cleanup, and `args` arrives as a JSON **string**. GO — enforcement stays in the hooks (OVI-140's hard-gate escape not triggered).

## Phase 1 — workflow scripts (F111+F112/OVI-142)
- `workflows/implement-features.js`: one Sonnet implementer per feature in an isolated worktree, then an Opus reviewer over the branch diff (never the implementer's notes); returns per-feature results with a partial-result/`unfinished` contract; never merges/commits/edits features.json — integration is the lead's.
- `workflows/review-branch.js`: fan reviewers, dedup findings (max-severity merge) before an adversarial verify pass, ranked confirmed verdicts, optional author-blind conformance in isolated worktrees.

## Phase 2 — harness-continue workflow mode (F113/OVI-143)
Three-way mode decision + availability probe with plain-subagent fallback; Step 5b orchestration flow pinning the integration order (local tests → merge → status flip → task complete → commit), mandatory `feature_id` task mirroring, worktree hygiene, and resume of unfinished runs. Teams retained as Step 5c.

## Review round
One adversarial-review pass (2 Opus reviewers + verify) over the combined diff found **20 confirmed findings**, all fixed before release — severity-rank inversion, an un-interpolated `<mergeBase>`, silent conformance no-ops, dead-agent accounting, and (the meta-finding) grep-only tests that let those ship green. The suite now has its first **executable** coverage: node-guarded tests slice the scripts' pure helpers into temp modules and run them (proven to fail on the original severity bug), skipping cleanly when node is absent.

## Testing
Full suite 2144/2144 (from 2070; +74, incl. 15 executed helper assertions). Smoke green. `node --check` clean on both scripts. Phases 3–6 remain in OVI-140 for later sessions.

Spec-verification returned ASK on both phase specs; resolutions are recorded in each feature's `features.json` notes (notably: reviewer runs Opus and reads the diff — reviewer.md wins over OVI-142's "Sonnet/spec-only" wording, since F017 author-blindness is the conformance-tester's, not the reviewer's).