### PR TITLE
Wire the conformance suite into CI, and add per-suite runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,3 +60,37 @@ jobs:
       - name: Record metadata-only skip
         if: steps.changes.outputs.mode == 'metadata'
         run: echo "Only operational metadata changed; the full suite is not affected." >> "$GITHUB_STEP_SUMMARY"
+
+  # Deliberately a SEPARATE job, never a step inside `test`. The branch ruleset
+  # on main requires the status-check context named `test`; folding this in
+  # would change what that context covers, and renaming or restructuring the job
+  # key stops the required check matching at all -- which blocks every merge and
+  # needs admin (the owner account) to repair. As its own job it runs in
+  # parallel, so wall-clock is unaffected, and it can be promoted to required
+  # later in the UI without touching this file.
+  hillclimb:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # Shallow is fine here, unlike the `test` job above: nothing in the
+      # conformance suite shells out to git against THIS repo. It builds its own
+      # throwaway fixture repos, so it needs no tags and no history.
+      - uses: actions/checkout@v4
+
+      # No change classification, unlike `test`. The suite covers documentation
+      # as well as code -- a broken link or a coverage threshold stated in prose
+      # that no longer matches the gate both fail it -- so there is no category
+      # of change that is safely skippable. At ~50s the saving would not be
+      # worth the reasoning, and "always runs" is the property that keeps a
+      # conformance suite from rotting.
+      #
+      # --skip regression: the `test` job above already runs test/run-tests.sh,
+      # which this suite otherwise folds in as its regression aggregate. A
+      # denylist rather than a spelled-out --suite list, so a suite added later
+      # is covered here by default instead of being silently dropped.
+      #
+      # --strict: the runner reports pass/fail by exit code. Without it the
+      # suite exits 0 and reports failures in its output, which is what the
+      # research harness wants and exactly what CI must not do.
+      - name: Run the conformance suite
+        run: python3 evals/hillclimb/run.py --skip regression --strict

