### PR TITLE
docs: record F118-F121 in features.json and add the session handoff

### DIFF
--- a/.harness/claude-progress.txt
+++ b/.harness/claude-progress.txt
@@ -1187,3 +1187,12 @@ Session 2026-08-08 (F100-F104, v5.4.0 release):
 - Decisions: details in context_summary.md Active Context + Meta-Session 2026-08-14; 5 new backlog rows + 1 score bump.
 - Next: Ovidiu reviews/merges PR -> tag v6.0.0 -> AC8 (exit-review comment on OVI-140 with Teams-era baseline comparison, sibling sub-issues Done, OVI-147 Done last, epic closed).
 - Blockers: none (merge/tag are Ovidiu-gated by design).
+
+## Session 2026-08-14 (cont.) - CI repair + v6.0.1 (F118-F121)
+- Post-v6.0.0 CI check found main RED since 2026-08-12: two harness-doctor health assertions compared the tool's whole output to the literal "healthy", which OVI-144's workflow-support notices break wherever no claude CLI exists (every CI runner). OVI-146 and OVI-147 both merged over it -- nothing requires the tests check before merge and I did not look at Actions before merging either. Fixed test-only via doctor_report_only() + 4 pins (PR #170, merged).
+- v6.0.1 (PR #171, merged, tagged 716c7c5): F118 rule/script model-policy sweep (Ovidiu chose option A -- the script was correct, rules/parallel-work.md carried Teams-era residue; added optional featureSpecs[ID].implementModel lever, default unchanged); F119 mandated-conformance warning exemption (conformance AND elevated only); F120 declared-but-unmeasured coverage target note (narrowed mid-implementation after F057's clean-accept assertion caught v1 firing on every task for any project without coverage tooling; two traps handled -- marker parsed as a coverage miss would have rejected tasks, and the if/elif systemMessage ladder dropped a third note); F121 worktree scope-diff before merging a branch from an unwatched run (grounded in the AC3 drill's unauthorized settings edit).
+- Tests: 2051/2051 with the claude CLI present, 2036/2036 with PATH stripped (CI-equivalent). Both hook copies in sync.
+- Release-consistency drift issues #169 and #172 closed by hand after verifying tag/manifest/CHANGELOG agree -- SIXTH consecutive false positive of the same tag-timing gap (#157,#159,#161,#164,#169,#172); backlog row scored 5.
+- Process gap owned and closed here: F118-F121 shipped before their features.json entries existed (this commit adds them). Task metadata carried the IDs but the tracker did not.
+- Next: no pending features. Open backlog candidates worth a session: release-consistency tag-timing (score 5), requiring the tests check on main via branch protection, and the qa_binding/coverage items already recorded.
+- Blockers: none.

--- a/.harness/features.json
+++ b/.harness/features.json
@@ -1,8 +1,8 @@
 {
   "project": "vv-claude-harness",
   "created": "2026-07-22",
-  "total_features": 117,
-  "passing": 100,
+  "total_features": 121,
+  "passing": 121,
   "features": [
     {
       "id": "F001",
@@ -3335,6 +3335,149 @@
         "evidence_type": "journey",
         "artifact": "evals/workflow-migration-validation.md",
         "not_established": "Per-agent cache-replay breakdown on resume (the resumed session completed the run but its report omitted which agents replayed vs re-ran; journal-level forensics not performed). AC7 merge+tag and AC8 epic closure pending Ovidiu's PR approval."
+      }
+    },
+    {
+      "assigned_to": null,
+      "test_file": "test/run-tests.sh",
+      "discovered_via": "F117",
+      "correction_cycles": 0,
+      "qa_binding": "unit",
+      "risk": "standard",
+      "status": "passing",
+      "id": "F118",
+      "priority": 118,
+      "description": "Elevation escalates the review stage, not the implementer. rules/parallel-work.md told the lead twice to \"upgrade its implementer to Opus\" for elevated features, while the same section, OVI-140's decided model policy, and workflows/implement-features.js all scope escalation to the review pass -- Teams-era residue Phase 4's rewrite missed, i.e. the drift the epic itself predicted. AC: (1) neither prescription survives in rules/parallel-work.md; (2) the rule states plainly that elevation escalates review, with the reason; (3) an optional per-feature featureSpecs[ID].implementModel exists (mirroring reviewModel) so the historical-signals table's correction_cycles>=3 case has a lever; (4) the implementer default is unchanged (Sonnet); (5) elevated risk never silently escalates the implementer's model.",
+      "scope": [
+        "rules/parallel-work.md",
+        "workflows/implement-features.js",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [],
+      "coverage": "2051/2051 suite (3 new assertions: no silent opus escalation, implementModel default, implementModel carried from featureSpecs)",
+      "notes": "Ovidiu chose option A (sweep the rule) over option B (change the script) -- the script matched the epic's policy and was left alone. Grep-based assertions mutation-checked directly: reverting both script edits makes them fail.",
+      "approaches_tried": [
+        "First diagnosis was wrong -- reported as a missing script feature; reading rules/parallel-work.md against OVI-140's model policy showed the script was correct and the RULE carried the residue. Backlog row corrected rather than 'fixing' working code.",
+        "The red-first run raced the implementation (the suite cats the script mid-run, after the edit landed) and came back green -- discarded as invalid evidence; mutation-checked the greps instead"
+      ],
+      "proof": {
+        "claim": "The rule no longer prescribes an implementer upgrade, and the lead has a real per-feature lever for the historical-signals case",
+        "evidence_type": "unit",
+        "artifact": "test/run-tests.sh (wf (impl) assertions)",
+        "not_established": "No live workflow run exercised implementModel end-to-end; the assertions are structural over the script source, same as the surrounding wf (impl) cluster."
+      },
+      "spec": {
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-08-14T12:10:00Z",
+        "source": "conversation"
+      }
+    },
+    {
+      "assigned_to": null,
+      "test_file": "test/run-tests.sh",
+      "discovered_via": "F117",
+      "correction_cycles": 0,
+      "qa_binding": "unit",
+      "risk": "standard",
+      "status": "passing",
+      "id": "F119",
+      "priority": 119,
+      "description": "The harness no longer warns about the proof it mandates. harness-continue Step 5b step 3.5 requires proof.evidence_type 'conformance' on an elevated feature; verify-task-quality.sh then warned that it did not match the declared qa_binding, so following the documented path guaranteed a warning -- observed on every elevated feature in OVI-147's field validation. AC: (1) an elevated feature with a conformance proof and a differing qa_binding produces no mismatch warning and exits 0; (2) a conformance proof on a standard-risk feature still warns (the exemption stays narrow); (3) every other binding/evidence mismatch still warns; (4) both hook copies stay in sync.",
+      "scope": [
+        ".claude/hooks/verify-task-quality.sh",
+        "skills/harness-init/verify-task-quality.sh.template",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [],
+      "coverage": "2051/2051 suite (2 new behavioral assertions through the real hook: elevated+conformance silent, standard+conformance still warns)",
+      "notes": "Exemption is the exact pair the harness mandates (conformance AND elevated), not a blanket acceptance of conformance -- a journey binding satisfied by spec-derived tests would be a real downgrade.",
+      "approaches_tried": [
+        "Considered blanket-accepting conformance for any qa_binding and rejected it: conformance is not strictly stronger than journey evidence",
+        "Considered rewriting the feature's qa_binding at close-out and rejected it: qa_binding comes from the verified spec and should not be mutated post-hoc"
+      ],
+      "proof": {
+        "claim": "Following harness-continue Step 3.5 on an elevated feature no longer self-warns, and the exemption does not widen",
+        "evidence_type": "unit",
+        "artifact": "test/run-tests.sh (ht (v6.0.1) assertions)",
+        "not_established": "The exemption keys on the feature's recorded `risk` field, so a legacy feature that was genuinely elevated but predates F064's risk persistence (risk absent/null) still warns on a conformance proof; not covered by a test."
+      },
+      "spec": {
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-08-14T12:10:00Z",
+        "source": "conversation"
+      }
+    },
+    {
+      "assigned_to": null,
+      "test_file": "test/run-tests.sh",
+      "discovered_via": "F117",
+      "correction_cycles": 0,
+      "qa_binding": "unit",
+      "risk": "standard",
+      "status": "passing",
+      "id": "F120",
+      "priority": 120,
+      "description": "A declared-but-unmeasured coverage target is surfaced. A feature that sets a numeric coverage_target and records no coverage now emits a visible, non-blocking note instead of silence. AC: (1) declared target + no coverage produces a visible note and still accepts (exit 0); (2) the marker is never parsed as an achieved|target miss (which would reject the task with exit 2); (3) a project declaring no coverage_target stays silent; (4) a descriptive non-numeric coverage string stays silent; (5) a third note cannot displace the existing two in the systemMessage.",
+      "scope": [
+        ".claude/hooks/verify-task-quality.sh",
+        "skills/harness-init/verify-task-quality.sh.template",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [],
+      "coverage": "2051/2051 suite (4 new behavioral assertions incl. the two silence cases)",
+      "notes": "Deliberately narrow, and narrowed DURING implementation: the first version keyed on coverage being absent, which fired on every task completion for any project without coverage tooling. The suite's pre-existing 'ht (F057): a fully clean accept has no stdout at all' assertion caught it. This does NOT address the broader 'nobody machine-checked the 95% bar' complaint from OVI-147's field sessions -- that stays lead discipline at close-out, and the code comment says so.",
+      "approaches_tried": [
+        "v1 keyed on `coverage is None` alone -- rejected after F057's clean-accept assertion failed; a control that fires on every task is one the ablation pass removes next session",
+        "Two traps found by reading the consumer: the new marker fell into the generic `elif [ -n \"$COVERAGE_RESULT\" ]` branch (would have rejected tasks with exit 2), and the two-variable if/elif SYSTEM_MESSAGE ladder silently dropped a third note -- rewritten as a loop"
+      ],
+      "proof": {
+        "claim": "A feature that declared a coverage target but measured nothing is surfaced, without adding per-task friction to projects that never declared one",
+        "evidence_type": "unit",
+        "artifact": "test/run-tests.sh (ht (F120) assertions)",
+        "not_established": "The broader no-coverage-tooling gap is explicitly out of scope; nothing here machine-checks a 95% bar that no tool produces."
+      },
+      "spec": {
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-08-14T12:10:00Z",
+        "source": "conversation"
+      }
+    },
+    {
+      "assigned_to": null,
+      "test_file": "test/run-tests.sh",
+      "discovered_via": "F117",
+      "correction_cycles": 0,
+      "qa_binding": "unit",
+      "risk": "standard",
+      "status": "passing",
+      "id": "F121",
+      "priority": 121,
+      "description": "Scope-diff recovered worktree branches before merging. An interrupted or dead run leaves a committed branch nobody reviewed, and the PreToolUse scope gate reports per call, not per branch, so an out-of-scope edit on that branch reaches the merge unannounced. AC: (1) rules/parallel-work.md's Worktree hygiene section documents the scope-diff step with the concrete git command; (2) it names the declared scope as the comparison basis; (3) harness-continue's unfinished-feature path cites it; (4) the section's existing pins (never merge, lead integrates, worktree removal) survive.",
+      "scope": [
+        "rules/parallel-work.md",
+        "skills/harness-continue/SKILL.md",
+        "test/run-tests.sh"
+      ],
+      "depends_on": [],
+      "coverage": "2051/2051 suite (Worktree hygiene extract-and-compare pin extended with the git command and declared-scope terms)",
+      "notes": "Grounded in a real incident: OVI-147's AC2d/AC3 fallback drill recovered a branch carrying an edit that removed the project's own permissions.deny [\"Workflow\"], unrelated to any feature, caught only because the recovering lead read the diff.",
+      "approaches_tried": [
+        "Documented in both the rule (canonical) and the skill (citation) per Phase 4's de-duplication convention, rather than duplicating the prose"
+      ],
+      "proof": {
+        "claim": "The recovery path documents a mechanical check for the out-of-scope-edit class the fallback drill hit",
+        "evidence_type": "unit",
+        "artifact": "test/run-tests.sh (Worktree hygiene need() pin)",
+        "not_established": "Documentation only -- no hook mechanically enforces the scope-diff at merge time; that would be a larger change and is left as a backlog candidate."
+      },
+      "spec": {
+        "verdict": "PASS",
+        "sv_version": "1.0",
+        "verified_at": "2026-08-14T12:10:00Z",
+        "source": "conversation"
       }
     }
   ]


### PR DESCRIPTION
## What changed

Bookkeeping only — no code, no version, no behavior.

The four v6.0.1 fixes shipped in #171 before their `features.json` entries existed. The session tasks carried `metadata.feature_id` (F118–F121), but the tracker itself never got the entries, which is exactly what the harness's own pre-commit `features.json` audit rule exists to prevent. This closes that gap.

Each entry records what actually happened rather than a tidy version:

- **F118** notes that my first diagnosis was wrong — I reported a missing script feature; the script was correct per OVI-140's model policy and the *rule* carried the residue — and that the red-first run raced the implementation and was discarded as invalid evidence in favour of a direct mutation check.
- **F119** carries an honest `not_established`: the exemption keys on the recorded `risk` field, so a genuinely elevated feature predating F064's risk persistence still warns, and no test covers that.
- **F120** records the mid-implementation narrowing after the suite's own `ht (F057): a fully clean accept has no stdout at all` assertion caught v1 firing on every task completion for any project without coverage tooling, plus the two traps found by reading the consumer (the marker would have been parsed as a coverage miss and rejected tasks; the if/elif `SYSTEM_MESSAGE` ladder silently dropped a third note).
- **F121** is marked documentation-only in its `not_established` — nothing mechanically enforces the scope-diff at merge time.

All four carry `discovered_via: F117`: they came out of the field validation, not fresh scoping.

The handoff entry also records the CI-red history (main red from 2026-08-12, two releases merged over it), the six consecutive release-consistency false positives, and this tracker gap itself.

## Testing

`bash test/run-tests.sh` → **2051/2051**. The suite validates the live `.harness/features.json` against the schema, so this is a real check, not a formality — it caught a null `not_established` and a null `spec.hash` while I was writing the entries.