### PR TITLE
v6.0.1: field-validation fixes (model policy, mandated-conformance warning, coverage omission, worktree scope-diff)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vv-harness",
   "displayName": "VV Claude Code Harness",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Multi-session continuity, worktree-isolated parallel workflows, and mechanical quality enforcement for Claude Code.",
   "author": {
     "name": "oeftimie",

--- a/.claude/hooks/verify-task-quality.sh
+++ b/.claude/hooks/verify-task-quality.sh
@@ -326,6 +326,18 @@ if match is not None:
         if not isinstance(target, int) or isinstance(target, bool):
             target = 95
         coverage_result = "pass" if coverage >= target else f"{coverage}|{target}"
+    elif coverage is None and isinstance(match.get("coverage_target"), int) \
+            and not isinstance(match.get("coverage_target"), bool):
+        # Declared a numeric target, recorded nothing: an omission, not a
+        # convention -- the gate silently didn't run on a feature that asked for
+        # it. Deliberately narrow. A project with no coverage tooling at all sets
+        # no target, and a descriptive string (this repo's own convention) is a
+        # choice, not an omission; both stay silent, or the note would fire on
+        # every task completion for whole classes of projects and be pure
+        # friction. The broader "nobody machine-checked the 95% bar" gap that
+        # OVI-147's field sessions reported is lead-discipline at close-out, not
+        # something this per-task hook can carry without becoming noise.
+        coverage_result = "unrecorded"
 print(coverage_result)
 
 # Claim-matched proof: warn (never block) when this feature accepts with no
@@ -336,8 +348,18 @@ proof_warning = ""
 if match is not None:
     proof = match.get("proof")
     qa_binding = match.get("qa_binding")
+    evidence_type = proof.get("evidence_type") if proof else None
+    # An elevated feature's author-blind conformance pass is mandated by the harness
+    # itself (harness-continue Step 5b, step 3.5: "record proof.evidence_type:
+    # 'conformance'"), so warning about it flags the documented path as a defect --
+    # observed on every elevated feature in OVI-147's field validation. Exempt exactly
+    # that pair; every other binding/evidence mismatch still warns, including a
+    # conformance proof on a NON-elevated feature (nothing mandated it there).
+    mandated_conformance = evidence_type == "conformance" and match.get("risk") == "elevated"
     if not proof:
         proof_warning = f"WARN: {feature_id} accepted with no proof recorded."
+    elif mandated_conformance:
+        pass
     elif qa_binding and proof.get("evidence_type") != qa_binding:
         proof_warning = (
             f"WARN: {feature_id}'s proof.evidence_type "
@@ -447,8 +469,15 @@ COVERAGE_BASELINE_ARG=""
 if [ -n "$FEATURE_ID" ]; then
     COVERAGE_BASELINE_ARG="coverage:$FEATURE_ID=drop"
 fi
+COVERAGE_NOTE=""
 if [ "$COVERAGE_RESULT" = "pass" ]; then
     COVERAGE_BASELINE_ARG="coverage:$FEATURE_ID=pass"
+elif [ "$COVERAGE_RESULT" = "unrecorded" ]; then
+    # Visible, never blocking: the gate did not run, and silence would read as
+    # "checked and fine". Keeps the =drop baseline of any other unevaluated case;
+    # MUST stay above the generic non-empty branch below, which would otherwise
+    # parse this marker as an achieved|target miss and reject the task.
+    COVERAGE_NOTE="NOTE: $FEATURE_ID records no coverage, so the coverage gate did not run -- the target was not checked."
 elif [ -n "$COVERAGE_RESULT" ]; then
     ACHIEVED="${COVERAGE_RESULT%%|*}"
     TARGET="${COVERAGE_RESULT##*|}"
@@ -493,14 +522,18 @@ fi
 # no-op here. Both warnings are combined into ONE systemMessage (not two
 # separate echoes) since only a single JSON object can be emitted per hook
 # invocation.
+# Built by appending every non-empty note, so a third one (v6.0.1's unrecorded-
+# coverage note) can't silently displace the other two the way a fixed if/elif
+# ladder over two variables would.
 SYSTEM_MESSAGE=""
-if [ -n "$PROOF_WARNING" ] && [ -n "$IN_PROGRESS_NOTE" ]; then
-    SYSTEM_MESSAGE="$PROOF_WARNING"$'\n'"$IN_PROGRESS_NOTE"
-elif [ -n "$PROOF_WARNING" ]; then
-    SYSTEM_MESSAGE="$PROOF_WARNING"
-elif [ -n "$IN_PROGRESS_NOTE" ]; then
-    SYSTEM_MESSAGE="$IN_PROGRESS_NOTE"
-fi
+for _NOTE in "$PROOF_WARNING" "$COVERAGE_NOTE" "$IN_PROGRESS_NOTE"; do
+    [ -n "$_NOTE" ] || continue
+    if [ -n "$SYSTEM_MESSAGE" ]; then
+        SYSTEM_MESSAGE="$SYSTEM_MESSAGE"$'\n'"$_NOTE"
+    else
+        SYSTEM_MESSAGE="$_NOTE"
+    fi
+done
 
 if [ -n "$SYSTEM_MESSAGE" ]; then
     python3 -c "

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 Version history for the VV Claude Code Harness. The current version lives in `.claude-plugin/plugin.json`.
 
+### v6.0.1 (2026-08-14)
+
+Four fixes from v6.0.0's own field validation, plus the CI repair it uncovered.
+
+1. **Elevation escalates the review stage, not the implementer (F118)** —
+   `rules/parallel-work.md` told the lead twice to "upgrade its implementer to Opus"
+   for elevated features, while the same section, OVI-140's model policy, and
+   `implement-features.js` all scope escalation to the review pass. The rule carried
+   Teams-era residue; the script was right. Swept the rule to match, and added an
+   optional per-feature `featureSpecs[ID].implementModel` so the historical-signals
+   table's `correction_cycles >= 3` case has an actual lever (default unchanged:
+   Sonnet).
+2. **The mandated conformance proof no longer warns (F119)** — `harness-continue`
+   Step 5b step 3.5 requires `proof.evidence_type: "conformance"` on an elevated
+   feature, and `verify-task-quality.sh` then warned that it didn't match the
+   declared `qa_binding`: following the documented path guaranteed a warning. Exempts
+   exactly that pair (conformance + elevated); a conformance proof on a standard-risk
+   feature still warns.
+3. **A declared-but-unmeasured coverage target is surfaced (F120)** — a feature that
+   sets a numeric `coverage_target` and records no `coverage` now gets a visible,
+   non-blocking note instead of silence. Deliberately narrow: projects that declare no
+   target, and this repo's own descriptive coverage strings, stay silent.
+4. **Scope-diff recovered worktree branches before merging (F121)** — an interrupted
+   run leaves a branch nobody reviewed, and the PreToolUse scope gate reports per call,
+   not per branch. OVI-147's fallback drill recovered one carrying an unrelated edit
+   that removed the project's own `permissions.deny: ["Workflow"]`, caught only because
+   a human read the diff. Now a documented step in the rule and the skill.
+5. **CI repair** — two harness-doctor health assertions compared the tool's whole
+   output to the literal `healthy`, so v6.0.0's own workflow-support notices failed the
+   suite in any environment without a `claude` CLI. `main` had been red since
+   2026-08-12 and two releases merged over it.
+
 ### v6.0.0 (2026-08-14)
 
 **Breaking: Agent Teams machinery removed. Dynamic workflows are the orchestration

--- a/rules/parallel-work.md
+++ b/rules/parallel-work.md
@@ -142,9 +142,9 @@ NAME fills each tier is a binding, held in the Model Selection table above.
 
 ## Dynamic overrides
 
-**Static elevation criteria**: a feature is elevated risk — upgrade its implementer to
-Opus and record `risk: "elevated"` plus `require_plan_approval: true` on the feature —
-when any of these holds, regardless of history:
+**Static elevation criteria**: a feature is elevated risk — record `risk: "elevated"`
+plus `require_plan_approval: true` on the feature — when any of these holds, regardless
+of history:
 - Touches 10+ files or spans multiple modules
 - Cross-cutting concerns (changing a shared interface)
 - Security-sensitive code (authentication, authorization, crypto)
@@ -156,17 +156,26 @@ implement-features script raises the reviewer's effort when `featureSpecs[ID].ri
 `"elevated"`) and, optionally, the author-blind conformance check (`/harness-continue`
 Step 5b, step 3.5).
 
