### PR TITLE
THROWAWAY — do not merge — OVI-150 AC6 failing-check probe

### DIFF
--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -14811,6 +14811,10 @@ fi
 
 echo ""
 TOTAL=$((PASS_COUNT + FAIL_COUNT))
+
+# THROWAWAY: deliberately failing assertion for OVI-150 AC6. Never merge this branch.
+assert_contains "ovi-150-ac6-probe" "this-substring-is-absent" "ovi-150 ac6: deliberately failing probe"
+
 echo "Summary: $PASS_COUNT/$TOTAL assertions passed, $FAIL_COUNT failed"
 if [ "$FAIL_COUNT" -gt 0 ]; then
   exit 1


### PR DESCRIPTION
**Do not merge. This PR exists to fail.**

Adds one deliberately failing assertion to `test/run-tests.sh` so OVI-150's AC6 can be observed: with the ruleset requiring the `test` context, a PR whose check fails must be unmergeable through both the UI and `gh pr merge`.

Closed and the branch deleted as soon as the observation is recorded.