### PR TITLE
docs: harness-init's description no longer advertises retired Agent Teams

### DIFF
--- a/skills/harness-init/SKILL.md
+++ b/skills/harness-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-init
-description: Initialize a new project with the Long-Running Agent Harness (vv-harness plugin). Sets up feature tracking, git identity capture, context summary, build hooks, quality gate hooks, and optional Agent Teams structure. Use when starting a new multi-session project.
+description: Initialize a new project with the Long-Running Agent Harness (vv-harness plugin). Sets up feature tracking, git identity capture, context summary, build hooks, quality gate hooks, and an optional workflow size guideline. Use when starting a new multi-session project.
 ---
 
 # Harness Initializer

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1496,6 +1496,49 @@ for MANIFEST in .claude-plugin/plugin.json .claude-plugin/marketplace.json; do
   fi
 done
 
+echo "== distribution descriptions =="
+
+# A skill's and an agent's frontmatter `description` is what Claude Code shows in
+# its own listing -- the most user-visible string this repo ships, and the one a
+# model reads when deciding whether to invoke the skill at all. The manifest sweep
+# above pinned the same class for the two .claude-plugin/ files, but nothing
+# covered frontmatter, which is how harness-init kept advertising "optional Agent
+# Teams structure" for the whole v6 line that removed the machinery.
+#
+# Scoped to the frontmatter block ONLY, deliberately. A skill BODY may legitimately
+# name retired machinery -- harness-doctor documents migration checks that detect
+# and remove exactly these artifacts -- so sweeping whole files would force a choice
+# between a false positive and deleting real migration documentation.
+DESC_DRIFT=$(python3 - "$REPO_ROOT" <<'PYEOF'
+import glob, os, re, sys
+
+root = sys.argv[1]
+# Retired with the Agent Teams machinery (OVI-144, v6.0.0). A description naming
+# any of these advertises a capability the shipped plugin no longer has.
+retired = re.compile(r"agent[ -]teams|teammate|TeammateIdle|SendMessage", re.IGNORECASE)
+targets = sorted(glob.glob(os.path.join(root, "skills", "*", "SKILL.md"))
+                 + glob.glob(os.path.join(root, "agents", "*.md")))
+for path in targets:
+    with open(path) as fh:
+        text = fh.read()
+    if not text.startswith("---"):
+        continue
+    end = text.find("\n---", 3)
+    if end == -1:
+        continue
+    hit = retired.search(text[3:end])
+    if hit:
+        print(f"{os.path.relpath(path, root)}:{hit.group(0)}")
+PYEOF
+)
+if [ -n "$DESC_DRIFT" ]; then
+    while IFS= read -r DRIFT_LINE; do
+        fail "dd: frontmatter advertises retired machinery -- $DRIFT_LINE"
+    done <<< "$DESC_DRIFT"
+else
+    pass "dd: no skill or agent frontmatter advertises retired Agent Teams machinery"
+fi
+
 HOOK_REF_ERRORS=$(python3 - "$REPO_ROOT" <<'PYEOF'
 import json
 import os


### PR DESCRIPTION
## What changed

`skills/harness-init/SKILL.md`'s frontmatter description said it sets up "optional Agent Teams structure". OVI-144 (v6.0.0) retired that machinery. What Step 6 actually configures is an optional workflow size guideline, so the description now says that.

Adds a test sweeping every `skills/*/SKILL.md` and `agents/*.md` **frontmatter block** for retired vocabulary (`agent teams`, `teammate`, `TeammateIdle`, `SendMessage`).

## Why

A frontmatter `description` is the most user-visible string this repo ships. Claude Code shows it in the skill listing, and a model reads it when deciding whether to invoke the skill at all, so a stale one misroutes invocation rather than merely reading wrong.

The manifest sweep added in the v6 review round already pinned this vocabulary for the two `.claude-plugin/*.json` files. Nothing covered frontmatter, which is how this one survived the entire v6 line that removed the machinery. This pins the class, not the instance.

## Scope decision

The check is scoped to the frontmatter block only, deliberately. A skill **body** may legitimately name retired machinery: `harness-doctor` documents the migration checks that detect and remove exactly these artifacts. A whole-file sweep would force a choice between a false positive and deleting real migration documentation.

## Testing

- New assertion verified red on the pre-fix tree: `2051/2052, 1 failed`, the failure being exactly `dd:` and nothing else.
- Green after the one-line description fix: `2052/2052, 0 failed`.
- Detector scans 14 frontmatter blocks (7 skills, 7 agents) and reported exactly one drift, with no false positive on `harness-doctor`.

## Dependencies

None. Branched from `origin/main`, developed in an isolated worktree because a concurrent session held the main checkout.