+**Elevation escalates the review stage, not the implementer.** Executors default to
+Sonnet (Model Selection above); risk buys a deeper review pass and, optionally, a
+spec-derived conformance pass — both of which judge the work rather than produce it.
+This is deliberate: two mechanisms describing one model policy drift apart, so the
+script owns the automatic part and there is exactly one place it happens. The lead can
+still override a single feature's implementer — the historical-signals table below is
+the reason to — by passing `featureSpecs[ID].implementModel` at launch; absent it,
+implementers run on their agent definition's model.
+
 **Historical signals** (based on operational metrics from past sessions): before
 assigning models, the lead reviews `features.json` for patterns in the same scope
 directories:
 
 | Historical signal | Action |
 |-------------------|--------|
-| `correction_cycles >= 3` on a past feature in the same scope | Upgrade this feature's implementer to Opus |
+| `correction_cycles >= 3` on a past feature in the same scope | Upgrade this feature's implementer to Opus, via `featureSpecs[ID].implementModel` |
 | `scope_expansions >= 3` on a past feature | Assign a broader initial scope; note it as expansion-prone in the feature's spec |
 | `failure_reason` mentions "approach mismatch" or "misunderstood interface" | Set `require_plan_approval: true` |
 | `discovered_via` depth > 1 (discovered features spawning discovered features) | Fold into parent scope rather than running it as a separate feature |
