### PR TITLE
docs accuracy pass: correct the qa_binding warning claim wherever it is stated

### DIFF
--- a/rules/parallel-work.md
+++ b/rules/parallel-work.md
@@ -101,8 +101,14 @@ in `skills/harness-init/SKILL.md` — link here instead of repeating it.
 the `evidence_type` it promises to be proven with. At completion time the lead records
 a `proof` object; `verify-task-quality.sh` warns (never blocks) when a feature accepts
 with no `proof`, or with `proof.evidence_type` not matching its declared `qa_binding`.
+One pair is exempt: a `conformance` proof on an `elevated`-risk feature, which Step 5b's
+author-blind conformance check mandates — warning there would flag the harness's own
+documented path as a defect. A `conformance` proof on a standard-risk feature still
+warns, since nothing mandated it.
 `coverage_target` (integer 1-100) overrides the 95% default; overrides should be
-justified in `notes`, advisory only, never machine-enforced. `delivered.merged_at` must
+justified in `notes`, advisory only, never machine-enforced. A feature that declares a
+numeric `coverage_target` and records no `coverage` gets a visible (non-blocking) note
+at completion: the gate did not run on a feature that asked for it. `delivered.merged_at` must
 be valid ISO8601. `design_contract` optionally points at a locked design artifact
 (mock, redline, screenshot set) that journey/manual proof is compared against.
 

--- a/schemas/feature.schema.json
+++ b/schemas/feature.schema.json
@@ -121,7 +121,7 @@
         "qa_binding": {
           "type": ["string", "null"],
           "enum": ["unit", "integration", "journey", "manual", "corpus", "conformance", null],
-          "description": "Optional, for backward compatibility. Declared at prep time (harness-issue-prep Step 5's mandatory 'QA binding' line): the evidence_type this feature promises to be proven with. verify-task-quality.sh compares it against proof.evidence_type to warn on a mismatch. Absent/null for legacy features."
+          "description": "Optional, for backward compatibility. Declared at prep time (harness-issue-prep Step 5's mandatory 'QA binding' line): the evidence_type this feature promises to be proven with. verify-task-quality.sh compares it against proof.evidence_type to warn on a mismatch, except for a 'conformance' proof on an 'elevated'-risk feature, which harness-continue Step 5b mandates and which therefore never warns. Absent/null for legacy features."
         },
         "proof": {
           "type": ["object", "null"],
@@ -142,7 +142,7 @@
           "type": ["integer", "null"],
           "minimum": 1,
           "maximum": 100,
-          "description": "Optional, for backward compatibility. Overrides the 95% default coverage gate; integer 1-100. Overrides should be justified in notes -- advisory only, never machine-enforced."
+          "description": "Optional, for backward compatibility. Overrides the 95% default coverage gate; integer 1-100. Overrides should be justified in notes -- advisory only, never machine-enforced. Declaring a target and recording no coverage produces a visible, non-blocking note at task completion."
         },
         "delivered": {
           "type": ["object", "null"],

--- a/skills/harness-issue-prep/SKILL.md
+++ b/skills/harness-issue-prep/SKILL.md
@@ -130,7 +130,12 @@ The `QA binding` line is mandatory: it declares, up front, which kind of evidenc
 (`proof.evidence_type` in `schemas/feature.schema.json`) this spec will eventually be
 proven with, so Pass 1 is never improvised at close time. It is written into the
 feature's `qa_binding` field at write-back time (Step 6); `verify-task-quality.sh`
-compares it against the recorded `proof.evidence_type` and warns on a mismatch.
+compares it against the recorded `proof.evidence_type` and warns on a mismatch. One
+pair is exempt (v6.0.1): a `conformance` proof on an `elevated`-risk feature, because
+`harness-continue` Step 5b's author-blind conformance check mandates exactly that
+combination — warning there would flag the harness's own documented path as a defect.
+So an elevated feature may declare any binding and still be proven by conformance
+without a warning; every other mismatch still warns.
 
 Fill each section from the verified spec content and the human loop's answers; do not
 invent requirements that were not established during verification. Populate the

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -5411,6 +5411,20 @@ OUT=$(run_hook "$DIR_HQ9C" verify-task-quality.sh '{"task":{"metadata":{"feature
 assert_contains "$OUT" "does not match" \
   "ht (v6.0.1): a conformance proof on a standard-risk feature still warns (exemption stays narrow)"
 
+# v6.0.2 doc-drift pin: three separate files described the pre-F119 behavior
+# ("warns on a mismatch", full stop) at the same time -- the canonical rule, the
+# schema's own field description, and the prep skill. The hook's behavior is pinned
+# above; this pins that the documents describing it stay truthful.
+for BINDING_DOC in rules/parallel-work.md schemas/feature.schema.json \
+  skills/harness-issue-prep/SKILL.md; do
+  if grep -qi "conformance" "$REPO_ROOT/$BINDING_DOC" \
+    && grep -qi "elevated" "$REPO_ROOT/$BINDING_DOC"; then
+    pass "ht (v6.0.2): $BINDING_DOC documents the conformance/elevated exemption"
+  else
+    fail "ht (v6.0.2): $BINDING_DOC describes the qa_binding warning without its exemption"
+  fi
+done
+
 # v6.0.1 (F120): a feature that DECLARED a numeric coverage_target but recorded no
 # coverage gets a visible, non-blocking note -- the gate silently didn't run on a
 # feature that asked for it. The marker must never be parsed as an achieved|target


### PR DESCRIPTION
## What changed

A verification pass over the docs against the code they describe, after today's gate changes (F118–F121). **Stacked on #174** — it will retarget to `main` automatically once that merges.

### One defect, three copies

F119 made the `qa_binding` / `proof.evidence_type` mismatch warning conditional: a `conformance` proof on an `elevated`-risk feature no longer warns, because `harness-continue` Step 5b mandates exactly that combination. Three documents still described the unconditional behavior:

| File | Role |
|---|---|
| `rules/parallel-work.md` | canonical feature-schema prose |
| `schemas/feature.schema.json` | the `qa_binding` field's own description |
| `skills/harness-issue-prep/SKILL.md` | where the QA binding is chosen |

All three promised a warning for precisely the combination the harness instructs you to produce. Corrected in place, including that the exemption stays narrow (a conformance proof on a standard-risk feature still warns).

Also documents F120 on `coverage_target`: declaring a numeric target and recording no coverage now produces a visible, non-blocking note.

### A pin for the class, not the instances

The hook's behavior was already asserted by F119's tests. Nothing checked that the *documents describing it* stayed truthful — which is exactly how three files drifted simultaneously. Added a loop requiring all three to mention the exemption.

### Deliberately not changed

`coverage_target`'s "advisory only, never machine-enforced" reads like a contradiction, since the target **is** machine-compared and can reject a task with exit 2. Parsing it, "advisory only" attaches to the *justify-it-in-notes* requirement, which genuinely nothing checks. Accurate as written, so I left it rather than "correcting" it into something false.

### INSTALL.md needed nothing

Its Agent Teams references are all correctly framed as retired machinery and migration steps, and F118–F121 didn't touch the migration path.

## Testing

`bash test/run-tests.sh` → **2061/2061** (3 new assertions).