--- a/README.md
+++ b/README.md
@@ -316,8 +316,21 @@ present but never read, or read but change nothing. Method: [evals/README.md](./
 behaves as specified, and needs no model at all:
 
 ```bash
-bash autoresearch.sh        # ~200s, prints METRIC harness_score=<0..100>
+bash autoresearch.sh                                  # ~200s, METRIC harness_score=<0..100>
+python3 evals/hillclimb/run.py --suite gates          # one suite, for iterating (~40s)
+python3 evals/hillclimb/run.py --list                 # suite names and weights
 ```
+
+A partial run prints per-suite results but deliberately no `harness_score`: the score is
+a weighted sum over every suite, and renormalizing it across a subset would produce a
+number that looks like the real one but isn't — and the cheapest way to raise it would
+be to drop the suite you are failing.
+
+CI runs it on every push and pull request as the `hillclimb` job in
+`.github/workflows/test.yml`, with `--skip regression` (the `test` job already runs
+`test/run-tests.sh`) and `--strict` (report pass/fail by exit code). It is a separate
+job from `test` on purpose: the branch ruleset requires that exact status-check context,
+so restructuring it would block merges.
 
 Roughly 4,200 boolean checks across six weighted suites — behavior (0.25), gates
 (0.20), regression (0.20), contracts (0.15), static (0.10), determinism (0.10). Every

--- a/evals/hillclimb/run.py
+++ b/evals/hillclimb/run.py
@@ -24,6 +24,7 @@ fixture, and is a pure function of the repository contents.
 
 from __future__ import annotations
 
+import argparse
 import shutil
 import sys
 import tempfile
@@ -51,21 +52,93 @@ WEIGHTS = {
 MAX_FAILURES_SHOWN = 60
 
 
-def main() -> int:
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="run.py",
+        description="Conformance suite over the shipped vv-harness plugin.",
+    )
+    selection = parser.add_mutually_exclusive_group()
+    selection.add_argument(
+        "--suite",
+        metavar="A,B",
+        help="run only these suites (comma-separated) -- for iterating on one area",
+    )
+    # A denylist rather than a longhand --suite list: CI skips the regression
+    # aggregate because its own `test` job already runs test/run-tests.sh, and a
+    # spelled-out allowlist there would silently stop covering any suite added
+    # later. --skip keeps new suites included by default.
+    selection.add_argument(
+        "--skip",
+        metavar="A,B",
+        help="run every suite except these (comma-separated)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help=(
+            "exit 1 when any check fails. Off by default: the research harness reads "
+            "the METRIC lines, so a failing check is data rather than an error. CI "
+            "wants the opposite."
+        ),
+    )
+    parser.add_argument(
+        "--list", action="store_true", help="print the suite names and weights, then exit"
+    )
+    return parser
+
+
+def select_suites(args, parser) -> list:
+    """The suites to run, in the canonical order WEIGHTS declares."""
+    if args.suite:
+        wanted = {name.strip() for name in args.suite.split(",") if name.strip()}
+    elif args.skip:
+        skipped = {name.strip() for name in args.skip.split(",") if name.strip()}
+        unknown = skipped - set(WEIGHTS)
+        if unknown:
+            parser.error(f"unknown suite(s): {', '.join(sorted(unknown))}")
+        wanted = set(WEIGHTS) - skipped
+    else:
+        return list(WEIGHTS)
+    unknown = wanted - set(WEIGHTS)
+    if unknown:
+        parser.error(f"unknown suite(s): {', '.join(sorted(unknown))}")
+    if not wanted:
+        parser.error("no suites selected")
+    return [name for name in WEIGHTS if name in wanted]
+
+
+def main(argv=None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    if args.list:
+        for name, weight in WEIGHTS.items():
+            print(f"{name:<12} weight {weight:.2f}")
+        return 0
+
+    selected = select_suites(args, parser)
+    partial = len(selected) != len(WEIGHTS)
+
     started = time.monotonic()
     rec = Recorder()
+    behavior = None
     work = Path(tempfile.mkdtemp(prefix="vv-hillclimb."))
+    runners = {
+        "behavior": lambda: suite_behavior.run(rec, work / "behavior"),
+        "gates": lambda: suite_gates.run(rec, work / "gates"),
+        "contracts": lambda: suite_contracts.run(rec, work / "contracts"),
+        "static": lambda: suite_static.run(rec),
+        "determinism": lambda: suite_determinism.run(rec, work / "determinism"),
+        "regression": lambda: suite_regression.run(rec),
+    }
     try:
-        behavior = suite_behavior.run(rec, work / "behavior")
-        suite_gates.run(rec, work / "gates")
-        suite_contracts.run(rec, work / "contracts")
-        suite_static.run(rec)
-        suite_determinism.run(rec, work / "determinism")
-        suite_regression.run(rec)
+        for name in selected:
+            result = runners[name]()
+            if name == "behavior":
+                behavior = result
     finally:
         shutil.rmtree(work, ignore_errors=True)
 
-    totals = {suite: [0, 0] for suite in WEIGHTS}
+    totals = {suite: [0, 0] for suite in selected}
     for suite, (passed, total) in rec.aggregates.items():
         bucket = totals.setdefault(suite, [0, 0])
         bucket[0] += passed
@@ -79,7 +152,7 @@ def main() -> int:
 
     failures = [c for c in rec.checks if not c.passed]
     print("=== vv-harness hillclimb eval ===")
-    for suite in WEIGHTS:
+    for suite in selected:
         passed, total = totals[suite]
         pct = 100.0 * passed / total if total else 0.0
         print(f"  {suite:<12} {passed:>4}/{total:<4} {pct:6.2f}%  (weight {WEIGHTS[suite]:.2f})")
@@ -92,37 +165,45 @@ def main() -> int:
         if len(failures) > MAX_FAILURES_SHOWN:
             print(f"  ... and {len(failures) - MAX_FAILURES_SHOWN} more")
 
-    score = 0.0
-    for suite, weight in WEIGHTS.items():
-        passed, total = totals[suite]
-        score += weight * (passed / total if total else 0.0)
-    score *= 100.0
-
-    sizes = behavior["sizes"]
-    timings = behavior["timings"]
-    canonical_ms = timings.get("canonical", 0.0)
-    start_times = [v for k, v in timings.items() if not k.startswith("session-end")]
-
-    print()
-    print(f"METRIC harness_score={score:.3f}")
-    for suite, weight in WEIGHTS.items():
-        passed, total = totals[suite]
-        print(f"METRIC {suite}_score={100.0 * passed / total if total else 0.0:.3f}")
     scored_total = sum(t[1] for t in totals.values())
     scored_failed = sum(t[1] - t[0] for t in totals.values())
+
+    print()
+    if partial:
+        # No harness_score on a partial run, deliberately. The score is a
+        # weighted sum over ALL suites; renormalizing it across a subset would
+        # produce a number that looks like the real one and is not, and the
+        # cheapest way to raise a renormalized score would be to drop the suite
+        # you are failing.
+        skipped = [name for name in WEIGHTS if name not in selected]
+        print(f"PARTIAL run: {', '.join(selected)} (skipped: {', '.join(skipped)})")
+        print("PARTIAL no harness_score -- the score is only defined over every suite")
+    else:
+        score = 100.0 * sum(
+            WEIGHTS[suite] * (totals[suite][0] / totals[suite][1] if totals[suite][1] else 0.0)
+            for suite in selected
+        )
+        print(f"METRIC harness_score={score:.3f}")
+    for suite in selected:
+        passed, total = totals[suite]
+        print(f"METRIC {suite}_score={100.0 * passed / total if total else 0.0:.3f}")
     print(f"METRIC checks_failed={scored_failed}")
     print(f"METRIC checks_total={scored_total}")
-    print(f"METRIC orientation_chars={sizes.get('canonical', 0)}")
-    print(f"METRIC max_orientation_chars={max(sizes.values()) if sizes else 0}")
-    print(f"METRIC context_headroom={CONTEXT_CAP - (max(sizes.values()) if sizes else 0)}")
-    print(f"METRIC session_start_ms={canonical_ms:.1f}")
-    print(f"METRIC session_start_p95_ms={_p95(start_times):.1f}")
+    if behavior is not None:
+        sizes = behavior["sizes"]
+        timings = behavior["timings"]
+        start_times = [v for k, v in timings.items() if not k.startswith("session-end")]
+        print(f"METRIC orientation_chars={sizes.get('canonical', 0)}")
+        print(f"METRIC max_orientation_chars={max(sizes.values()) if sizes else 0}")
+        print(f"METRIC context_headroom={CONTEXT_CAP - (max(sizes.values()) if sizes else 0)}")
+        print(f"METRIC session_start_ms={timings.get('canonical', 0.0):.1f}")
+        print(f"METRIC session_start_p95_ms={_p95(start_times):.1f}")
     print(f"METRIC eval_wall_s={time.monotonic() - started:.2f}")
 
-    by_suite = ",".join(f"{s}:{totals[s][0]}/{totals[s][1]}" for s in WEIGHTS)
+    by_suite = ",".join(f"{s}:{totals[s][0]}/{totals[s][1]}" for s in selected)
     print(f"ASI suites={by_suite}")
     print(f"ASI top_failures={';'.join(c.name for c in failures[:8]) or 'none'}")
-    return 0
+    return 1 if (args.strict and scored_failed) else 0
 
 
 def _p95(values: list[float]) -> float:


### PR DESCRIPTION
## Why

v6.1.0 shipped the 4,208-check conformance suite with **nothing running it**. `test.yml` and `maintenance.yml` both run `test/run-tests.sh`; `autoresearch.sh` ran by hand or not at all. A conformance suite nobody runs is worse than none — it reads as coverage.

## CI

A `hillclimb` job in `test.yml`, on every push and PR.

**Separate job, not a step inside `test`, on purpose.** The branch ruleset requires the status-check context named `test`; folding this in changes what that context covers, and renaming or restructuring the job key stops the required check matching at all — which blocks every merge and needs admin to repair. As its own job it runs in parallel (wall-clock unaffected) and can be promoted to required later in the UI without touching this file.

No change classification, unlike `test`: the suite covers documentation as well as code — a broken link, or a coverage threshold stated in prose that no longer matches the gate, both fail it — so there's no safely skippable category. At ~50s the saving wouldn't be worth the reasoning, and *always runs* is the property that stops rot.

## Flags

| flag | purpose |
|---|---|
| `--suite A,B` | run a subset — `gates` is ~40s, `static` is 0.06s, against 200s for the lot |
| `--skip A,B` | denylist form; CI uses `--skip regression` since the `test` job already runs `run-tests.sh` |
| `--strict` | exit 1 on a failing check |
| `--list` | suite names and weights |

`--skip` rather than a spelled-out `--suite` list in CI so a suite added later is covered by default instead of silently dropped.

`--strict` is off by default: the research harness reads the METRIC lines, so a failing check is data rather than an error. CI needs the opposite.

**A partial run prints no `harness_score`.** The score is a weighted sum over every suite; renormalizing across a subset produces a number that looks like the real one and isn't — and the cheapest way to raise a renormalized score would be to drop the suite you're failing.

## Testing

- `bash autoresearch.sh` → `harness_score=100.000`, 4208/4208.
- CI invocation `--skip regression --strict` → 2110 checks, 50s, rc 0.
- `--strict` → rc 1 on a deliberately broken check, rc 0 without the flag.
- `--suite nope` → rc 2 with a usage error; `--suite` and `--skip` are mutually exclusive.
- `test` job key confirmed intact.

The real verification is this PR's own CI run, where the `hillclimb` job appears for the first time.

No plugin version bump: nothing users receive changes.