-| Stamp or prep marked risk: "elevated" | Set require_plan_approval: true and upgrade the implementer to Opus |
+| Stamp or prep marked risk: "elevated" | Set require_plan_approval: true; escalation is automatic and review-side (below) — the implementer stays Sonnet |
 
 These are judgment calls for the lead, not mechanical rules. If no historical data
 exists (first session, new scope), default to Sonnet.
@@ -231,6 +240,22 @@ branch is its durable deliverable: work survives a dead agent because it is comm
 on that branch, not because the agent reported it. After merging a feature's branch,
 remove the changed worktree before any repo-wide suite run — a leftover worktree
 hands repo-wide assertions a duplicate copy of every file (verified in Phase 0).
+
+**Scope-diff every branch you did not watch produced.** Before merging a worktree
+branch recovered from an interrupted or dead run, diff the files it touched against
+that feature's declared `scope` and account for every file outside it:
+
+```bash
+git diff --name-only <mergeBase>...<worktree_branch>
+```
+
+An agent that dies mid-run leaves a branch nobody reviewed, and the enforcement that
+normally bounds it (the PreToolUse scope gate) reports per call, not per branch — so
+an out-of-scope edit on that branch reaches the merge unannounced. In OVI-147's
+fallback drill a recovered branch carried an edit removing the project's own
+`permissions.deny: ["Workflow"]` — unrelated to the feature, caught only because the
+recovering lead happened to read the diff. Exclude what doesn't belong; merging is
+the point of no return.
 
 ## Integration failure recovery
 

--- a/skills/harness-continue/SKILL.md
+++ b/skills/harness-continue/SKILL.md
@@ -359,7 +359,10 @@ the `TaskCompleted` and commit gates fire in the lead session. Run these steps *
    `Workflow({scriptPath, resumeFromRunId, args})` — completed agents replay from
    cache; the ORIGINAL `args` must be resent or the resume fails fast (OVI-147
    field validation) — or reconcile from the committed worktree branches; do not
-   silently drop them.
+   silently drop them. Before merging any branch produced by a run you did not watch
+   to completion, scope-diff it (`git diff --name-only <mergeBase>...<branch>`) and
+   account for every file outside that feature's declared `scope` — see
+   `rules/parallel-work.md`, "Worktree hygiene".
 6. **Retrospective.** Run the retrospective, promotion, and ablation passes plus the
    MLD telemetry — the Retrospective section below.
 

--- a/skills/harness-init/verify-task-quality.sh.template
+++ b/skills/harness-init/verify-task-quality.sh.template
@@ -326,6 +326,18 @@ if match is not None:
         if not isinstance(target, int) or isinstance(target, bool):
             target = 95
         coverage_result = "pass" if coverage >= target else f"{coverage}|{target}"
+    elif coverage is None and isinstance(match.get("coverage_target"), int) \
+            and not isinstance(match.get("coverage_target"), bool):
+        # Declared a numeric target, recorded nothing: an omission, not a
+        # convention -- the gate silently didn't run on a feature that asked for
+        # it. Deliberately narrow. A project with no coverage tooling at all sets
+        # no target, and a descriptive string (this repo's own convention) is a
+        # choice, not an omission; both stay silent, or the note would fire on
+        # every task completion for whole classes of projects and be pure
+        # friction. The broader "nobody machine-checked the 95% bar" gap that
+        # OVI-147's field sessions reported is lead-discipline at close-out, not
+        # something this per-task hook can carry without becoming noise.
+        coverage_result = "unrecorded"
 print(coverage_result)
 
 # Claim-matched proof: warn (never block) when this feature accepts with no
@@ -336,8 +348,18 @@ proof_warning = ""
 if match is not None:
     proof = match.get("proof")
     qa_binding = match.get("qa_binding")
+    evidence_type = proof.get("evidence_type") if proof else None
+    # An elevated feature's author-blind conformance pass is mandated by the harness
+    # itself (harness-continue Step 5b, step 3.5: "record proof.evidence_type:
+    # 'conformance'"), so warning about it flags the documented path as a defect --
+    # observed on every elevated feature in OVI-147's field validation. Exempt exactly
+    # that pair; every other binding/evidence mismatch still warns, including a
+    # conformance proof on a NON-elevated feature (nothing mandated it there).
+    mandated_conformance = evidence_type == "conformance" and match.get("risk") == "elevated"
     if not proof:
         proof_warning = f"WARN: {feature_id} accepted with no proof recorded."
+    elif mandated_conformance:
+        pass
     elif qa_binding and proof.get("evidence_type") != qa_binding:
         proof_warning = (
             f"WARN: {feature_id}'s proof.evidence_type "
@@ -447,8 +469,15 @@ COVERAGE_BASELINE_ARG=""
 if [ -n "$FEATURE_ID" ]; then
     COVERAGE_BASELINE_ARG="coverage:$FEATURE_ID=drop"
 fi
+COVERAGE_NOTE=""
 if [ "$COVERAGE_RESULT" = "pass" ]; then
     COVERAGE_BASELINE_ARG="coverage:$FEATURE_ID=pass"
+elif [ "$COVERAGE_RESULT" = "unrecorded" ]; then
+    # Visible, never blocking: the gate did not run, and silence would read as
+    # "checked and fine". Keeps the =drop baseline of any other unevaluated case;
+    # MUST stay above the generic non-empty branch below, which would otherwise
+    # parse this marker as an achieved|target miss and reject the task.
+    COVERAGE_NOTE="NOTE: $FEATURE_ID records no coverage, so the coverage gate did not run -- the target was not checked."
 elif [ -n "$COVERAGE_RESULT" ]; then
     ACHIEVED="${COVERAGE_RESULT%%|*}"
     TARGET="${COVERAGE_RESULT##*|}"
@@ -493,14 +522,18 @@ fi
 # no-op here. Both warnings are combined into ONE systemMessage (not two
 # separate echoes) since only a single JSON object can be emitted per hook
 # invocation.
+# Built by appending every non-empty note, so a third one (v6.0.1's unrecorded-
+# coverage note) can't silently displace the other two the way a fixed if/elif
+# ladder over two variables would.
 SYSTEM_MESSAGE=""
-if [ -n "$PROOF_WARNING" ] && [ -n "$IN_PROGRESS_NOTE" ]; then
-    SYSTEM_MESSAGE="$PROOF_WARNING"$'\n'"$IN_PROGRESS_NOTE"
-elif [ -n "$PROOF_WARNING" ]; then
-    SYSTEM_MESSAGE="$PROOF_WARNING"
-elif [ -n "$IN_PROGRESS_NOTE" ]; then
-    SYSTEM_MESSAGE="$IN_PROGRESS_NOTE"
-fi
+for _NOTE in "$PROOF_WARNING" "$COVERAGE_NOTE" "$IN_PROGRESS_NOTE"; do
+    [ -n "$_NOTE" ] || continue
+    if [ -n "$SYSTEM_MESSAGE" ]; then
+        SYSTEM_MESSAGE="$SYSTEM_MESSAGE"$'\n'"$_NOTE"
+    else
+        SYSTEM_MESSAGE="$_NOTE"
+    fi
+done
 
 if [ -n "$SYSTEM_MESSAGE" ]; then
     python3 -c "

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -5379,6 +5379,89 @@ assert_rc0 "$RC" "ht: acceptance with mismatched proof/qa_binding still exits 0"
 assert_contains "$OUT" "unit" "ht: mismatch warning names the declared qa_binding"
 assert_contains "$OUT" "journey" "ht: mismatch warning names the actual evidence_type"
 
+# v6.0.1: harness-continue Step 5b step 3.5 MANDATES proof.evidence_type
+# "conformance" on an elevated feature, so warning about it flagged the harness's
+# own documented path as a defect -- it fired on every elevated feature in
+# OVI-147's field validation. The exemption is exactly that pair.
+DIR_HQ9B="$WORK/ht-quality-elevated-conformance"
+make_fixture "$DIR_HQ9B"
+install_hooks "$DIR_HQ9B"
+printf '#!/bin/bash\nexit 0\n' > "$DIR_HQ9B/.harness/init.sh"
+set_f003_fields "$DIR_HQ9B" 'feature["qa_binding"] = "unit"
+        feature["risk"] = "elevated"
+        feature["proof"] = {"claim": "x", "evidence_type": "conformance",
+        "artifact": "y", "not_established": "z"}'
+OUT=$(run_hook "$DIR_HQ9B" verify-task-quality.sh '{"task":{"metadata":{"feature_id":"F003"}}}' 2>&1)
+RC=$?
+assert_rc0 "$RC" "ht: an elevated feature's mandated conformance proof exits 0"
+assert_not_contains "$OUT" "does not match" \
+  "ht (v6.0.1): the harness-mandated conformance proof on an elevated feature does not warn"
+
+# The exemption is narrow: a conformance proof on a NON-elevated feature was never
+# mandated by anything, so the mismatch still warns.
+DIR_HQ9C="$WORK/ht-quality-standard-conformance"
+make_fixture "$DIR_HQ9C"
+install_hooks "$DIR_HQ9C"
+printf '#!/bin/bash\nexit 0\n' > "$DIR_HQ9C/.harness/init.sh"
+set_f003_fields "$DIR_HQ9C" 'feature["qa_binding"] = "unit"
+        feature["risk"] = "standard"
+        feature["proof"] = {"claim": "x", "evidence_type": "conformance",
+        "artifact": "y", "not_established": "z"}'
+OUT=$(run_hook "$DIR_HQ9C" verify-task-quality.sh '{"task":{"metadata":{"feature_id":"F003"}}}' 2>&1)
+assert_contains "$OUT" "does not match" \
+  "ht (v6.0.1): a conformance proof on a standard-risk feature still warns (exemption stays narrow)"
+
+# v6.0.1 (F120): a feature that DECLARED a numeric coverage_target but recorded no
+# coverage gets a visible, non-blocking note -- the gate silently didn't run on a
+# feature that asked for it. The marker must never be parsed as an achieved|target
+# miss (that would reject the task).
+DIR_HQ9D="$WORK/ht-quality-coverage-unrecorded"
+make_fixture "$DIR_HQ9D"
+install_hooks "$DIR_HQ9D"
+printf '#!/bin/bash\nexit 0\n' > "$DIR_HQ9D/.harness/init.sh"
+set_f003_fields "$DIR_HQ9D" 'feature["coverage"] = None
+        feature["coverage_target"] = 95
+        feature["qa_binding"] = "unit"
+        feature["proof"] = {"claim": "x", "evidence_type": "unit",
+        "artifact": "y", "not_established": "z"}'
+OUT=$(run_hook "$DIR_HQ9D" verify-task-quality.sh '{"task":{"metadata":{"feature_id":"F003"}}}' 2>&1)
+RC=$?
+assert_rc0 "$RC" "ht (F120): a declared-but-unrecorded coverage target accepts (never blocks)"
+assert_contains "$OUT" "records no coverage" \
+  "ht (F120): a declared-but-unrecorded coverage target surfaces a visible note"
+assert_not_contains "$OUT" "Task rejected" \
+  "ht (F120): the unrecorded marker is never parsed as a coverage miss"
+
+# Deliberately narrow. A project with no coverage tooling declares no target, and a
+# descriptive coverage string (this repo's own convention) is a choice, not an
+# omission -- both stay silent. Without this, the note fired on every task
+# completion for whole classes of projects; the existing F057 "a fully clean accept
+# has no stdout at all" assertion caught exactly that.
+DIR_HQ9E="$WORK/ht-quality-coverage-descriptive"
+make_fixture "$DIR_HQ9E"
+install_hooks "$DIR_HQ9E"
+printf '#!/bin/bash\nexit 0\n' > "$DIR_HQ9E/.harness/init.sh"
+set_f003_fields "$DIR_HQ9E" 'feature["coverage"] = "2036/2036 suite assertions"
+        feature["coverage_target"] = 95
+        feature["qa_binding"] = "unit"
+        feature["proof"] = {"claim": "x", "evidence_type": "unit",
+        "artifact": "y", "not_established": "z"}'
+OUT=$(run_hook "$DIR_HQ9E" verify-task-quality.sh '{"task":{"metadata":{"feature_id":"F003"}}}' 2>&1)
+assert_not_contains "$OUT" "records no coverage" \
+  "ht (F120): a deliberate descriptive coverage string stays silent"
+
+DIR_HQ9F="$WORK/ht-quality-coverage-no-target"
+make_fixture "$DIR_HQ9F"
+install_hooks "$DIR_HQ9F"
+printf '#!/bin/bash\nexit 0\n' > "$DIR_HQ9F/.harness/init.sh"
+set_f003_fields "$DIR_HQ9F" 'feature["coverage"] = None
+        feature["qa_binding"] = "unit"
+        feature["proof"] = {"claim": "x", "evidence_type": "unit",
+        "artifact": "y", "not_established": "z"}'
+OUT=$(run_hook "$DIR_HQ9F" verify-task-quality.sh '{"task":{"metadata":{"feature_id":"F003"}}}' 2>&1)
+assert_not_contains "$OUT" "records no coverage" \
+  "ht (F120): a project that declares no coverage target stays silent (no per-task friction)"
+
 DIR_HQ10="$WORK/ht-quality-legacy-no-binding"
 make_fixture "$DIR_HQ10"
 install_hooks "$DIR_HQ10"
@@ -13685,7 +13768,7 @@ done
 # implement-features specifics.
 IF_SRC=$(cat "$REPO_ROOT/workflows/implement-features.js" 2>/dev/null)
 # Every agent() spawn in the implement path carries an explicit model or agentType.
-assert_contains "$IF_SRC" "model: 'sonnet'" "wf (impl): implementer runs Sonnet"
+assert_contains "$IF_SRC" "'sonnet'" "wf (impl): implementer defaults to Sonnet"
 assert_contains "$IF_SRC" "agentType: 'vv-harness:feature-implementer'" "wf (impl): implementer uses the plugin agent type"
 assert_contains "$IF_SRC" "agentType: 'vv-harness:reviewer'" "wf (impl): reviewer uses the plugin agent type (Opus by definition)"
 assert_contains "$IF_SRC" "isolation: 'worktree'" "wf (impl): implementers run in isolated worktrees"
@@ -13704,6 +13787,14 @@ assert_not_contains "$IF_SRC" "git diff <mergeBase>" "wf (impl): reviewer prompt
 assert_contains "$IF_SRC" "spec.mergeBase + '...' + branch" "wf (impl): reviewer prompt interpolates the real merge base"
 # risk is live, not a dead arg: an elevated feature escalates the review effort.
 assert_contains "$IF_SRC" "spec.risk === 'elevated') reviewOpts.effort" "wf (impl): elevated risk escalates the review pass"
+# v6.0.1: risk escalates the REVIEW stage only -- the implementer stays on its default
+# model. rules/parallel-work.md said twice to upgrade the implementer to Opus while the
+# script (correctly, per OVI-140's model policy) never did; the rule was swept to match.
+# The lead keeps a per-feature lever for the historical-signals table's correction_cycles
+# case, mirroring reviewModel.
+assert_not_contains "$IF_SRC" "spec.risk === 'elevated' ? 'opus'" "wf (impl): elevated risk does NOT silently escalate the implementer's model"
+assert_contains "$IF_SRC" "spec.implementModel || 'sonnet'" "wf (impl): implementer model is per-feature overridable, defaulting to Sonnet"
+assert_contains "$IF_SRC" "implementModel: fs.implementModel" "wf (impl): implementModel is carried from featureSpecs onto the spec"
 
 # review-branch specifics.
 RB_SRC=$(cat "$REPO_ROOT/workflows/review-branch.js" 2>/dev/null)
@@ -14283,7 +14374,11 @@ need("Author blindness",
 #    worktrees are removed after merge, before any repo-wide suite run.
 need("Worktree hygiene",
      ["never merge", "the lead integrates",
-      "remove the changed worktree before any repo-wide suite run"])
+      "remove the changed worktree before any repo-wide suite run",
+      # v6.0.1 (F121): a branch from an unwatched run must be scope-diffed before
+      # merge -- OVI-147's fallback drill recovered one carrying an unauthorized
+      # settings edit, caught only because a human read the diff.
+      "git diff --name-only", "declared `scope`"])
 # f. Escalation: Opus review routing, and the single-session fallback triggers
 #    (blocked results, review rounds exhausted).
 need("Escalation",

--- a/workflows/implement-features.js
+++ b/workflows/implement-features.js
@@ -152,6 +152,11 @@ const specs = featureIds.map((id) => {
     scope: fs.scope || [],
     risk: fs.risk === 'elevated' ? 'elevated' : 'standard',
     mergeBase: fs.mergeBase || parsed.mergeBase || 'HEAD',
+    // Optional per-feature implementer model. Risk elevation escalates the REVIEW
+    // stage, never the implementer (rules/parallel-work.md, "Dynamic overrides"), so
+    // this is the lead's only lever — it exists for that rule's historical-signals
+    // case (`correction_cycles >= 3` in the same scope), not for risk.
+    implementModel: fs.implementModel,
   }
 })
 
@@ -168,7 +173,7 @@ const results = await pipeline(
     schema: IMPLEMENT_SCHEMA,
     isolation: 'worktree',
     agentType: 'vv-harness:feature-implementer',
-    model: 'sonnet',
+    model: spec.implementModel || 'sonnet',
   }),
   (impl, spec) => {
     // A blocked implementer short-circuits its own review — nothing to review.


### PR DESCRIPTION
## What changed

Four defects that v6.0.0's own field validation (OVI-147) surfaced, plus the v6.0.1 bump. Every one was found by running the harness on itself, not by reading code.

### F118 — elevation escalates the review stage, not the implementer

`rules/parallel-work.md` told the lead twice to *"upgrade its implementer to Opus"* for elevated features. The same section four lines later, OVI-140's decided model policy, and `implement-features.js` all scope escalation to the **review** pass. The script was correct; the rule carried Teams-era residue Phase 4's rewrite missed — the exact drift the epic predicted ("two mechanisms describing the same policy will drift").

Swept the rule to match shipped behavior, and added an optional per-feature `featureSpecs[ID].implementModel` (mirroring the existing `reviewModel`) so the rule's historical-signals table — which tells the lead to upgrade an implementer after `correction_cycles >= 3` — has an actual lever. **Default is unchanged**: implementers run Sonnet.

### F119 — the harness no longer warns about the proof it mandates

`harness-continue` Step 5b step 3.5 requires `proof.evidence_type: "conformance"` on an elevated feature; `verify-task-quality.sh` then warned that it didn't match the declared `qa_binding`. Following the documented path guaranteed a warning on every elevated feature. Exempts exactly that pair (conformance **and** elevated) — a conformance proof on a standard-risk feature still warns, and that's pinned.

### F120 — a declared-but-unmeasured coverage target is surfaced

A feature setting a numeric `coverage_target` and recording no `coverage` now gets a visible, non-blocking note.

**Deliberately narrow, and it got narrower under test.** The first version fired whenever coverage was absent — which meant every task completion on any project without coverage tooling. The suite's own pre-existing `ht (F057): a fully clean accept has no stdout at all` assertion caught it. A control that fires constantly is one you remove next session, so the trigger is now a genuine omission only; projects declaring no target and this repo's own descriptive coverage strings stay silent. This does **not** reproduce the broader "nobody machine-checked the 95% bar" complaint from the field sessions — that stays lead-discipline at close-out, and the code says so.

Two traps handled: the `unrecorded` marker needed its own branch **above** the generic `elif [ -n "$COVERAGE_RESULT" ]`, which would have parsed it as an achieved|target miss and rejected the task with exit 2; and `SYSTEM_MESSAGE` assembly is now a loop rather than a two-variable if/elif ladder, so a third note can't silently displace the other two.

### F121 — scope-diff recovered worktree branches before merging

An interrupted run leaves a branch nobody reviewed, and the PreToolUse scope gate reports per call, not per branch. OVI-147's fallback drill recovered a branch carrying an edit that removed the project's own `permissions.deny: ["Workflow"]` — unrelated to the feature, caught only because the recovering lead happened to read the diff. Now a documented step in both `rules/parallel-work.md` ("Worktree hygiene") and the skill.

## Testing

- `bash test/run-tests.sh` → **2051/2051** (9 new assertions)
- `env PATH="/usr/bin:/bin" bash test/run-tests.sh` (CI-equivalent, no `claude` CLI) → **2036/2036**
- F118's grep-based assertions were mutation-checked directly (reverting the script makes both fail); F119/F120 are behavioral tests through the real hook.
- Both hook copies (`.claude/hooks/` and the `skills/harness-init/` template) are in sync and parse under `bash -n`.

## Note

The CI repair that made this branch possible shipped separately in #170 — `main` had been red since 2026-08-12 because two doctor assertions compared the tool's whole output to the literal `healthy`, which v6.0.0's own workflow-support notices broke in any environment without a `claude` CLI.